### PR TITLE
Fix misleading taskcluster-github error message

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -15,12 +15,18 @@ tasks:
     head_branch:
       $if: 'tasks_for == "github-pull-request"'
       then: ${event.pull_request.head.ref}
-      else: ${event.release.target_commitish}
+      else:
+        $if: 'tasks_for == "github-push"'
+        then: ${event.ref}
+        else: ${event.release.target_commitish}
 
     head_rev:
       $if: 'tasks_for == "github-pull-request"'
       then: ${event.pull_request.head.sha}
-      else: ${event.release.tag_name}
+      else:
+        $if: 'tasks_for == "github-push"'
+        then: ${event.after}
+        else: ${event.release.tag_name}
 
     repository:
       $if: 'tasks_for == "github-pull-request"'

--- a/automation/taskcluster/decision_task_nightly.py
+++ b/automation/taskcluster/decision_task_nightly.py
@@ -25,7 +25,7 @@ BUILDER = lib.tasks.TaskBuilder(
     owner="android-components-team@mozilla.com",
     source='{}/raw/{}/.taskcluster.yml'.format(GITHUB_HTTP_REPOSITORY, HEAD_REV),
     scheduler_id=SCHEDULER_ID,
-    build_worker_type=BUILD_WORKER_TYPE,
+    build_worker_type=os.environ.get('BUILD_WORKER_TYPE'),
 )
 
 


### PR DESCRIPTION
Fixes https://github.com/mozilla-mobile/reference-browser/commit/683457b1cd7e630ba4713c94496b4e04f7c73cbb\#commitcomment-32315515. Follows https://github.com/mozilla-mobile/reference-browser/pull/579 up 

I thought I could avoid defining the some datam because we don't handle push graphs, yet. However this caused the error above. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] ~~**Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)~~ Not applicable
- [ ] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~ Not applicable

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
