### PR TITLE
Add User Story template [ci skip]

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -1,0 +1,13 @@
+---
+name: "\U0001F31F User Story"
+about: Create a user story to satisfy a feature request.
+title: ''
+labels: "\U0001F31F feature"
+assignees: ''
+
+---
+
+<!--
+TITLE FORMAT: As a ‹role›, I want to ‹feature short description› [ , so that ‹value it adds›. ]
+e.g. As a user, I want to be able to turn remote debugging on/off
+-->


### PR DESCRIPTION
What do we think of this for the user story template for new users?

We don't have a 'user story' label so I've repurposed the 'feature' one rather than create another label that might get lost.