### PR TITLE
Add support for redirecting rust logs to the a-c logger

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -187,6 +187,7 @@ dependencies {
 
     implementation Deps.mozilla_support_utils
     implementation Deps.mozilla_support_ktx
+    implementation Deps.mozilla_support_rustlog
     implementation Deps.mozilla_lib_crash
     implementation Deps.thirdparty_sentry
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -15,7 +15,7 @@ private object Versions {
     const val google_material = "1.0.0"
 
     const val android_gradle_plugin = "3.2.1"
-    const val appservices_gradle_plugin = "0.2.0"
+    const val appservices_gradle_plugin = "0.3.1"
 
     const val mozilla_android_components = "0.42.0-SNAPSHOT"
 
@@ -75,6 +75,7 @@ object Deps {
 
     const val mozilla_support_utils = "org.mozilla.components:support-utils:${Versions.mozilla_android_components}"
     const val mozilla_support_ktx= "org.mozilla.components:support-ktx:${Versions.mozilla_android_components}"
+    const val mozilla_support_rustlog = "org.mozilla.components:support-rustlog:${Versions.mozilla_android_components}"
 
     const val mozilla_lib_crash = "org.mozilla.components:lib-crash:${Versions.mozilla_android_components}"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,6 +24,7 @@ if (localProperties != null) {
                 substitute module('org.mozilla.fxaclient:fxaclient') with project(':fxa-client-library')
                 substitute module('org.mozilla.sync15:logins') with project(':logins-library')
                 substitute module('org.mozilla.places:places') with project(':places-library')
+                substitute module('org.mozilla.appservices:rustlog') with project(':rustlog-library')
             }
         }
 


### PR DESCRIPTION
This is just https://github.com/mozilla-mobile/reference-browser/pull/459 with some minor feedback addressed. Thom asked me to take over landing it.