### PR TITLE
Bump android-components dependency to 0.26.0

### DIFF
--- a/app/src/geckoBeta/java/org/mozilla/reference/browser/EngineProvider.kt
+++ b/app/src/geckoBeta/java/org/mozilla/reference/browser/EngineProvider.kt
@@ -6,11 +6,9 @@ import android.content.Context
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
-import org.mozilla.geckoview.GeckoRuntime
 
 object EngineProvider {
     fun getEngine(context: Context, defaultSettings: DefaultSettings): Engine {
-        val runtime = GeckoRuntime.getDefault(context)
-        return GeckoEngine(runtime, defaultSettings)
+        return GeckoEngine(context, defaultSettings)
     }
 }

--- a/app/src/geckoNightly/java/org/mozilla/reference/browser/EngineProvider.kt
+++ b/app/src/geckoNightly/java/org/mozilla/reference/browser/EngineProvider.kt
@@ -6,11 +6,9 @@ import android.content.Context
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
-import org.mozilla.geckoview.GeckoRuntime
 
 object EngineProvider {
     fun getEngine(context: Context, defaultSettings: DefaultSettings): Engine {
-        val runtime = GeckoRuntime.getDefault(context)
-        return GeckoEngine(runtime, defaultSettings)
+        return GeckoEngine(context, defaultSettings)
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/Components.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/Components.kt
@@ -37,7 +37,7 @@ class Components(
     val sessionStorage by lazy { DefaultSessionStorage(applicationContext) }
 
     val sessionManager by lazy {
-        SessionManager(engine).apply {
+        SessionManager(engine, defaultSession = { Session("about:blank") }).apply {
             sessionStorage.restore(this)
 
             if (size == 0) {

--- a/app/src/main/java/org/mozilla/reference/browser/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/TabsTrayFragment.kt
@@ -45,8 +45,7 @@ class TabsTrayFragment : Fragment(), BackHandler {
             tabsTray,
             requireComponents.sessionManager,
             requireComponents.tabsUseCases,
-            ::closeTabsTray,
-            onTabsTrayEmpty = ::createNewTab)
+            ::closeTabsTray)
     }
 
     override fun onStart() {
@@ -64,10 +63,6 @@ class TabsTrayFragment : Fragment(), BackHandler {
     override fun onBackPressed(): Boolean {
         closeTabsTray()
         return true
-    }
-
-    private fun createNewTab() {
-        requireComponents.tabsUseCases.addSession.invoke("about:blank")
     }
 
     private fun closeTabsTray() {

--- a/app/src/system/java/org/mozilla/reference/browser/EngineProvider.kt
+++ b/app/src/system/java/org/mozilla/reference/browser/EngineProvider.kt
@@ -9,6 +9,6 @@ import mozilla.components.concept.engine.Engine
 
 object EngineProvider {
     fun getEngine(context: Context, defaultSettings: DefaultSettings): Engine {
-        return SystemEngine(defaultSettings)
+        return SystemEngine(context, defaultSettings)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,12 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
 
         maven {
             url "https://maven.mozilla.org/maven2"
         }
+
+        jcenter()
     }
 }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -17,7 +17,7 @@ private object Versions {
 
     const val android_gradle_plugin = "3.1.4"
 
-    const val mozilla_android_components = "0.25.2"
+    const val mozilla_android_components = "0.26.0"
 }
 
 // Synchronized dependencies used by (some) modules


### PR DESCRIPTION
Minimal changes required:
- System/GeckoEngine now use 'context' in constructor
- SessionManager now accepts 'defaultSession', which replaces 'onTabsTrayEmpty' hook