### PR TITLE
[WIP] Moves gecko nightly version to .buildconfig yaml

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,0 +1,1 @@
+geckoNightlyVersion: 67.0.20190214044118

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'org.yaml:snakeyaml:1.23'
+    }
+}
+
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
 }
@@ -12,6 +22,7 @@ apply plugin: 'kotlin-android-extensions'
 apply from: "$project.rootDir/automation/gradle/versionCode.gradle"
 
 apply plugin: 'org.mozilla.appservices'
+import org.yaml.snakeyaml.Yaml
 
 appservices {
     defaultConfig {
@@ -149,6 +160,9 @@ configurations {
     geckoNightlyAarch64Implementation {}
 }
 
+def buildconfig = new Yaml().load(new File(rootDir, '.buildconfig.yml').newInputStream())
+def gecko = new Gecko(buildconfig.geckoNightlyVersion)
+
 dependencies {
     implementation Deps.mozilla_concept_engine
     implementation Deps.mozilla_concept_tabstray
@@ -193,9 +207,9 @@ dependencies {
     implementation Deps.thirdparty_sentry
 
     geckoNightlyImplementation Deps.mozilla_browser_engine_gecko_nightly
-    geckoNightlyArmImplementation Gecko.geckoview_nightly_arm
-    geckoNightlyX86Implementation Gecko.geckoview_nightly_x86
-    geckoNightlyAarch64Implementation Gecko.geckoview_nightly_aarch64
+    geckoNightlyArmImplementation gecko.geckoview_nightly_arm
+    geckoNightlyX86Implementation gecko.geckoview_nightly_x86
+    geckoNightlyAarch64Implementation gecko.geckoview_nightly_aarch64
 
     implementation Deps.kotlin_stdlib
     implementation Deps.kotlin_coroutines

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -2,12 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-private object GeckoVersions {
-    const val nightly_version = "67.0.20190214044118"
-}
-
-object Gecko {
-    const val geckoview_nightly_arm = "org.mozilla.geckoview:geckoview-nightly-armeabi-v7a:${GeckoVersions.nightly_version}"
-    const val geckoview_nightly_x86 = "org.mozilla.geckoview:geckoview-nightly-x86:${GeckoVersions.nightly_version}"
-    const val geckoview_nightly_aarch64 = "org.mozilla.geckoview:geckoview-nightly-arm64-v8a:${GeckoVersions.nightly_version}"
+class Gecko(geckoNightlyVersion: String) {
+    val geckoview_nightly_arm = "org.mozilla.geckoview:geckoview-nightly-armeabi-v7a:$geckoNightlyVersion"
+    val geckoview_nightly_x86 = "org.mozilla.geckoview:geckoview-nightly-x86:$geckoNightlyVersion"
+    val geckoview_nightly_aarch64 = "org.mozilla.geckoview:geckoview-nightly-arm64-v8a:$geckoNightlyVersion"
 }


### PR DESCRIPTION
We're going to need access to the `geckoNightlyVersion` from CI for enabling Raptor performance tests, and it would add significant complexity to need to invoke gradle.
This change pulls these values into a top level `.buildconfig.yml`, just like for [`android-components`](https://github.com/mozilla-mobile/android-components/blob/master/.buildconfig.yml)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [x] **Changelog**: This PR does not need a changelog entry
