### PR TITLE
Fix routes.statuses to be under the right decision task

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -29,8 +29,6 @@ tasks:
         scopes:
           - queue:create-task:aws-provisioner-v1/github-worker
           - queue:scheduler-id:${scheduler_id}
-        routes:
-          - statuses  # Automatically added by taskcluster-github. It must be explicit because of Chain of Trust
         payload:
           maxRunTime: 7200
           image: mozillamobile/android-components:1.10
@@ -109,6 +107,8 @@ tasks:
                 - project:mobile:reference-browser:releng:signing:cert:dep-signing
                 - project:mobile:reference-browser:releng:googleplay:product:reference-browser:dep
                 - queue:route:index.project.mobile.reference-browser.staging-nightly.latest
+        routes:
+          - statuses  # Automatically added by taskcluster-github. It must be explicit because of Chain of Trust
         payload:
           maxRunTime: 600   # Decision should remain fast enough to schedule a handful of tasks
           image: mozillamobile/android-components:1.10


### PR DESCRIPTION
Follows https://github.com/mozilla-mobile/reference-browser/pull/375 up. See https://github.com/mozilla-mobile/android-components/pull/1657