### PR TITLE
Closes #130: Enable telemetry by default.

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -15,7 +15,7 @@
         android:title="@string/firefox_account" />
 
     <androidx.preference.SwitchPreferenceCompat
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:title="@string/use_telemetry"
             android:key="@string/pref_key_telemetry"
             android:summary="@string/preferences_use_telemetry_summary"/>


### PR DESCRIPTION
PR #349 is not ready for landing yet. However let's enable the setting already so that users will get telemetry once it lands.