### PR TITLE
Issue #367: Introduce aarch64 flavor and avoid APK split.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -134,8 +134,8 @@ tasks:
               && python automation/taskcluster/decision_task_nightly.py \
                 --commit \
                 --output app/build/outputs/apk \
-                --apk geckoNightlyX86/release/app-geckoNightly-x86-x86-release-unsigned.apk \
-                --apk geckoNightlyArm/release/app-geckoNightly-arm-armeabi-v7a-release-unsigned.apk \
+                --apk geckoNightlyX86/release/app-geckoNightly-x86-release-unsigned.apk.apk \
+                --apk geckoNightlyArm/release/app-geckoNightly-arm-release-unsigned.apk \
                 ${command_staging_flag}
           artifacts:
             public/task-graph.json:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,15 +48,23 @@ android {
         geckoNightly { dimension "engine" }
 
         // Processor architectures
-        arm       { dimension "abi" }
-        x86       { dimension "abi" }
-    }
-
-    splits {
-        abi {
-            enable true
-            reset()
-            include 'x86', 'armeabi-v7a'
+        arm {
+            dimension "abi"
+            ndk {
+                abiFilter "armeabi-v7a"
+            }
+        }
+        x86 {
+            dimension "abi"
+            ndk {
+                abiFilter "x86"
+            }
+        }
+        aarch64 {
+            dimension "abi"
+            ndk {
+                abiFilter "arm64-v8a"
+            }
         }
     }
 
@@ -124,6 +132,7 @@ android.applicationVariants.all { variant ->
 configurations {
     geckoNightlyArmImplementation {}
     geckoNightlyX86Implementation {}
+    geckoNightlyAarch64Implementation {}
 }
 
 dependencies {
@@ -167,6 +176,7 @@ dependencies {
     geckoNightlyImplementation Deps.mozilla_browser_engine_gecko_nightly
     geckoNightlyArmImplementation Gecko.geckoview_nightly_arm
     geckoNightlyX86Implementation Gecko.geckoview_nightly_x86
+    geckoNightlyAarch64Implementation Gecko.geckoview_nightly_aarch64
 
     implementation Deps.kotlin_stdlib
     implementation Deps.kotlin_coroutines

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -9,4 +9,5 @@ private object GeckoVersions {
 object Gecko {
     const val geckoview_nightly_arm = "org.mozilla.geckoview:geckoview-nightly-armeabi-v7a:${GeckoVersions.nightly_version}"
     const val geckoview_nightly_x86 = "org.mozilla.geckoview:geckoview-nightly-x86:${GeckoVersions.nightly_version}"
+    const val geckoview_nightly_aarch64 = "org.mozilla.geckoview:geckoview-nightly-arm64-v8a:${GeckoVersions.nightly_version}"
 }


### PR DESCRIPTION
This adds the new flavor for aarch64. Nothing gets published yet though. We'll wait for the GV team (Chris) to green light that.

As a side effect I could get rid of the APK split and use an `abiFilter` now. That avoids creating a bunch of APK combinations that made no sense (e.g. arm-gecko with x86 AS).