### PR TITLE
Add GitHub bug report format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,20 @@
+---
+name: "\U0001F41E Bug report"
+about: Create a report to help us improve
+
+---
+
+### Steps to reproduce
+1.
+
+### Expected behavior
+-
+
+### Actual behavior
+-
+
+### Device information
+
+* Android device: ?
+* Reference Browser version: ?
+


### PR DESCRIPTION
I've added a template for creating bug reports. If it's something else, the person can opt for the default empty template instead.

If we feel it's necessary, we can add a feature request template as well similar to our sister projects.