### PR TITLE
Closes #190: Add an About Page to show build and gecko version

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/AppRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/AppRequestInterceptor.kt
@@ -10,6 +10,7 @@ import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.request.RequestInterceptor
 import org.mozilla.reference.browser.ext.components
+import org.mozilla.reference.browser.settings.AboutPage
 import org.mozilla.reference.browser.tabs.PrivatePage
 
 class AppRequestInterceptor(private val context: Context) : RequestInterceptor {
@@ -17,6 +18,11 @@ class AppRequestInterceptor(private val context: Context) : RequestInterceptor {
         return when (uri) {
             "about:privatebrowsing" -> {
                 val page = PrivatePage.createPrivateBrowsingPage(context, uri)
+                return RequestInterceptor.InterceptionResponse.Content(page, encoding = "base64")
+            }
+
+            "about:version" -> {
+                val page = AboutPage.createAboutPage(context)
                 return RequestInterceptor.InterceptionResponse.Content(page, encoding = "base64")
             }
 

--- a/app/src/main/java/org/mozilla/reference/browser/ext/String.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/ext/String.kt
@@ -1,0 +1,16 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.mozilla.reference.browser.ext
+
+/**
+ * Replaces the keys with the values with the map provided.
+ */
+fun String.replace(pairs: Map<String, String>): String {
+    var result = this
+    pairs.forEach { (l, r) -> result = result.replace(l, r) }
+    return result
+}

--- a/app/src/main/java/org/mozilla/reference/browser/settings/AboutPage.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/AboutPage.kt
@@ -1,0 +1,49 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.mozilla.reference.browser.settings
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.annotation.RawRes
+import org.mozilla.reference.browser.R
+import org.mozilla.geckoview.BuildConfig
+import org.mozilla.reference.browser.ext.replace
+
+object AboutPage {
+    fun createAboutPage(context: Context): String {
+        val substitutionMap = mutableMapOf<String, String>()
+        val appName = context.resources.getString(R.string.app_name)
+
+        try {
+            val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+            val geckoVersion = packageInfo.versionCode.toString() + " \uD83E\uDD8E " +
+                BuildConfig.MOZ_APP_VERSION + "-" + BuildConfig.MOZ_APP_BUILDID
+            String.format(
+                "%s (Build #%s)",
+                packageInfo.versionName,
+                geckoVersion
+            ).also { aboutVersion ->
+                substitutionMap["%about-version%"] = aboutVersion
+            }
+        } catch (e: PackageManager.NameNotFoundException) {
+            // Nothing to do if we can't find the package name.
+        }
+
+        context.resources.getString(R.string.about_content, appName).also { content ->
+            substitutionMap["%about-content%"] = content
+        }
+
+        return loadResourceFile(context, R.raw.about, substitutionMap)
+    }
+
+    private fun loadResourceFile(context: Context, @RawRes resId: Int, replacements: Map<String, String>): String {
+        context.resources.openRawResource(resId)
+            .bufferedReader()
+            .use { it.readText() }
+            .also { return it.replace(replacements) }
+    }
+}

--- a/app/src/main/java/org/mozilla/reference/browser/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/SettingsFragment.kt
@@ -12,12 +12,14 @@ import androidx.preference.Preference.OnPreferenceClickListener
 import androidx.preference.PreferenceFragmentCompat
 import android.widget.Toast
 import android.widget.Toast.LENGTH_SHORT
+import mozilla.components.browser.session.Session
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.R.string.pref_key_firefox_account
 import org.mozilla.reference.browser.ext.getPreferenceKey
 import org.mozilla.reference.browser.R.string.pref_key_sign_in
 import org.mozilla.reference.browser.R.string.pref_key_make_default_browser
 import org.mozilla.reference.browser.R.string.pref_key_remote_debugging
+import org.mozilla.reference.browser.R.string.pref_key_about_page
 import org.mozilla.reference.browser.ext.requireComponents
 
 class SettingsFragment : PreferenceFragmentCompat() {
@@ -49,10 +51,12 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val firefoxAccountKey = context?.getPreferenceKey(pref_key_firefox_account)
         val makeDefaultBrowserKey = context?.getPreferenceKey(pref_key_make_default_browser)
         val remoteDebuggingKey = context?.getPreferenceKey(pref_key_remote_debugging)
+        val aboutPageKey = context?.getPreferenceKey(pref_key_about_page)
         val preferenceSignIn = findPreference(signInKey)
         val preferenceFirefoxAccount = findPreference(firefoxAccountKey)
         val preferenceMakeDefaultBrowser = findPreference(makeDefaultBrowserKey)
         val preferenceRemoteDebugging = findPreference(remoteDebuggingKey)
+        val preferenceAboutPage = findPreference(aboutPageKey)
         val fxaIntegration = requireComponents.services.accounts
 
         preferenceSignIn.onPreferenceClickListener = getClickListenerForSignIn()
@@ -65,11 +69,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
         preferenceMakeDefaultBrowser.onPreferenceClickListener = getClickListenerForMakeDefaultBrowser()
 
         preferenceRemoteDebugging.onPreferenceChangeListener = getChangeListenerForRemoteDebugging()
+
+        preferenceAboutPage.onPreferenceClickListener = getAboutPageListener()
     }
 
     private fun getClickListenerForMakeDefaultBrowser(): OnPreferenceClickListener {
         return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-            OnPreferenceClickListener { _ ->
+            OnPreferenceClickListener {
                 val intent = Intent(
                     Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS
                 )
@@ -82,7 +88,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun getClickListenerForSignIn(): OnPreferenceClickListener {
-        return OnPreferenceClickListener { _ ->
+        return OnPreferenceClickListener {
             activity?.finish()
             requireComponents.services.accounts.authenticate()
             true
@@ -90,7 +96,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun getClickListenerForFirefoxAccount(): OnPreferenceClickListener {
-        return OnPreferenceClickListener { _ ->
+        return OnPreferenceClickListener {
             fragmentManager?.beginTransaction()
                     ?.replace(android.R.id.content, AccountSettingsFragment())
                     ?.addToBackStack(null)
@@ -105,6 +111,14 @@ class SettingsFragment : PreferenceFragmentCompat() {
     private fun getChangeListenerForRemoteDebugging(): OnPreferenceChangeListener {
         return OnPreferenceChangeListener { _, newValue ->
             requireComponents.core.engine.settings.remoteDebuggingEnabled = newValue as Boolean
+            true
+        }
+    }
+
+    private fun getAboutPageListener(): OnPreferenceClickListener {
+        return OnPreferenceClickListener {
+            activity?.finish()
+            requireComponents.core.sessionManager.add(Session("about:version"), true)
             true
         }
     }

--- a/app/src/main/res/raw/about.html
+++ b/app/src/main/res/raw/about.html
@@ -1,0 +1,48 @@
+<!doctype html><!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this file,
+   - You can obtain one at http://mozilla.org/MPL/2.0/.  -->
+<head>
+    <meta
+        name="viewport"
+        charset="utf-8"
+        content="width=device-width, initial-scale=1">
+    <style>
+body, html {
+    background: #221F1F;
+    color: #FFFFFF;
+    font-family: sans-serif;
+    line-height: 24px;
+    font-size: 14px;
+}
+
+body{
+    padding-left: 24px;
+    padding-right: 24px;
+    margin-left: 0px;
+    margin-right: 0px;
+}
+
+a {
+    color: #0A9AF4;
+}
+
+p.subtitle {
+    text-align: center;
+    opacity: .7;
+    margin: 0;
+}
+
+h1#wordmark {
+    padding-top: 24px;
+    text-align: center;
+}
+    </style>
+</head>
+<html>
+    <body
+        class="about">
+        <h1 id="wordmark">Reference Browser</h1>
+        <p class="subtitle">%about-version%</p>
+        %about-content%
+    </body>
+</html>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -12,4 +12,5 @@
     <string name="pref_key_sync_history" translatable="false">pref_key_sync_history</string>
     <string name="pref_key_remote_debugging" translatable="false">pref_key_remote_debugging</string>
     <string name="pref_key_testing_mode" translatable="false">pref_key_testing_mode</string>
+    <string name="pref_key_about_page" translatable="false">pref_key_about_page</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,9 @@
     <!-- Preference enabling remote debugging -->
     <string name="preferences_remote_debugging">Remote debugging via USB</string>
 
+    <!-- Preference about page -->
+    <string name="preferences_about_page">About Reference Browser</string>
+
     <!-- Preference for signing in -->
     <string name="sign_in">Sign in</string>
 
@@ -56,6 +59,9 @@
 
     <!-- Preference for settings related turn on telemetry data-->
     <string name="use_telemetry">Use Telemetry</string>
+
+    <!-- Preference category for Mozilla about/legal etc. -->
+    <string name="mozilla_category">Mozilla</string>
 
     <!-- Menu option on the toolbar that takes you to settings page-->
     <string name="settings">Settings</string>
@@ -92,4 +98,16 @@
     
     <string name="default_notification_channel">Browser</string>
 
+    <!-- About content -->
+    <string name="about_content"><![CDATA[
+<p>%1$s puts you in control.</p>
+<p>Use it as a reference browser:
+  <ul>
+    <li>Learn how to build your own browser.</li>
+    <li>Contribute to making it easier to build browsers.</li>
+    <li>File bug reports!</li>
+  </ul>
+</p>
+<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>
+    ]]></string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -34,4 +34,13 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory
+        android:title="@string/mozilla_category">
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_about_page"
+            android:title="@string/preferences_about_page" />
+
+    </PreferenceCategory>
+
 </androidx.preference.PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    // Synchronized versions numbers of GeckoView (Beta) artifacts.
-    ext.geckoBeta = [
-        // mozilla-beta: FENNEC_63_0b3
-        revision: '0269319281578bff4e01d77a21350bf91ba08620',
-        version: '63.0.20180904170936'
-    ]
-
-    ext.geckoRelease = [
-        // mozilla-release: FENNEC_62_0_RELEASE
-        revision: '9cbae12a3fff404ed2c12070ad475424d0ae869f',
-        version: '62.0.20180830143136'
-    ]
-
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
A couple of things to note here:
 1. We had to expose the Nightly version through the `BuildConfig` class so that it could be retrieved at runtime.
 2. The UI code for the HTML and PNG encoder were taken from Focus which was converted from Java but could be better done? We use a png because encoding an SVG of this type has a huge perf loss.
    - The PNG encoder does some header checking which may not be necessary?
    - It has comments from the old code that I've copied over as well - should we re-write those to be clearer?
 3. Old unused configs in the buildSrc for `geckoRelease` and `geckoBeta` were removed.
 4. There are few helper functions like `loadPngAsDataURI` and `loadResourceFile` that can be made to be more re-usable but right now there aren't may use cases for it.
 5. I also took some liberties with the About page copy. 😅 