### PR TITLE
Removes mis-typed "taskclusterProxy" feature

### DIFF
--- a/automation/taskcluster/decision_task_nightly.py
+++ b/automation/taskcluster/decision_task_nightly.py
@@ -46,7 +46,7 @@ def generate_build_task(apks):
                  ' && ./gradlew --no-daemon -PcrashReportEnabled=true -Ptelemetry=true clean test assembleRelease'),
         features={
             "chainOfTrust": True,
-            "taskClusterProxy": True
+            "taskclusterProxy": True
         },
         artifacts=artifacts,
         scopes=[

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -19,11 +19,6 @@ class TaskBuilder(object):
         expires = taskcluster.fromNow('1 year')
         deadline = taskcluster.fromNow('1 day')
 
-        features = features.copy()
-        features.update({
-            "taskclusterProxy": True
-        })
-
         return {
             "workerType": 'gecko-focus',
             "taskGroupId": self.task_id,


### PR DESCRIPTION
### Pull Request checklist
Regular checklist doesn't apply, but I've triggered a "staging nightly build". The pushapk task is expected to fail (staging builds will be improved in next `pushapkscript` update)

### Before merging checklist
- [ ] **Changelog**: This PR ~includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or~ does not need one.
