### PR TITLE
Closes #38: Add Sync Now button

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/AppRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/AppRequestInterceptor.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.reference.browser
 
 import android.content.Context

--- a/app/src/main/java/org/mozilla/reference/browser/ext/Long.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/ext/Long.kt
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.ext
+
+import android.content.Context
+import android.text.format.DateUtils
+import org.mozilla.reference.browser.R
+import java.util.Date
+import java.util.Calendar
+import java.util.GregorianCalendar
+
+@Suppress("MagicNumber")
+fun Long.timeSince(context: Context, time: Long): String {
+    val earliestValidSyncDate: Date = GregorianCalendar.getInstance().run {
+        set(2000, Calendar.JANUARY, 1, 0, 0, 0)
+        getTime()
+    }
+
+    if (Date(time).before(earliestValidSyncDate)) {
+        return context.getString(R.string.preferences_sync_never_synced_summary)
+    }
+
+    val relativeTimeSpanString = DateUtils.getRelativeTimeSpanString(time, this, DateUtils.MINUTE_IN_MILLIS)
+    return context.resources.getString(R.string.preferences_sync_last_synced_summary, relativeTimeSpanString)
+}

--- a/app/src/main/java/org/mozilla/reference/browser/settings/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/AccountSettingsFragment.kt
@@ -11,6 +11,7 @@ import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.getPreferenceKey
 import org.mozilla.reference.browser.ext.requireComponents
 import org.mozilla.reference.browser.R.string.pref_key_sign_out
+import org.mozilla.reference.browser.R.string.pref_key_sync_now
 
 class AccountSettingsFragment : PreferenceFragmentCompat() {
 
@@ -18,14 +19,30 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
         setPreferencesFromResource(R.xml.account_preferences, rootKey)
 
         val signOutKey = context?.getPreferenceKey(pref_key_sign_out)
+        val syncNowKey = context?.getPreferenceKey(pref_key_sync_now)
+
+        // Sign Out
         val preferenceSignOut = findPreference(signOutKey)
         preferenceSignOut.onPreferenceClickListener = getClickListenerForSignOut()
+
+        // Sync Now
+        val preferenceSyncNow = findPreference(syncNowKey)
+        preferenceSyncNow.isEnabled = false // Make this `fxaIntegration.profile == null` when implemented
+        preferenceSyncNow.summary = getString(R.string.preferences_sync_never_synced_summary) // Use Long.timeSince()
+        preferenceSyncNow.onPreferenceClickListener = getClickListenerForSyncNow()
     }
 
     private fun getClickListenerForSignOut(): OnPreferenceClickListener {
-        return OnPreferenceClickListener { _ ->
+        return OnPreferenceClickListener {
             requireComponents.firefoxAccountsIntegration.logout()
             activity?.onBackPressed()
+            true
+        }
+    }
+
+    private fun getClickListenerForSyncNow(): OnPreferenceClickListener {
+        return OnPreferenceClickListener {
+            // Implement this Sync Now functionality when available.
             true
         }
     }

--- a/app/src/main/java/org/mozilla/reference/browser/settings/CustomColorPreference.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/CustomColorPreference.kt
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.settings
+
+import android.content.Context
+import android.support.v4.content.ContextCompat
+import android.support.v7.preference.Preference
+import android.support.v7.preference.PreferenceViewHolder
+import android.util.AttributeSet
+import android.widget.TextView
+import org.mozilla.reference.browser.R
+
+/**
+ * This preference is used to define custom  colors for both title and summary texts.
+ * Color code #777777 (placeholder_grey) is used as the fallback color for both title and summary.
+ */
+class CustomColorPreference : Preference {
+    private var titleColor: Int = 0
+    private var summaryColor: Int = 0
+
+    constructor(context: Context) : super(context)
+
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
+        init(context, attrs)
+    }
+
+    constructor(context: Context, attrs: AttributeSet, defStyle: Int) : super(context, attrs,
+        defStyle) {
+        init(context, attrs)
+    }
+
+    private fun init(context: Context, attrs: AttributeSet) {
+        context.obtainStyledAttributes(attrs, R.styleable.CustomColorPreference).apply {
+            titleColor = getColor(R.styleable.CustomColorPreference_titleColor,
+                ContextCompat.getColor(context, R.color.placeholder_grey))
+            summaryColor = getColor(R.styleable.CustomColorPreference_summaryColor,
+                ContextCompat.getColor(context, R.color.placeholder_grey))
+            recycle()
+        }
+    }
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder?) {
+        super.onBindViewHolder(holder)
+        holder?.let {
+            val title = it.itemView.findViewById(android.R.id.title) as TextView
+            val summary = it.itemView.findViewById(android.R.id.summary) as TextView
+            title.setTextColor(titleColor)
+            summary.setTextColor(summaryColor)
+        }
+    }
+}

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -2,6 +2,9 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<full-backup-content>
-    <include domain="sharedpref" path="."/>
-</full-backup-content>
+<resources>
+    <declare-styleable name="CustomColorPreference">
+        <attr name="titleColor" format="color" />
+        <attr name="summaryColor" format="color" />
+    </declare-styleable>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,6 +2,6 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<full-backup-content>
-    <include domain="sharedpref" path="."/>
-</full-backup-content>
+<resources>
+    <color name="placeholder_grey">#777777</color>
+</resources>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -5,6 +5,7 @@
 <resources>
     <string name="pref_key_sign_in" translatable="false">pref_key_sign_in</string>
     <string name="pref_key_sign_out" translatable="false">pref_key_sign_out</string>
+    <string name="pref_key_sync_now" translatable="false">pref_key_sync_now</string>
     <string name="pref_key_firefox_account" translatable="false">pref_key_firefox_account</string>
     <string name="pref_key_telemetry" translatable="false">pref_key_telemetry</string>
     <string name="pref_key_make_default_browser" translatable="false">pref_key_make_default_browser</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,15 @@
     <!-- Preference for signing out -->
     <string name="sign_out">Sign out</string>
 
+    <!-- Preference for syncing immediately -->
+    <string name="sync_now">Sync now</string>
+
+    <!-- Preference summary showing last time synced -->
+    <string name="preferences_sync_last_synced_summary">Last synced: %s</string>
+
+    <!-- Preference summary showing never synced -->
+    <string name="preferences_sync_never_synced_summary">Last synced: never</string>
+
     <!-- Preference category for sync settings -->
     <string name="sync_category">Choose what to sync</string>
 

--- a/app/src/main/res/xml/account_preferences.xml
+++ b/app/src/main/res/xml/account_preferences.xml
@@ -2,12 +2,13 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<android.support.v7.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<android.support.v7.preference.PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-        <android.support.v7.preference.Preference
-            android:key="@string/pref_key_sign_out"
-            android:title="@string/sign_out" />
-
+    <android.support.v7.preference.Preference
+            android:key="@string/pref_key_sync_now"
+            android:title="@string/sync_now" />
 
     <PreferenceCategory
         android:title="@string/sync_category">
@@ -21,5 +22,10 @@
             android:defaultValue="true"
             android:title="@string/preferences_sync_history" />
     </PreferenceCategory>
+
+    <org.mozilla.reference.browser.settings.CustomColorPreference
+            android:key="@string/pref_key_sign_out"
+            android:title="@string/sign_out"
+            app:titleColor="@color/photonRed50" />
 
 </android.support.v7.preference.PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->


### PR DESCRIPTION
Added the Sync Now button with a helper extension to show the time since
last sync when the implementation lands.

Also moved the sign out button down (and made it red) so that the two buttons weren't so
close together.

Closes mozilla-mobile/android-components#1223