### PR TITLE
Uses new email as taskcluster tasks' owner

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -154,5 +154,5 @@ tasks:
         metadata:
           name: Decision task (nightly)
           description: Scheduling tasks for nightly release of reference browser
-          owner: skaspari@mozilla.com
+          owner: android-components-team@mozilla.com
           source: ${repository}/raw/${event.release.tag_name}/.taskcluster.yml

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -67,7 +67,7 @@ def create_raw_task(name, description, full_command, scopes = []):
         "metadata": {
             "name": name,
             "description": description,
-            "owner": "skaspari@mozilla.com",
+            "owner": "android-components-team@mozilla.com",
             "source": "https://github.com/mozilla-mobile/android-components"
         }
     }

--- a/automation/taskcluster/decision_task_nightly.py
+++ b/automation/taskcluster/decision_task_nightly.py
@@ -21,7 +21,7 @@ HEAD_REV = os.environ.get('MOBILE_HEAD_REV')
 
 BUILDER = lib.tasks.TaskBuilder(
     task_id=TASK_ID,
-    owner="skaspari@mozilla.com",
+    owner="android-components-team@mozilla.com",
     source='{}/raw/{}/.taskcluster.yml'.format(GITHUB_HTTP_REPOSITORY, HEAD_REV),
     scheduler_id=SCHEDULER_ID
 )


### PR DESCRIPTION
I've updated the scopes in the hooks themselves.
[rationale for this PR](https://github.com/mozilla-mobile/reference-browser/pull/268#discussion_r241800535)