### PR TITLE
Closes #264: Provide testing mode setting / pref

### DIFF
--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -11,4 +11,5 @@
     <string name="pref_key_make_default_browser" translatable="false">pref_key_make_default_browser</string>
     <string name="pref_key_sync_history" translatable="false">pref_key_sync_history</string>
     <string name="pref_key_remote_debugging" translatable="false">pref_key_remote_debugging</string>
+    <string name="pref_key_testing_mode" translatable="false">pref_key_testing_mode</string>
 </resources>


### PR DESCRIPTION
Currently blocked until the next a-c release. 

This brings in the new `testingModeEnabled` setting and ties it to a pref so it can be turned on in instrumented tests. Right now this is just for making sure `GeckoSessionSettings.FULL_ACCESSIBILITY_TREE` is set to true. 

We don't need a UI for it right now. Example for how to turn it on in a test:

```Kotlin
val testingModePref = InstrumentationRegistry
    .getTargetContext()
    .getString(R.string.pref_key_testing_mode)

PreferenceManager.getDefaultSharedPreferences(appContext)
    .edit()
    .putBoolean(testingModePref, true)
    .apply()
```
/cc @npark-mozilla  