### PR TITLE
Add developer setting for detecting leaks (via LeakCanary).

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -187,8 +187,11 @@ dependencies {
 
     implementation Deps.mozilla_support_utils
     implementation Deps.mozilla_support_ktx
+
     implementation Deps.mozilla_lib_crash
+
     implementation Deps.thirdparty_sentry
+    implementation Deps.thirdparty_leakcanary
 
     geckoNightlyImplementation Deps.mozilla_browser_engine_gecko_nightly
     geckoNightlyArmImplementation Gecko.geckoview_nightly_arm

--- a/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
@@ -6,6 +6,7 @@ package org.mozilla.reference.browser
 
 import android.app.Application
 import android.content.Context
+import com.squareup.leakcanary.LeakCanary
 import mozilla.components.service.glean.Glean
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.logger.Logger
@@ -23,6 +24,7 @@ open class BrowserApplication : Application() {
         setupCrashReporting(this)
         setupGlean(this)
         setupMegazord()
+        setupLeakDetection(this)
     }
 
     companion object {
@@ -75,4 +77,16 @@ private fun setupMegazord() {
     } catch (e: ClassNotFoundException) {
         Logger.info("mozilla.appservices.ReferenceBrowserMegazord not found; skipping megazord init.")
     }
+}
+
+private fun setupLeakDetection(application: BrowserApplication) {
+    if (!Settings.isLeakDetectionEnabled(application)) {
+        return
+    }
+
+    if (LeakCanary.isInAnalyzerProcess(application)) {
+        return
+    }
+
+    LeakCanary.install(application)
 }

--- a/app/src/main/java/org/mozilla/reference/browser/settings/Settings.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/Settings.kt
@@ -12,4 +12,8 @@ object Settings {
     fun isTelemetryEnabled(context: Context): Boolean =
         PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
             context.getString(R.string.pref_key_telemetry), true)
+
+    fun isLeakDetectionEnabled(context: Context): Boolean =
+        PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
+            context.getString(R.string.pref_key_telemetry), false)
 }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -8,6 +8,7 @@
     <string name="pref_key_sync_now" translatable="false">pref_key_sync_now</string>
     <string name="pref_key_firefox_account" translatable="false">pref_key_firefox_account</string>
     <string name="pref_key_telemetry" translatable="false">pref_key_telemetry</string>
+    <string name="pref_key_leak_detection" translatable="false">pref_key_leak_detection</string>
     <string name="pref_key_make_default_browser" translatable="false">pref_key_make_default_browser</string>
     <string name="pref_key_sync_history" translatable="false">pref_key_sync_history</string>
     <string name="pref_key_remote_debugging" translatable="false">pref_key_remote_debugging</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,9 @@
     <!-- Preference enabling remote debugging -->
     <string name="preferences_remote_debugging">Remote debugging via USB</string>
 
+    <!-- Preference enabling leak detection via leak canary -->
+    <string name="preferences_leak_detection">Detect memory leaks</string>
+
     <!-- Preference for enabling tracking protection in normal mode -->
     <string name="preferences_tracking_protection_normal">Enable in Normal Browsing Mode</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -31,6 +31,11 @@
             android:defaultValue="false"
             android:title="@string/preferences_remote_debugging" />
 
+        <androidx.preference.SwitchPreferenceCompat
+            android:key="@string/pref_key_leak_detection"
+            android:defaultValue="false"
+            android:title="@string/preferences_leak_detection" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -20,6 +20,7 @@ private object Versions {
     const val mozilla_android_components = "0.41.0-SNAPSHOT"
 
     const val thirdparty_sentry = "1.7.10"
+    const val thirdparty_leakcanary = "1.6.3"
 
     const val tools_espresso_core = "2.2.2"
     const val tools_espresso_version = "3.0.2"
@@ -79,6 +80,7 @@ object Deps {
     const val mozilla_lib_crash = "org.mozilla.components:lib-crash:${Versions.mozilla_android_components}"
 
     const val thirdparty_sentry = "io.sentry:sentry-android:${Versions.thirdparty_sentry}"
+    const val thirdparty_leakcanary = "com.squareup.leakcanary:leakcanary-android:${Versions.thirdparty_leakcanary}"
 
     const val androidx_appcompat = "androidx.appcompat:appcompat:${Versions.androidx_appcompat}"
     const val androidx_constraintlayout = "androidx.constraintlayout:constraintlayout:${Versions.androidx_constraintlayout}"


### PR DESCRIPTION
Disabled by default. This will help us to find leaks. Specifically I'm interested in situations where we may hold on to a (non-application) Context for too long or keep other objects like `Session` around even though they should have been removed. This is the basic setup that just tracks Activity context leakage.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
