### PR TITLE
Resolves build failure caused by mistyped filename

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -134,7 +134,7 @@ tasks:
               && python automation/taskcluster/decision_task_nightly.py \
                 --commit \
                 --output app/build/outputs/apk \
-                --apk geckoNightlyX86/release/app-geckoNightly-x86-release-unsigned.apk.apk \
+                --apk geckoNightlyX86/release/app-geckoNightly-x86-release-unsigned.apk \
                 --apk geckoNightlyArm/release/app-geckoNightly-arm-release-unsigned.apk \
                 ${command_staging_flag}
           artifacts:


### PR DESCRIPTION
[this commit](https://github.com/mozilla-mobile/reference-browser/commit/df307ec1422a9758cfdc2d037567d7928601107c#diff-ac0229d1171c0983b27003af4c7441a5L137) accidentally added the extension to one of the expected apks twice.
(I've done a local build to confirm that our local `gradle` build is not double-`.apk`-ing our artifacts :+1:)