### PR TITLE
Browser menu improvements

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/Components.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/Components.kt
@@ -21,7 +21,7 @@ class Components(private val context: Context) {
     val search by lazy { Search(context) }
     val useCases by lazy { UseCases(context, core.sessionManager, search.searchEngineManager) }
     val services by lazy { Services(context, useCases.tabsUseCases, core.historyStorage) }
-    val toolbar by lazy { Toolbar(context, useCases.sessionUseCases, core.sessionManager) }
+    val toolbar by lazy { Toolbar(context, useCases.sessionUseCases, useCases.tabsUseCases, core.sessionManager) }
     val analytics by lazy { Analytics(context) }
     val utils by lazy { Utilities(core.sessionManager, useCases.sessionUseCases, useCases.searchUseCases) }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/components/Toolbar.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Toolbar.kt
@@ -73,9 +73,6 @@ class Toolbar(
             SimpleBrowserMenuItem("Settings") {
                 openSettingsActivity()
             },
-            SimpleBrowserMenuItem("Clear Data") {
-                sessionUseCases.clearData.invoke()
-            },
             SimpleBrowserMenuCheckbox("Request desktop site", {
                 sessionManager.selectedSessionOrThrow.desktopMode
             }) { checked ->

--- a/app/src/main/java/org/mozilla/reference/browser/components/Toolbar.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Toolbar.kt
@@ -13,6 +13,7 @@ import mozilla.components.browser.menu.item.SimpleBrowserMenuCheckbox
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.feature.tabs.TabsUseCases
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.share
 import org.mozilla.reference.browser.settings.SettingsActivity
@@ -23,6 +24,7 @@ import org.mozilla.reference.browser.settings.SettingsActivity
 class Toolbar(
     private val context: Context,
     private val sessionUseCases: SessionUseCases,
+    private val tabsUseCases: TabsUseCases,
     private val sessionManager: SessionManager
 ) {
 
@@ -70,13 +72,20 @@ class Toolbar(
                 val url = sessionManager.selectedSession?.url ?: ""
                 context.share(url)
             },
-            SimpleBrowserMenuItem("Settings") {
-                openSettingsActivity()
-            },
+
             SimpleBrowserMenuCheckbox("Request desktop site", {
                 sessionManager.selectedSessionOrThrow.desktopMode
             }) { checked ->
                 sessionUseCases.requestDesktopSite.invoke(checked)
+            },
+
+            SimpleBrowserMenuItem("Report issue") {
+                tabsUseCases.addTab.invoke(
+                    "https://github.com/mozilla-mobile/reference-browser/issues/new")
+            },
+
+            SimpleBrowserMenuItem("Settings") {
+                openSettingsActivity()
             }
         )
     }

--- a/app/src/main/java/org/mozilla/reference/browser/ext/Context.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/ext/Context.kt
@@ -16,6 +16,7 @@ import mozilla.components.support.base.log.Log.Priority.WARN
 import mozilla.components.support.base.log.Log
 import org.mozilla.reference.browser.BrowserApplication
 import org.mozilla.reference.browser.Components
+import org.mozilla.reference.browser.R
 
 /**
  * Get the BrowserApplication object from a context.
@@ -47,7 +48,12 @@ fun Context.share(text: String, subject: String = ""): Boolean {
             putExtra(EXTRA_TEXT, text)
             flags = FLAG_ACTIVITY_NEW_TASK
         }
-        startActivity(intent)
+
+        val shareIntent = Intent.createChooser(intent, getString(R.string.menu_share_with)).apply {
+            flags = FLAG_ACTIVITY_NEW_TASK
+        }
+
+        startActivity(shareIntent)
         true
     } catch (e: ActivityNotFoundException) {
         Log.log(WARN, message = "No activity to share to found", throwable = e, tag = "Reference-Browser")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,4 +110,7 @@
 </p>
 <p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>
     ]]></string>
+
+    <string name="menu_share_with">Share with…</string>
+
 </resources>


### PR DESCRIPTION
* Share should open the share sheet and not open an app (and set a default)
* "Clear data" shouldn't do anything, so let's remove it from the menu
* Added a "Report issue" item that links to the issue tracker