### PR TITLE
Improve sync scheduling and document current decisions

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/services/SyncManager.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/services/SyncManager.kt
@@ -17,6 +17,7 @@ import androidx.work.PeriodicWorkRequest
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import androidx.work.Worker
 import androidx.work.WorkerParameters
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 import mozilla.components.browser.storage.sync.SyncAuthInfo
@@ -50,6 +51,10 @@ private enum class SyncWorkerName {
 private const val SYNC_STATE_PREFS_KEY = "syncPrefs"
 private const val SYNC_LAST_SYNCED_KEY = "lastSynced"
 
+private const val SYNC_STAGGER_BUFFER_MS = 10 * 60 * 1000L // 10 minutes.
+private const val SYNC_STARTUP_DELAY_MS = 5 * 1000L // 5 seconds.
+private const val SYNC_PERIODIC_START_DELAY_MS = SYNC_STAGGER_BUFFER_MS
+
 fun getLastSynced(context: Context): Long {
     return context
         .getSharedPreferences(SYNC_STATE_PREFS_KEY, Context.MODE_PRIVATE)
@@ -74,8 +79,26 @@ class SyncManager(
     val storage: PlacesHistoryStorage
 ) : Observable<SyncStatusObserver> by ObserverRegistry() {
     companion object {
-        const val SYNC_PERIOD = 15L
-        val SYNC_PERIOD_UNIT = TimeUnit.MINUTES
+        // Periodically sync in the background, to make our syncs a little more incremental.
+        // This isn't strictly necessary, and could be considered an optimization.
+        //
+        // Assuming that we synchronize during app startup, our trade-offs are:
+        // - not syncing in the background at all might mean longer syncs, more arduous startup syncs
+        // - on a slow mobile network, these delays could be significant
+        // - a delay during startup sync may affect user experience, since our data will be stale
+        // for longer
+        // - however, background syncing eats up some of the device resources
+        // - ... so we only do so a few times per day
+        // - we also rely on the OS and the WorkManager APIs to minimize those costs. It promises to
+        // bundle together tasks from different applications that have similar resource-consumption
+        // profiles. Specifically, we need device radio to be ON to talk to our servers; OS will run
+        // our periodic syncs bundled with another tasks that also need radio to be ON, thus "spreading"
+        // the overall cost.
+        //
+        // If we wanted to be very fancy, this period could be driven by how much new activity an
+        // account is actually expected to generate. For now, it's just a hard-coded constant.
+        const val SYNC_PERIOD = 4L
+        val SYNC_PERIOD_UNIT = TimeUnit.HOURS
     }
 
     private val syncImpl = FirefoxSyncFeature(mapOf("history" to storage)) {
@@ -85,8 +108,16 @@ class SyncManager(
 
     init {
         // If we're authenticated, let's start syncing periodically.
+        // Delay start of periodic syncing a little bit, so that it doesn't begin at the same time
+        // as our startup syncing.
         if (accountManager.authenticatedAccount() != null) {
-            startPeriodicSync()
+            syncNow(startup = true)
+
+            WorkManager.getInstance().beginWith(
+                OneTimeWorkRequestBuilder<PeriodicSyncKickoffWorker>()
+                .setInitialDelay(SYNC_PERIODIC_START_DELAY_MS, TimeUnit.MILLISECONDS)
+                .build()
+            ).enqueue()
         }
 
         // Monitor account state for authentication changes.
@@ -109,23 +140,40 @@ class SyncManager(
         })
     }
 
-    fun syncRunning(): Boolean {
+    fun isSyncRunning(): Boolean {
         syncWorkInfoList.value?.let { workers ->
             return workers.any { it.state == WorkInfo.State.RUNNING }
         }
         return false
     }
 
-    fun syncNow() {
-        // Use the 'keep' policy to minimize overhead from multiple "sync now" operations coming in
-        // at the same time.
+    /**
+     * Kick-off an immediate sync.
+     *
+     * @param startup Boolean flag indicating if we're in a startup situation.
+     */
+    fun syncNow(startup: Boolean = false) {
+        val delayMs = if (startup) {
+            // Startup delay is there to avoid SQLITE_BUSY crashes, since we currently do a poor job
+            // of managing database connections, and we expect there to be database writes at the start.
+            // FIXME https://github.com/mozilla-mobile/android-components/issues/1369
+            SYNC_STARTUP_DELAY_MS
+        } else {
+            0L
+        }
         WorkManager.getInstance().beginUniqueWork(
                 SyncWorkerName.Immediate.name,
+                // Use the 'keep' policy to minimize overhead from multiple "sync now" operations coming in
+                // at the same time.
                 ExistingWorkPolicy.KEEP,
-                immediateSyncWorkRequest()
+                immediateSyncWorkRequest(delayMs)
         ).enqueue()
     }
 
+    /**
+     * Periodic background syncing is mainly intended to reduce workload when we sync during
+     * application startup.
+     */
     private fun startPeriodicSync() {
         // Use the 'replace' policy as a simple way to upgrade periodic worker configurations across
         // application versions. We do this instead of versioning workers.
@@ -149,7 +197,7 @@ class SyncManager(
                 .build()
     }
 
-    private fun immediateSyncWorkRequest(): OneTimeWorkRequest {
+    private fun immediateSyncWorkRequest(delayMs: Long = 0L): OneTimeWorkRequest {
         return OneTimeWorkRequestBuilder<SyncWorker>()
                 .setConstraints(
                         Constraints.Builder()
@@ -158,6 +206,7 @@ class SyncManager(
                 )
                 .addTag(SyncWorkerTag.Common.name)
                 .addTag(SyncWorkerTag.Immediate.name)
+                .setInitialDelay(delayMs, TimeUnit.MILLISECONDS)
                 .build()
     }
 
@@ -165,17 +214,41 @@ class SyncManager(
         return syncImpl.sync(account)
     }
 
-    class SyncWorker(
+    // We can't set an initial delay on periodic tasks. Since we want to delay the start of periodic
+    // syncing, we wrap that kick-off process in a one-off, delayed task.
+    private class PeriodicSyncKickoffWorker(
+        private val context: Context,
+        params: WorkerParameters
+    ) : Worker(context, params) {
+        override fun doWork(): Result {
+            context.components.backgroundServices.syncManager.startPeriodicSync()
+            return Result.success()
+        }
+    }
+
+    private class SyncWorker(
         private val context: Context,
         private val params: WorkerParameters
     ) : CoroutineWorker(context, params) {
         private val logTag = "SyncWorker"
 
-        @Suppress("ReturnCount")
+        @Suppress("ReturnCount", "ComplexMethod")
         override suspend fun doWork(): Result {
             val syncManager = context.components.backgroundServices.syncManager
 
             Log.d(logTag, "Starting sync... Tagged as: ${params.tags}")
+
+            // If this is a periodic sync task, and we've very recently synced successfully, skip it.
+            // There could have been a manual or heuristic-driven syc very recently, and it's unlikely
+            // that an additional sync so shortly afterward will be valuable.
+            // NB: this does not affect manually triggered syncing in any way.
+            val lastSyncedTs = getLastSynced(context)
+            if (params.tags.contains(SyncWorkerTag.Periodic.name) &&
+                lastSyncedTs != 0L &&
+                (System.currentTimeMillis() - lastSyncedTs) < SYNC_STAGGER_BUFFER_MS
+            ) {
+                return Result.success()
+            }
 
             // We need an account to sync. Make sure that it's present.
             val account = context.components.backgroundServices.syncManager.accountManager.authenticatedAccount()
@@ -188,7 +261,7 @@ class SyncManager(
             // a request for an immediate sync while periodic sync was already running.
             // Overlaps like are possible in theory, but should be quite rare in practice.
             // NB: feature-sync maintains its own mutex lock on actual sync operations.
-            if (syncManager.syncRunning()) {
+            if (syncManager.isSyncRunning()) {
                 Log.w(logTag, "Sync is already running. Requesting retry.")
                 return Result.retry()
             }

--- a/app/src/main/java/org/mozilla/reference/browser/settings/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/AccountSettingsFragment.kt
@@ -70,7 +70,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
 
         preferenceSyncNow.onPreferenceClickListener = getClickListenerForSyncNow()
 
-        if (requireComponents.backgroundServices.syncManager.syncRunning()) {
+        if (requireComponents.backgroundServices.syncManager.isSyncRunning()) {
             preferenceSyncNow.title = getString(R.string.syncing)
             preferenceSyncNow.isEnabled = false
         } else {


### PR DESCRIPTION
This patch works around the fact that we're currently poorly
managing database connections, and may have SQLITE_BUSY crashes
if we interleave writes. Delays are introduced to ensure we won't
sync _right_ at the start of the application, but instead wait a
few seconds. This should give initial 'noteObservation' calls enough
time to process.

Other changes are around not doing sync work when we don't have to.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [x] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
