### PR TITLE
Adds releng to codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,4 +17,6 @@
 
 # By default the Android Components team will be the owner for everything in
 # the repo. Unless a later match takes precedence.
-*    @mozilla-mobile/act
+* @mozilla-mobile/act
+/automation @mozilla-mobile/releng
+/CODEOWNERS @mozilla-mobile/releng

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,5 +18,5 @@
 # By default the Android Components team will be the owner for everything in
 # the repo. Unless a later match takes precedence.
 * @mozilla-mobile/act
-/automation @mozilla-mobile/releng
-/CODEOWNERS @mozilla-mobile/releng
+/automation/ @mozilla-mobile/releng @mozilla-mobile/act
+/CODEOWNERS @mozilla-mobile/releng @mozilla-mobile/act


### PR DESCRIPTION
Set up according to [this RFC](https://github.com/mozilla-releng/releng-rfcs/blob/master/rfcs/0002-repo-automation-code-owners.md).

Minor note: do we want to align the owners in a column? I'd prefer to just do `<filter> <owner>`, because otherwise we need to move everything over each time we add a new long line.