### PR TITLE
Closes #108: Add tracking protection settings and enable by default

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/settings/PrivacySettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/PrivacySettingsFragment.kt
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.settings
+
+import android.os.Bundle
+import androidx.preference.Preference.OnPreferenceChangeListener
+import androidx.preference.PreferenceFragmentCompat
+import mozilla.components.service.glean.Glean
+import org.mozilla.reference.browser.R
+import org.mozilla.reference.browser.ext.getPreferenceKey
+import org.mozilla.reference.browser.ext.requireComponents
+
+class PrivacySettingsFragment : PreferenceFragmentCompat() {
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.privacy_preferences, rootKey)
+
+        val telemetryKey = context?.getPreferenceKey(R.string.pref_key_telemetry)
+        val trackingProtectionNormalKey = context?.getPreferenceKey(R.string.pref_key_tracking_protection_normal)
+        val trackingProtectionPrivateKey = context?.getPreferenceKey(R.string.pref_key_tracking_protection_private)
+
+        val prefTelemetry = findPreference(telemetryKey)
+        val prefTrackingProtectionNormal = findPreference(trackingProtectionNormalKey)
+        val prefTrackingProtectionPrivate = findPreference(trackingProtectionPrivateKey)
+
+        prefTelemetry.onPreferenceChangeListener = getChangeListenerForTelemetry()
+        prefTrackingProtectionNormal.onPreferenceChangeListener = getChangeListenerForTrackingProtection { enabled ->
+            with(requireComponents.core) {
+                engine.settings.trackingProtectionPolicy = createTrackingProtectionPolicy(normalMode = enabled)
+            }
+        }
+        prefTrackingProtectionPrivate.onPreferenceChangeListener = getChangeListenerForTrackingProtection { enabled ->
+            with(requireComponents.core) {
+                engine.settings.trackingProtectionPolicy = createTrackingProtectionPolicy(privateMode = enabled)
+            }
+        }
+    }
+
+    private fun getChangeListenerForTelemetry(): OnPreferenceChangeListener {
+        return OnPreferenceChangeListener { _, value ->
+            val enabled = value as Boolean
+            Glean.setMetricsEnabled(enabled)
+            true
+        }
+    }
+
+    private fun getChangeListenerForTrackingProtection(callback: (Boolean) -> Unit): OnPreferenceChangeListener {
+        return OnPreferenceChangeListener { _, value ->
+            callback(value as Boolean)
+            true
+        }
+    }
+}

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -13,4 +13,7 @@
     <string name="pref_key_remote_debugging" translatable="false">pref_key_remote_debugging</string>
     <string name="pref_key_testing_mode" translatable="false">pref_key_testing_mode</string>
     <string name="pref_key_about_page" translatable="false">pref_key_about_page</string>
+    <string name="pref_key_privacy" translatable="false">pref_key_privacy</string>
+    <string name="pref_key_tracking_protection_normal" translatable="false">pref_key_tracking_protection_normal</string>
+    <string name="pref_key_tracking_protection_private" translatable="false">pref_key_tracking_protection_private</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,12 @@
     <!-- Preference enabling remote debugging -->
     <string name="preferences_remote_debugging">Remote debugging via USB</string>
 
+    <!-- Preference for enabling tracking protection in normal mode -->
+    <string name="preferences_tracking_protection_normal">Enable in Normal Browsing Mode</string>
+
+    <!-- Preference for enabling tracking protection in private mode -->
+    <string name="preferences_tracking_protection_private">Enable in Private Browsing Mode</string>
+
     <!-- Preference about page -->
     <string name="preferences_about_page">About Reference Browser</string>
 
@@ -51,6 +57,12 @@
     <!-- Preference summary showing never synced -->
     <string name="preferences_sync_never_synced_summary">Last synced: never</string>
 
+    <!-- Preference for privacy -->
+    <string name="privacy">Privacy</string>
+
+    <!-- Preference summary for privacy -->
+    <string name="preferences_privacy_summary">Tracking, cookies, data choices</string>
+
     <!-- Preference category for sync settings -->
     <string name="sync_category">Choose what to sync</string>
 
@@ -63,11 +75,20 @@
     <!-- Preference category for Mozilla about/legal etc. -->
     <string name="mozilla_category">Mozilla</string>
 
+    <!-- Preference category for tracking protection -->
+    <string name="tracker_category">Tracking Protection</string>
+
+    <!-- Preference category for data choices e.g. usage data -->
+    <string name="data_choices_category">Data Choices</string>
+
     <!-- Menu option on the toolbar that takes you to settings page-->
     <string name="settings">Settings</string>
 
     <!-- Menu option on the toolbar that takes you to account settings page-->
     <string name="account_settings">Account Settings</string>
+
+    <!-- Menu option on the toolbar that takes you to privacy settings page-->
+    <string name="privacy_settings">Privacy Settings</string>
 
     <!-- Snackbar message when a non fatal crash happen-->
     <string name="crash_report_non_fatal_message">Sorry. We crashed</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -14,11 +14,10 @@
         android:key="@string/pref_key_firefox_account"
         android:title="@string/firefox_account" />
 
-    <androidx.preference.SwitchPreferenceCompat
-            android:defaultValue="true"
-            android:title="@string/use_telemetry"
-            android:key="@string/pref_key_telemetry"
-            android:summary="@string/preferences_use_telemetry_summary"/>
+    <androidx.preference.Preference
+        android:key="@string/pref_key_privacy"
+        android:title="@string/privacy"
+        android:summary="@string/preferences_privacy_summary"/>
 
     <androidx.preference.Preference
             android:key="@string/pref_key_make_default_browser"

--- a/app/src/main/res/xml/privacy_preferences.xml
+++ b/app/src/main/res/xml/privacy_preferences.xml
@@ -1,0 +1,36 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<androidx.preference.PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory
+        android:title="@string/tracker_category">
+
+        <androidx.preference.SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:title="@string/preferences_tracking_protection_normal"
+            android:key="@string/pref_key_tracking_protection_normal"/>
+
+        <androidx.preference.SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:title="@string/preferences_tracking_protection_private"
+            android:key="@string/pref_key_tracking_protection_private"/>
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/data_choices_category">
+
+        <androidx.preference.SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:title="@string/use_telemetry"
+            android:key="@string/pref_key_telemetry"
+            android:summary="@string/preferences_use_telemetry_summary"/>
+
+    </PreferenceCategory>
+
+
+</androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Small PR to bring in a new Privacy setting screen which contains the tracking protection settings similar to the iOS version (see #108). Decided for this version as it's the latest design by UX and it's easy to use :).

I've also moved the telemetry setting to Privacy.

Tracking protection is on by default for all sessions with this. 