### PR TITLE
WIP customizable device name in FxA settings page

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/FirefoxAccountsIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/FirefoxAccountsIntegration.kt
@@ -10,6 +10,7 @@ import android.arch.lifecycle.OnLifecycleEvent
 import android.content.Context
 import android.content.SharedPreferences
 import android.net.Uri
+import android.widget.Toast
 import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.Deferred
 import kotlinx.coroutines.experimental.Dispatchers
@@ -74,6 +75,10 @@ class FirefoxAccountsIntegration(
         profile = null
         getSharedPreferences().edit().putString(FXA_STATE_KEY, "").apply()
         init()
+    }
+
+    fun setDeviceName(name: String) {
+        Toast.makeText(context, "Device name changed to: ${name}", Toast.LENGTH_SHORT).show()
     }
 
     private fun persistProfile(profile: Profile) {

--- a/app/src/main/java/org/mozilla/reference/browser/browser/FirefoxAccountsIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/FirefoxAccountsIntegration.kt
@@ -25,6 +25,7 @@ import mozilla.components.service.fxa.Config
 import mozilla.components.service.fxa.FirefoxAccount
 import mozilla.components.service.fxa.FxaException
 import mozilla.components.service.fxa.Profile
+import mozilla.components.support.base.log.logger.Logger
 import kotlin.coroutines.experimental.CoroutineContext
 
 class FirefoxAccountsIntegration(
@@ -78,7 +79,12 @@ class FirefoxAccountsIntegration(
     }
 
     fun setDeviceName(name: String) {
-        Toast.makeText(context, "Device name changed to: ${name}", Toast.LENGTH_SHORT).show()
+        Logger.info("Let's change device name to: ${name}")
+        launch {
+            account.await().setDeviceName(name).await()
+            Logger.info("Device name changed to: ${name}")
+            Toast.makeText(context, "Device name changed to: ${name}", Toast.LENGTH_SHORT).show()
+        }
     }
 
     private fun persistProfile(profile: Profile) {
@@ -102,7 +108,7 @@ class FirefoxAccountsIntegration(
             } catch (e: FxaException) {
                 null
             }
-        } ?: null
+        }
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)

--- a/app/src/main/java/org/mozilla/reference/browser/settings/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/AccountSettingsFragment.kt
@@ -6,12 +6,16 @@ package org.mozilla.reference.browser.settings
 
 import android.os.Bundle
 import android.support.v7.preference.Preference.OnPreferenceClickListener
+import android.support.v7.preference.Preference.OnPreferenceChangeListener
+import android.support.v7.preference.EditTextPreference
 import android.support.v7.preference.PreferenceFragmentCompat
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.getPreferenceKey
 import org.mozilla.reference.browser.ext.requireComponents
 import org.mozilla.reference.browser.R.string.pref_key_sign_out
 import org.mozilla.reference.browser.R.string.pref_key_sync_now
+import org.mozilla.reference.browser.R.string.pref_key_device_name
+
 
 class AccountSettingsFragment : PreferenceFragmentCompat() {
 
@@ -30,6 +34,12 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
         preferenceSyncNow.isEnabled = false // Make this `fxaIntegration.profile == null` when implemented
         preferenceSyncNow.summary = getString(R.string.preferences_sync_never_synced_summary) // Use Long.timeSince()
         preferenceSyncNow.onPreferenceClickListener = getClickListenerForSyncNow()
+
+        // Device Name
+        val deviceNameKey = context?.getPreferenceKey(pref_key_device_name)
+        val preferenceDeviceName = findPreference(deviceNameKey) as EditTextPreference
+        preferenceDeviceName.setSummary(preferenceDeviceName.getText())
+        preferenceDeviceName.onPreferenceChangeListener = getChangeListenerForDeviceName()
     }
 
     private fun getClickListenerForSignOut(): OnPreferenceClickListener {
@@ -43,6 +53,15 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
     private fun getClickListenerForSyncNow(): OnPreferenceClickListener {
         return OnPreferenceClickListener {
             // Implement this Sync Now functionality when available.
+            true
+        }
+    }
+
+    private fun getChangeListenerForDeviceName(): OnPreferenceChangeListener {
+        return OnPreferenceChangeListener { pref, newValue ->
+            val name = newValue as String
+            pref.setSummary(name)
+            requireComponents.firefoxAccountsIntegration.setDeviceName(name)
             true
         }
     }

--- a/app/src/main/java/org/mozilla/reference/browser/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/SettingsFragment.kt
@@ -56,7 +56,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
         preferenceFirefoxAccount.onPreferenceClickListener = getClickListenerForFirefoxAccount()
         preferenceFirefoxAccount.isVisible = fxaIntegration.profile != null
-        preferenceFirefoxAccount.summary = fxaIntegration?.profile?.email
+        preferenceFirefoxAccount.summary = fxaIntegration.profile?.email
 
         preferenceMakeDefaultBrowser.onPreferenceClickListener = getClickListenerForMakeDefaultBrowser()
     }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -7,6 +7,7 @@
     <string name="pref_key_sign_out" translatable="false">pref_key_sign_out</string>
     <string name="pref_key_sync_now" translatable="false">pref_key_sync_now</string>
     <string name="pref_key_firefox_account" translatable="false">pref_key_firefox_account</string>
+    <string name="pref_key_device_name" translatable="false">pref_key_device_name</string>
     <string name="pref_key_telemetry" translatable="false">pref_key_telemetry</string>
     <string name="pref_key_make_default_browser" translatable="false">pref_key_make_default_browser</string>
     <string name="pref_key_sync_logins" translatable="false">pref_key_sync_logins</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,9 @@
     <!-- Preference for settings related to changing the default browser -->
     <string name="preferences_make_default_browser">Make default browser</string>
 
+    <!-- Preference to edit device name -->
+    <string name="preferences_fxa_device_name">Device name</string>
+
     <!-- Preference enables sync for logins -->
     <string name="preferences_sync_logins">Logins</string>
 
@@ -40,6 +43,9 @@
 
     <!-- Preference summary showing never synced -->
     <string name="preferences_sync_never_synced_summary">Last synced: never</string>
+
+    <!-- Preference for showing/changing device name -->
+    <string name="device_name">Device name</string>
 
     <!-- Preference category for sync settings -->
     <string name="sync_category">Choose what to sync</string>

--- a/app/src/main/res/xml/account_preferences.xml
+++ b/app/src/main/res/xml/account_preferences.xml
@@ -10,6 +10,11 @@
             android:key="@string/pref_key_sync_now"
             android:title="@string/sync_now" />
 
+    <EditTextPreference
+        android:key="@string/pref_key_device_name"
+        android:defaultValue=""
+        android:title="@string/preferences_fxa_device_name" />
+
     <PreferenceCategory
         android:title="@string/sync_category">
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ plugins {
 
 allprojects {
     repositories {
+        mavenLocal()
         google()
 
         maven {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -17,7 +17,7 @@ private object Versions {
 
     const val android_gradle_plugin = "3.1.4"
 
-    const val mozilla_android_components = "0.30.0"
+    const val mozilla_android_components = "0.31.1-SNAPSHOT"
 }
 
 // Synchronized dependencies used by (some) modules


### PR DESCRIPTION
An extremely WIP attempt at https://github.com/mozilla-mobile/reference-browser/issues/39 allowing a customizable device name.  Mostly I want to have something usable to help flesh out the underlying API layers, which are not yet implemented.

Are WIP PRs like this helpful or annoying on this repo?  Please let me know if you're prefer a different approach to sharing early work like this.