### PR TITLE
Menu: Hide "share" and "Desktop mode" items if no session is selected.

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/components/Toolbar.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Toolbar.kt
@@ -71,12 +71,16 @@ class Toolbar(
             SimpleBrowserMenuItem("Share") {
                 val url = sessionManager.selectedSession?.url ?: ""
                 context.share(url)
+            }.apply {
+                visible = { sessionManager.selectedSession != null }
             },
 
             BrowserMenuSwitch("Request desktop site", {
                 sessionManager.selectedSessionOrThrow.desktopMode
             }) { checked ->
                 sessionUseCases.requestDesktopSite.invoke(checked)
+            }.apply {
+                visible = { sessionManager.selectedSession != null }
             },
 
             SimpleBrowserMenuItem("Report issue") {


### PR DESCRIPTION
With that you can still open the menu if there's no selected session. Currently we always have one. But that may change.