### PR TITLE
Bug 1517732 - Expose routes.statuses because taskcluster-github now a…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -29,6 +29,8 @@ tasks:
         scopes:
           - queue:create-task:aws-provisioner-v1/github-worker
           - queue:scheduler-id:${scheduler_id}
+        routes:
+          - statuses  # Automatically added by taskcluster-github. It must be explicit because of Chain of Trust
         payload:
           maxRunTime: 7200
           image: mozillamobile/android-components:1.10


### PR DESCRIPTION
…dds it

See https://github.com/mozilla-mobile/android-components/pull/1650. Depends on https://github.com/taskcluster/taskcluster/pull/29