### PR TITLE
Updates pushapk google play scope, replacing "focus" with "reference-browser"

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -99,13 +99,13 @@ tasks:
                 - queue:create-task:highest:scriptworker-prov-v1/mobile-signing-v1
                 - queue:create-task:highest:scriptworker-prov-v1/mobile-pushapk-v1
                 - project:mobile:reference-browser:releng:signing:cert:release-signing
-                - project:mobile:focus:releng:googleplay:product:reference-browser
+                - project:mobile:reference-browser:releng:googleplay:product:reference-browser
                 - queue:route:index.project.mobile.reference-browser.nightly.latest
               else:
                 - queue:create-task:highest:scriptworker-prov-v1/mobile-signing-dep-v1
                 - queue:create-task:highest:scriptworker-prov-v1/mobile-pushapk-dep-v1
                 - project:mobile:reference-browser:releng:signing:cert:dep-signing
-                - project:mobile:focus:releng:googleplay:product:reference-browser:dep
+                - project:mobile:reference-browser:releng:googleplay:product:reference-browser:dep
                 - queue:route:index.project.mobile.reference-browser.staging-nightly.latest
         payload:
           maxRunTime: 600   # Decision should remain fast enough to schedule a handful of tasks

--- a/automation/taskcluster/decision_task_nightly.py
+++ b/automation/taskcluster/decision_task_nightly.py
@@ -88,7 +88,7 @@ def generate_push_task(signing_task_id, apks, commit, is_staging):
         description="Upload signed release builds of Reference Browser to Google Play",
         apks=artifacts,
         scopes=[
-            "project:mobile:focus:releng:googleplay:product:reference-browser{}".format(':dep' if is_staging else '')
+            "project:mobile:reference-browser:releng:googleplay:product:reference-browser{}".format(':dep' if is_staging else '')
         ],
         commit=commit,
         is_staging=is_staging


### PR DESCRIPTION
Taskcluster hooks and roles have been updated (both nightly and staging-nightly).
Thanks Johan for [the related work in pushapk!](https://github.com/mozilla-releng/pushapkscript/pull/54)