### PR TITLE
Revert "Always refresh dynamic dependencies (snapshots)"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -147,10 +147,6 @@ configurations {
     geckoNightlyArmImplementation {}
     geckoNightlyX86Implementation {}
     geckoNightlyAarch64Implementation {}
-
-    all {
-        resolutionStrategy.cacheDynamicVersionsFor 0, 'seconds'
-    }
 }
 
 dependencies {


### PR DESCRIPTION
This reverts commit 8c82700010e042ddcab4b769f8aeecd54dfd3936.

The root cause for this was fixed by cloud services, i.e. the CDNs serving our snapshots were getting old versions in some regions.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
