### PR TITLE
Closes #220:  FxA integration can cause the app to freeze / deadlock

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/FirefoxAccountsIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/FirefoxAccountsIntegration.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.feature.tabs.TabsUseCases
@@ -103,7 +102,12 @@ class FirefoxAccountsIntegration(
 
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     fun destroy() {
-        runBlocking { account.await().close() }
+        if (account.isCompleted) {
+            account.getCompleted().close()
+        } else {
+            account.cancel()
+        }
+
         job.cancel()
     }
 


### PR DESCRIPTION
The sync `saveState` when switching fragments is definitely making the UI sluggish, but what caused  the app to freeze for me is this. I noticed it because the sample browser actually doesn't freeze for me (using Gecko, using Webview it does), just becomes a little slow.

The freeze/deadlock can be reproduced by quickly switching between tabs tray and browser. This PR fixes that.