### PR TITLE
Optional: Picture-in-picture video support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
         tools:ignore="UnusedAttribute">
         <activity android:name=".BrowserActivity"
             android:launchMode="singleTask"
+            android:resizeableActivity="true"
+            android:supportsPictureInPicture="true"
             android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
@@ -62,6 +62,16 @@ open class BrowserActivity : AppCompatActivity(), ComponentCallbacks2 {
         super.onBackPressed()
     }
 
+    override fun onUserLeaveHint() {
+        supportFragmentManager.fragments.forEach {
+            if (it is UserInteractionHandler && it.onHomePressed()) {
+                return
+            }
+        }
+
+        super.onUserLeaveHint()
+    }
+
     override fun onCreateView(parent: View?, name: String?, context: Context, attrs: AttributeSet?): View? =
         when (name) {
             EngineView::class.java.name -> components.core.engine.createView(context, attrs).asView()

--- a/app/src/main/java/org/mozilla/reference/browser/UserInteractionHandler.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/UserInteractionHandler.kt
@@ -1,0 +1,22 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.mozilla.reference.browser
+
+import android.app.Activity
+
+/**
+ * Interface for fragments that want to handle user interactions.
+ */
+interface UserInteractionHandler {
+    /**
+     * In most cases, when the home button is pressed, we invoke this callback to inform the app that the user
+     * is going to leave the app.
+     *
+     * See also [Activity.onUserLeaveHint] for more details.
+     */
+    fun onHomePressed(): Boolean
+}

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
@@ -25,18 +25,21 @@ import mozilla.components.support.ktx.android.content.isPermissionGranted
 import mozilla.components.support.ktx.android.view.enterToImmersiveMode
 import mozilla.components.support.ktx.android.view.exitImmersiveModeIfNeeded
 import org.mozilla.reference.browser.BackHandler
+import org.mozilla.reference.browser.UserInteractionHandler
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.requireComponents
+import org.mozilla.reference.browser.pip.PictureInPictureFeature
 import org.mozilla.reference.browser.tabs.TabsTrayFragment
 
 @Suppress("TooManyFunctions")
-class BrowserFragment : Fragment(), BackHandler {
+class BrowserFragment : Fragment(), BackHandler, UserInteractionHandler {
     private lateinit var sessionFeature: SessionFeature
     private lateinit var tabsToolbarFeature: TabsToolbarFeature
     private lateinit var downloadsFeature: DownloadsFeature
     private lateinit var awesomeBarFeature: AwesomeBarFeature
     private lateinit var promptsFeature: PromptFeature
     private lateinit var fullScreenFeature: FullScreenFeature
+    private lateinit var pipFeature: PictureInPictureFeature
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_browser, container, false)
@@ -110,6 +113,8 @@ class BrowserFragment : Fragment(), BackHandler {
             sessionId, ::fullScreenChanged
         )
 
+        pipFeature = PictureInPictureFeature(requireComponents.core.sessionManager, requireActivity(), this)
+
         lifecycle.addObservers(
             sessionFeature,
             downloadsFeature,
@@ -151,6 +156,17 @@ class BrowserFragment : Fragment(), BackHandler {
         }
 
         return false
+    }
+
+    override fun onHomePressed(): Boolean {
+        if (pipFeature.onHomePressed()) {
+            return true
+        }
+        return false
+    }
+
+    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean) {
+        pipFeature.onPictureInPictureModeChanged(isInPictureInPictureMode)
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {

--- a/app/src/main/java/org/mozilla/reference/browser/pip/PictureInPictureFeature.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/pip/PictureInPictureFeature.kt
@@ -1,0 +1,54 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.mozilla.reference.browser.pip
+
+import android.annotation.TargetApi
+import android.app.Activity
+import android.app.PictureInPictureParams
+import android.os.Build
+import androidx.fragment.app.Fragment
+import mozilla.components.browser.session.SessionManager
+import org.mozilla.reference.browser.BackHandler
+
+/**
+ * A simple implementation of Picture-in-picture mode support.
+ *
+ * @param sessionManager Session Manager for observing the selected session's fullscreen mode changes.
+ * @param activity the activity with the EngineView for calling PIP mode when required; the AndroidX Fragment
+ * doesn't support this.
+ * @param fragment the current fragment for back button handling.
+ */
+class PictureInPictureFeature(
+    private val sessionManager: SessionManager,
+    private val activity: Activity,
+    private val fragment: Fragment
+) {
+
+    fun onHomePressed(): Boolean {
+        val fullScreenMode = sessionManager.selectedSession?.fullScreenMode ?: false
+        return fullScreenMode && enterPipModeCompat()
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    fun enterPipModeCompat() = when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O ->
+            activity.enterPictureInPictureMode(PictureInPictureParams.Builder().build())
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.N -> {
+            activity.enterPictureInPictureMode()
+            true
+        }
+        else -> false
+    }
+
+    fun onPictureInPictureModeChanged(enabled: Boolean) {
+        val fullScreenMode = sessionManager.selectedSession?.fullScreenMode ?: false
+        // If we're exiting PIP mode and we're in fullscreen mode, then we should exit fullscreen mode as well.
+        if (!enabled && fullScreenMode && fragment is BackHandler) {
+            fragment.onBackPressed()
+        }
+    }
+}


### PR DESCRIPTION
This isn't a needed feature it's a nice-to-have, and also a fair example on how to easily add features to a browser.

Notable points:
- This works great for almost all videos, but Youtube autoplay looks a bit awkward since it loads a new video and loses the fullscreen mode (we can't programmatically choose to leave PIP mode, only the user can).
- When we exit out of PIP mode, we invoke the back press, so that the full page is visible when returning.

GIF (click for HQ video):
<a href="https://thumbs.gfycat.com/EnergeticLavishKangaroo-mobile.mp4">![](https://giant.gfycat.com/EnergeticLavishKangaroo.gif)</a>