### PR TITLE
Add private browsing in TabsTray

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,6 +115,7 @@ dependencies {
     implementation Deps.mozilla_feature_storage
 
     implementation Deps.mozilla_ui_autocomplete
+    implementation Deps.mozilla_ui_colors
 
     implementation Deps.mozilla_service_firefox_accounts
 

--- a/app/src/main/java/org/mozilla/reference/browser/AppRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/AppRequestInterceptor.kt
@@ -10,10 +10,18 @@ import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.request.RequestInterceptor
 import org.mozilla.reference.browser.ext.components
+import org.mozilla.reference.browser.tabs.PrivatePage
 
 class AppRequestInterceptor(private val context: Context) : RequestInterceptor {
     override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {
-        return context.components.firefoxAccountsIntegration.interceptor.onLoadRequest(session, uri)
+        return when (uri) {
+            "about:privatebrowsing" -> {
+                val page = PrivatePage.createPrivateBrowsingPage(context, uri)
+                return RequestInterceptor.InterceptionResponse.Content(page, encoding = "base64")
+            }
+
+            else -> context.components.firefoxAccountsIntegration.interceptor.onLoadRequest(session, uri)
+        }
     }
 
     override fun onErrorRequest(

--- a/app/src/main/java/org/mozilla/reference/browser/Components.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/Components.kt
@@ -146,6 +146,23 @@ class Components(
     // Tabs
     val tabsUseCases: TabsUseCases by lazy { TabsUseCases(sessionManager) }
 
+    // TODO work around until we have https://github.com/mozilla-mobile/android-components/issues/1457
+    val removeSessions = {
+        sessionManager.all.filter { session ->
+            !session.private
+        }.forEach { session ->
+            sessionManager.remove(session)
+        }
+    }
+
+    val removePrivateSessions = {
+        sessionManager.all.filter { session ->
+            session.private
+        }.forEach { session ->
+            sessionManager.remove(session)
+        }
+    }
+
     // Firefox Accounts
     val firefoxAccountsIntegration: FirefoxAccountsIntegration by lazy {
         FirefoxAccountsIntegration(applicationContext, tabsUseCases)

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
@@ -6,11 +6,11 @@ package org.mozilla.reference.browser.browser
 
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import androidx.core.content.PermissionChecker.PERMISSION_GRANTED
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_browser.*
 import mozilla.components.feature.awesomebar.AwesomeBarFeature
 import mozilla.components.feature.downloads.DownloadsFeature
@@ -45,14 +45,14 @@ class BrowserFragment : Fragment(), BackHandler {
 
         lifecycle.addObserver(ToolbarIntegration(
             requireContext(),
-            toolbar,
+            tabsPanel,
             requireComponents.placesHistoryStorage,
             requireComponents.shippedDomainsProvider,
             sessionId))
 
         lifecycle.addObserver(requireComponents.firefoxAccountsIntegration)
 
-        awesomeBarFeature = AwesomeBarFeature(awesomeBar, toolbar, engineView)
+        awesomeBarFeature = AwesomeBarFeature(awesomeBar, tabsPanel, engineView)
             .addSearchProvider(
                 requireComponents.searchEngineManager.getDefaultSearchEngine(requireContext()),
                 requireComponents.searchUseCases.defaultSearch)
@@ -63,7 +63,7 @@ class BrowserFragment : Fragment(), BackHandler {
                 requireComponents.placesHistoryStorage,
                 requireComponents.sessionUseCases.loadUrl)
 
-        tabsToolbarFeature = TabsToolbarFeature(toolbar, requireComponents.sessionManager, ::showTabs)
+        tabsToolbarFeature = TabsToolbarFeature(tabsPanel, requireComponents.sessionManager, ::showTabs)
 
         downloadsFeature = DownloadsFeature(
                 requireContext(),
@@ -100,7 +100,7 @@ class BrowserFragment : Fragment(), BackHandler {
     }
 
     override fun onBackPressed(): Boolean {
-        if (toolbar.onBackPressed()) {
+        if (tabsPanel.onBackPressed()) {
             return true
         }
 

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/PrivatePage.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/PrivatePage.kt
@@ -15,21 +15,21 @@ object PrivatePage {
      * Load and generate a private browsing page for the given url and html/css resources
      */
     fun createPrivateBrowsingPage(
-            context: Context,
-            url: String,
-            @RawRes htmlRes: Int = R.raw.private_mode,
-            @RawRes cssRes: Int = R.raw.private_style
+        context: Context,
+        url: String,
+        @RawRes htmlRes: Int = R.raw.private_mode,
+        @RawRes cssRes: Int = R.raw.private_style
     ): String {
         val css = context.resources.openRawResource(cssRes).bufferedReader().use {
             it.readText()
         }
 
         return context.resources.openRawResource(htmlRes)
-                .bufferedReader()
-                .use { it.readText() }
-                .replace("%pageTitle%", context.getString(R.string.private_browsing_title))
-                .replace("%pageBody%", context.getString(R.string.private_browsing_body))
-                .replace("%privateBrowsingSupportUrl%", url)
-                .replace("%css%", css)
+            .bufferedReader()
+            .use { it.readText() }
+            .replace("%pageTitle%", context.getString(R.string.private_browsing_title))
+            .replace("%pageBody%", context.getString(R.string.private_browsing_body))
+            .replace("%privateBrowsingSupportUrl%", url)
+            .replace("%css%", css)
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/PrivatePage.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/PrivatePage.kt
@@ -1,0 +1,35 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.mozilla.reference.browser.tabs
+
+import android.content.Context
+import androidx.annotation.RawRes
+import org.mozilla.reference.browser.R
+
+object PrivatePage {
+    /**
+     * Load and generate a private browsing page for the given url and html/css resources
+     */
+    fun createPrivateBrowsingPage(
+            context: Context,
+            url: String,
+            @RawRes htmlRes: Int = R.raw.private_mode,
+            @RawRes cssRes: Int = R.raw.private_style
+    ): String {
+        val css = context.resources.openRawResource(cssRes).bufferedReader().use {
+            it.readText()
+        }
+
+        return context.resources.openRawResource(htmlRes)
+                .bufferedReader()
+                .use { it.readText() }
+                .replace("%pageTitle%", context.getString(R.string.private_browsing_title))
+                .replace("%pageBody%", context.getString(R.string.private_browsing_body))
+                .replace("%privateBrowsingSupportUrl%", url)
+                .replace("%css%", css)
+    }
+}

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/TabsPanel.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/TabsPanel.kt
@@ -1,0 +1,121 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.mozilla.reference.browser.tabs
+
+import android.content.Context
+import android.content.res.Resources
+import android.graphics.PorterDuff.Mode.SRC_IN
+import android.graphics.drawable.Drawable
+import android.util.AttributeSet
+import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
+import mozilla.components.feature.tabs.tabstray.TabsFeature
+import mozilla.components.ui.colors.R.color.photonPurple50
+import org.mozilla.reference.browser.R
+import org.mozilla.reference.browser.ext.components
+import org.mozilla.reference.browser.view.ToggleImageButton
+
+class TabsPanel @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : androidx.appcompat.widget.Toolbar(context, attrs) {
+    private lateinit var button: ToggleImageButton
+    private lateinit var privateButton: ToggleImageButton
+    private var tabsFeature: TabsFeature? = null
+    private var isPrivateTray = false
+    private var closeTabsTray: (() -> Unit)? = null
+
+    init {
+        setNavigationIcon(R.drawable.mozac_ic_back)
+        setNavigationOnClickListener {
+            closeTabsTray?.invoke()
+        }
+        inflateMenu(R.menu.tabstray_menu)
+        setOnMenuItemClickListener {
+            when (it.itemId) {
+                R.id.newTab -> {
+                    with(components.tabsUseCases) {
+                        when (isPrivateTray) {
+                            true -> addPrivateTab.invoke("about:privatebrowsing", selectTab = true)
+                            false -> addTab.invoke("about:blank", selectTab = true)
+                        }
+                    }
+                    closeTabsTray?.invoke()
+                }
+                R.id.closeTab -> {
+                    with(components) {
+                        when (isPrivateTray) {
+                            true -> removePrivateSessions.invoke()
+                            false -> removeSessions.invoke()
+                        }
+                    }
+                }
+            }
+            true
+        }
+
+        button = ToggleImageButton(context).apply {
+            setImageDrawable(resources.getThemedDrawable(R.drawable.mozac_ic_tab))
+            setOnCheckedChangeListener { _, checked ->
+                if (checked) {
+                    updateToggleStates(this, privateButton, false)
+                }
+            }
+        }
+        privateButton = ToggleImageButton(context).apply {
+            setImageDrawable(resources.getThemedDrawable(R.drawable.mozac_ic_globe))
+            setOnCheckedChangeListener { _, checked ->
+                if (checked) {
+                    updateToggleStates(this, button, true)
+                }
+            }
+        }
+
+        addView(button)
+        addView(privateButton)
+    }
+
+    private fun updateToggleStates(ours: ToggleImageButton, theirs: ToggleImageButton, isPrivate: Boolean) {
+        // Tint our button
+        ours.drawable.colorTint(photonPurple50)
+
+        // Uncheck their button and remove tint
+        theirs.isChecked = false
+        theirs.drawable.colorFilter = null
+
+        // Store the state for the menu option
+        isPrivateTray = isPrivate
+
+        // Update the tabs tray with our filter
+        tabsFeature?.filterTabs { it.private == isPrivate }
+
+        // Update the menu option text
+        menu.findItem(R.id.closeTab).title = if (isPrivate) {
+            context.getString(R.string.menu_action_close_tabs_private)
+        } else {
+            context.getString(R.string.menu_action_close_tabs)
+        }
+    }
+
+    fun initialize(tabsFeature: TabsFeature?, closeTabsTray: () -> Unit) {
+        this.tabsFeature = tabsFeature
+        this.closeTabsTray = closeTabsTray
+
+        // initial opening of tabs tray should show regular tabs.
+        button.isChecked = true
+    }
+
+    private fun Resources.getThemedDrawable(@DrawableRes resId: Int) = getDrawable(resId, context.theme)
+
+    private fun Drawable.colorTint(@ColorRes color: Int) = apply {
+        mutate()
+        setColorFilter(ContextCompat.getColor(context, color), SRC_IN)
+    }
+
+    private val components = context.components
+}

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/TabsPanel.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/TabsPanel.kt
@@ -68,7 +68,7 @@ class TabsPanel @JvmOverloads constructor(
             }
         }
         privateButton = ToggleImageButton(context).apply {
-            setImageDrawable(resources.getThemedDrawable(R.drawable.mozac_ic_globe))
+            setImageDrawable(resources.getThemedDrawable(R.drawable.mozac_ic_private_browsing))
             setOnCheckedChangeListener { _, checked ->
                 if (checked) {
                     updateToggleStates(this, button, true)

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/TabsTrayFragment.kt
@@ -50,7 +50,12 @@ class TabsTrayFragment : Fragment(), BackHandler {
         toolbar.setOnMenuItemClickListener {
             when (it.itemId) {
                 R.id.newTab -> {
-                    requireComponents.tabsUseCases.addTab.invoke("about:blank", selectTab = true)
+                    when (regularTabs) {
+                        true ->
+                            requireComponents.tabsUseCases.addTab.invoke("about:blank", selectTab = true)
+                        false ->
+                            requireComponents.tabsUseCases.addPrivateTab.invoke("about:privatebrowsing", selectTab = true)
+                    }
                     closeTabsTray()
                 }
             }

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/TabsTrayFragment.kt
@@ -4,23 +4,14 @@
 
 package org.mozilla.reference.browser.tabs
 
-import android.content.res.Resources
-import android.graphics.PorterDuff.Mode.SRC_IN
-import android.graphics.drawable.Drawable
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.ColorRes
-import androidx.annotation.DrawableRes
-import androidx.core.content.ContextCompat
-import kotlinx.android.synthetic.main.fragment_tabstray.toolbar
+import kotlinx.android.synthetic.main.fragment_tabstray.tabsPanel
 import kotlinx.android.synthetic.main.fragment_tabstray.tabsTray
-import mozilla.components.browser.toolbar.BrowserToolbar
-import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.tabs.tabstray.TabsFeature
-import mozilla.components.ui.colors.R.color.photonPurple50
 import org.mozilla.reference.browser.BackHandler
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.browser.BrowserFragment
@@ -29,13 +20,8 @@ import org.mozilla.reference.browser.ext.requireComponents
 /**
  * A fragment for displaying the tabs tray.
  */
-@Suppress("TooManyFunctions")
 class TabsTrayFragment : Fragment(), BackHandler {
     private var tabsFeature: TabsFeature? = null
-    private lateinit var tabsButton: BrowserToolbar.TwoStateButton
-    private lateinit var privateTabsButton: BrowserToolbar.TwoStateButton
-    private val browserActions: MutableList<DisplayAction> = mutableListOf()
-    private var isPrivateTray = false
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
         inflater.inflate(R.layout.fragment_tabstray, container, false)
@@ -43,70 +29,13 @@ class TabsTrayFragment : Fragment(), BackHandler {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        toolbar.setNavigationIcon(R.drawable.mozac_ic_back)
-        toolbar.setNavigationOnClickListener {
-            closeTabsTray()
-        }
-
-        toolbar.inflateMenu(R.menu.tabstray_menu)
-        toolbar.setOnMenuItemClickListener {
-            when (it.itemId) {
-                R.id.newTab -> {
-                    when (isPrivateTray) {
-                        true ->
-                            requireComponents.tabsUseCases.addPrivateTab.invoke("about:privatebrowsing", selectTab = true)
-                        false ->
-                            requireComponents.tabsUseCases.addTab.invoke("about:blank", selectTab = true)
-                    }
-                    closeTabsTray()
-                }
-                R.id.closeTab -> {
-                    when (isPrivateTray) {
-                        true -> requireComponents.removePrivateSessions.invoke()
-                        false -> requireComponents.removeSessions.invoke()
-                    }
-                }
-            }
-            true
-        }
-
-        tabsButton = BrowserToolbar.TwoStateButton(
-                resources.getThemedDrawable(R.drawable.mozac_ic_tab),
-                "Tabs",
-                resources.getThemedDrawable(R.drawable.mozac_ic_tab).colorTint(photonPurple50),
-                "Tabs selected",
-                isEnabled = { !isPrivateTray }
-        ) {
-            isPrivateTray = false
-            invalidateActions()
-            updateCloseMenu()
-        }
-
-        privateTabsButton = BrowserToolbar.TwoStateButton(
-                resources.getThemedDrawable(R.drawable.mozac_ic_globe),
-                "Private tabs",
-                resources.getThemedDrawable(R.drawable.mozac_ic_globe).colorTint(photonPurple50),
-                "Private tabs selected",
-                isEnabled = { isPrivateTray }
-        ) {
-            isPrivateTray = true
-            invalidateActions()
-            updateCloseMenu()
-        }
-
-        toolbar.apply {
-            addBrowserAction(tabsButton)
-            addBrowserAction(privateTabsButton)
-        }
-
         tabsFeature = TabsFeature(
             tabsTray,
             requireComponents.sessionManager,
             requireComponents.tabsUseCases,
-            { it.private == isPrivateTray },
             ::closeTabsTray)
 
-        invalidateActions()
+        tabsPanel.initialize(tabsFeature) { closeTabsTray() }
     }
 
     override fun onStart() {
@@ -132,60 +61,4 @@ class TabsTrayFragment : Fragment(), BackHandler {
             commit()
         }
     }
-
-    private fun invalidateActions() {
-        for (action in browserActions) {
-            val visible = action.actual.visible()
-
-            if (!visible && action.view != null) {
-                // Action should not be visible anymore. Remove view.
-                toolbar.removeView(action.view)
-                action.view = null
-            } else if (visible && action.view == null) {
-                // Action should be visible. Add view for it.
-                action.actual.createView(toolbar).let {
-                    action.view = it
-                    toolbar.addView(it)
-                }
-            }
-
-            action.view?.let { action.actual.bind(it) }
-        }
-        tabsFeature?.invalidate()
-    }
-
-    private fun updateCloseMenu() {
-        toolbar.menu.findItem(R.id.closeTab).also {
-            if (isPrivateTray) {
-                it.title = getString(R.string.menu_action_close_tabs_private)
-            } else {
-                it.title = getString(R.string.menu_action_close_tabs)
-            }
-        }
-    }
-
-    private fun Resources.getThemedDrawable(@DrawableRes resId: Int) = getDrawable(resId, context?.theme)
-
-    private fun Drawable.colorTint(@ColorRes color: Int) = apply {
-        mutate()
-        setColorFilter(ContextCompat.getColor(requireContext(), color), SRC_IN)
-    }
-
-    private fun ViewGroup.addBrowserAction(action: Toolbar.Action) {
-        val displayAction = DisplayAction(action)
-
-        if (action.visible()) {
-            action.createView(toolbar).let {
-                displayAction.view = it
-                addView(it)
-            }
-        }
-
-        browserActions.add(displayAction)
-    }
-
-    private class DisplayAction(
-        var actual: Toolbar.Action,
-        var view: View? = null
-    )
 }

--- a/app/src/main/java/org/mozilla/reference/browser/view/ToggleImageButton.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/view/ToggleImageButton.kt
@@ -1,0 +1,89 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.mozilla.reference.browser.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.View
+import android.view.accessibility.AccessibilityEvent
+import android.widget.Checkable
+import androidx.appcompat.widget.AppCompatImageButton
+import androidx.core.view.AccessibilityDelegateCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
+import mozilla.components.support.base.android.Padding
+import mozilla.components.support.ktx.android.view.setPadding
+import org.mozilla.reference.browser.R
+
+/**
+ * Based off the internal version of com.google.android.material.internal.CheckableImageButton
+ */
+class ToggleImageButton @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = androidx.appcompat.R.attr.imageButtonStyle
+) : AppCompatImageButton(context, attrs, defStyle), Checkable {
+    private var onCheckedChangeListener: ((ToggleImageButton, Boolean) -> Unit)? = null
+
+    init {
+        ViewCompat.setAccessibilityDelegate(this, object : AccessibilityDelegateCompat() {
+            override fun onInitializeAccessibilityEvent(host: View, event: AccessibilityEvent) {
+                super.onInitializeAccessibilityEvent(host, event)
+                event.isChecked = this@ToggleImageButton.isChecked
+            }
+
+            override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfoCompat) {
+                super.onInitializeAccessibilityNodeInfo(host, info)
+                info.isCheckable = true
+                info.isChecked = this@ToggleImageButton.isChecked
+            }
+        })
+
+        TypedValue().apply {
+            context.theme.resolveAttribute(R.attr.selectableItemBackgroundBorderless, this, true)
+            setBackgroundResource(resourceId)
+        }
+        setPadding(PADDING)
+
+        setChecked(attrs)
+    }
+
+    private fun setChecked(attrs: AttributeSet?) {
+        context.obtainStyledAttributes(attrs, R.styleable.ToggleImageButton).apply {
+            isChecked = getBoolean(R.styleable.ToggleImageButton_android_checked, false)
+            recycle()
+        }
+    }
+
+    override fun isChecked(): Boolean {
+        return isSelected
+    }
+
+    override fun setChecked(checked: Boolean) {
+        isSelected = checked
+        onCheckedChangeListener?.invoke(this, checked)
+    }
+
+    override fun toggle() {
+        isChecked = !isChecked
+    }
+
+    override fun performClick(): Boolean {
+        toggle()
+        return super.performClick()
+    }
+
+    fun setOnCheckedChangeListener(listener: (ToggleImageButton, Boolean) -> Unit) {
+        this.onCheckedChangeListener = listener
+    }
+
+    companion object {
+        private const val ACTION_PADDING_DP = 16
+        private val PADDING = Padding(ACTION_PADDING_DP, ACTION_PADDING_DP, ACTION_PADDING_DP, ACTION_PADDING_DP)
+    }
+}

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -16,7 +16,7 @@
         android:layout_width="match_parent">
 
         <mozilla.components.browser.toolbar.BrowserToolbar
-            android:id="@+id/toolbar"
+            android:id="@+id/tabsPanel"
             android:layout_width="match_parent"
             android:layout_height="56dp"
             android:background="@color/primary"

--- a/app/src/main/res/layout/fragment_tabstray.xml
+++ b/app/src/main/res/layout/fragment_tabstray.xml
@@ -7,8 +7,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/toolbar"
+    <org.mozilla.reference.browser.tabs.TabsPanel
+        android:id="@+id/tabsPanel"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
@@ -24,7 +24,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar">
+        app:layout_constraintTop_toBottomOf="@+id/tabsPanel">
 
     </mozilla.components.concept.tabstray.TabsTray>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/tabstray_menu.xml
+++ b/app/src/main/res/menu/tabstray_menu.xml
@@ -9,4 +9,8 @@
         android:icon="@drawable/mozac_ic_tab_new"
         android:title="@string/menu_action_add_tab"
         app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/closeTab"
+        android:title="@string/menu_action_close_tabs"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/raw/private_mode.html
+++ b/app/src/main/res/raw/private_mode.html
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<html xmlns="http://www.w3.org/1999/xhtml" class="private">
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>%pageTitle%</title>
+        <style>%css%</style>
+    </head>
+    <body>
+        <svg style="position: absolute; width: 4em; height: 4em; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <defs>
+                <symbol id="icon-private" viewBox="0 0 200 200">
+                    <title>icon-private-browsing</title><path d="M181.3,68.94c-6-7.07-17.89-9-28.28-8.83-31.17.66-37,11.1-52.71,11.1S78.76,60.77,47.59,60.11c-10.39-.22-22.32,1.76-28.28,8.83s-7.73,18.78-4.42,33.81c2.9,13.13,13,38,36.23,37.55,21.88-.41,29.16-18.68,49.13-18.93,20,.25,27.36,18.52,49.24,18.93,23.19.45,33.33-24.42,36.23-37.55C189,87.72,187.16,75.88,181.3,68.94Zm-117.89,38c-8.62.08-23.3-4.62-23-8.68.26-4.28,16-11.6,26.26-11.3,4.2.12,17.47,3.29,18.64,13.83C85.53,103.05,75,106.8,63.41,106.92Zm73.79,0c-11.59-.12-22.12-3.87-21.86-6.15C116.5,90.23,129.78,87.06,134,86.94c10.3-.3,26,7,26.26,11.3C160.5,102.3,145.82,107,137.2,106.92Z" fill="#fff"/>
+                </symbol>
+            </defs>
+        </svg>
+        <div class="container">
+            <svg class="icon"><use xlink:href="#icon-private"></use></svg>
+            <section class="section-main">%pageBody%</section>
+        </div>
+        <script>
+          (() => {
+            const urls = {
+              privateBrowsingSupportUrl: '%privateBrowsingSupportUrl%'
+            };
+            const learnMoreEl = document.getElementById('learnMore');
+            if (learnMoreEl) {
+              learnMoreEl.href = urls.privateBrowsingSupportUrl;
+            }
+          })();
+        </script>
+    </body>
+</html>

--- a/app/src/main/res/raw/private_style.css
+++ b/app/src/main/res/raw/private_style.css
@@ -1,0 +1,146 @@
+/* - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this file,
+   - You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+:root {
+    --color-steel: #434c58;
+    --color-driftwood: #f4f4f4;
+    --color-dusk: #556f8e;
+    --color-void: #232426;
+    --color-purple: #331a50;
+    --color-text: #fff;
+}
+
+*,
+*:before,
+*:after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+* {
+    font: 20px/1.2em BlinkMacSystemFont, -apple-system, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+}
+
+html,
+body {
+    align-items: center;
+    background: var(--color-driftwood);
+    display: grid;
+    grid-template-rows: auto;
+    height: 100%;
+    justify-items: center;
+    width: 100%;
+}
+
+h1 {
+    font-size: 2em;
+    font-weight: bold;
+    margin: 0 0 0.5em;
+    position: relative;
+}
+
+strong {
+    font-weight: bold;
+}
+
+ol,
+ul,
+p {
+    margin: 1em 0;
+}
+
+ol:first-child,
+ul:first-child,
+p:first-child {
+    margin-top: 0;
+}
+
+ol:last-child,
+ul:last-child,
+p:last-child {
+    margin-bottom: 0;
+}
+
+ol,
+ul {
+    list-style-position: inside;
+}
+
+ol {
+    list-style-type: decimal;
+}
+
+li {
+    margin: 0.25em 0;
+    text-indent: -1em;
+    padding-left: 1em;
+}
+
+p {
+    line-height: 1.5em;
+}
+
+a {
+    color: inherit;
+    font-size: inherit;
+    text-decoration: underline;
+}
+
+button,
+button:active {
+    color: var(--color-text);
+}
+
+button {
+    background: var(--color-steel);
+    border-radius: 10px;
+    border: 2px solid var(--color-steel);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: 900;
+    height: 3em;
+    padding: 0 1em;
+}
+
+button:hover {
+    background: transparent;
+    color: var(--color-steel);
+}
+
+button:active {
+    background: var(--color-void);
+    border-color: var(--color-void);
+    color: var(--color-text);
+}
+
+.container {
+    grid-column-start: 1;
+    width: 75%;
+}
+
+.icon {
+    height: 4em;
+    width: 4em;
+}
+
+.two-column {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-column-gap: 1em;
+}
+
+html.private body {
+    background: var(--color-purple);
+    color: var(--color-text);
+}
+
+.section-main {
+    margin-bottom: 48px;
+}
+
+.about-info {
+    font-size: .9rem;
+}

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -7,4 +7,8 @@
         <attr name="titleColor" format="color" />
         <attr name="summaryColor" format="color" />
     </declare-styleable>
+
+    <declare-styleable name="ToggleImageButton">
+        <attr name="android:checked" />
+    </declare-styleable>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,10 @@
     <!-- Menu option on the toolbar to open a new tab-->
     <string name="menu_action_add_tab">Add New Tab</string>
 
+    <!-- Menu option on the toolbar to close all tabs-->
+    <string name="menu_action_close_tabs">Close All Tabs</string>
+    <string name="menu_action_close_tabs_private">Close Private Tabs</string>
+
     <!-- Preference summary for settings related sign in -->
     <string name="preferences_sign_in_summary">Sync your tabs, logins and history</string>
 
@@ -63,7 +67,7 @@
     <string name="private_browsing_title">Private Browsing</string>
     <string name="private_browsing_body"><![CDATA[
 <h1>Private Browsing</h1>
-<p>When you browse in a Private Window, Firefox Reality <strong>does not save</strong>:</p>
+<p>When you browse in a Private Window, Reference Browser <strong>does not save</strong>:</p>
 <ul class="two-column">
     <li>visited pages</li>
     <li>searches</li>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,4 +58,19 @@
 
     <!-- Snackbar action button when a non fatal crash happen-->
     <string name="crash_report_non_fatal_action">Report</string>
+
+    <!-- Private Browsing -->
+    <string name="private_browsing_title">Private Browsing</string>
+    <string name="private_browsing_body"><![CDATA[
+<h1>Private Browsing</h1>
+<p>When you browse in a Private Window, Firefox Reality <strong>does not save</strong>:</p>
+<ul class="two-column">
+    <li>visited pages</li>
+    <li>searches</li>
+    <li>cookies</li>
+    <li>temporary files</li>
+</ul>
+<p>Private Browsing <strong>doesn\'t make you anonymous</strong> on the Internet. Your employer or Internet service provider can still know what page you visit.</p>
+<p class="about-info">Learn more about <a id="learnMore">Private Browsing</a>.</p>
+     ]]></string>
 </resources>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -51,6 +51,7 @@ object Deps {
     const val mozilla_feature_downloads = "org.mozilla.components:feature-downloads:${Versions.mozilla_android_components}"
     const val mozilla_feature_storage = "org.mozilla.components:feature-storage:${Versions.mozilla_android_components}"
     const val mozilla_ui_autocomplete = "org.mozilla.components:ui-autocomplete:${Versions.mozilla_android_components}"
+    const val mozilla_ui_colors = "org.mozilla.components:ui-colors:${Versions.mozilla_android_components}"
     const val mozilla_service_firefox_accounts = "org.mozilla.components:service-firefox-accounts:${Versions.mozilla_android_components}"
     const val mozilla_support_utils = "org.mozilla.components:support-utils:${Versions.mozilla_android_components}"
     const val mozilla_support_ktx= "org.mozilla.components:support-ktx:${Versions.mozilla_android_components}"


### PR DESCRIPTION
These is some duplication from private helper functions in the BrowserToolbar which I've reused here. Maybe they should be made accessible for other apps as well? (i.e. `DisplayAction`, `addBrowserAction` and `invalidateActions`)

Blocked on:
- [x] https://github.com/mozilla-mobile/android-components/issues/1451
- [x] https://github.com/mozilla-mobile/android-components/issues/1403
- [x] A-C 0.33.0 integration