### PR TITLE
Nightly build: Set crash reporter flag correctly.

### DIFF
--- a/automation/taskcluster/decision_task_nightly.py
+++ b/automation/taskcluster/decision_task_nightly.py
@@ -42,7 +42,7 @@ def generate_build_task(apks):
         command=('cd .. && ' + checkout +
                  ' && python automation/taskcluster/helper/get-secret.py'
                  ' -s project/mobile/reference-browser/sentry -k dsn -f .sentry_token'
-                 ' && ./gradlew --no-daemon -PcrashReportingEnabled clean test assembleRelease'),
+                 ' && ./gradlew --no-daemon -PcrashReportEnabled=true -Ptelemetry=true clean test assembleRelease'),
         features={
             "chainOfTrust": True,
             "taskClusterProxy": True


### PR DESCRIPTION
We somehow didn't use the correct flag which caused the crash reporter to not be enabled.

While editing this line I added the flag for telemetry already (in preparation for #349).