### PR TITLE
Close mozilla-mobile#162: Add FxA pairing integration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -185,6 +185,7 @@ dependencies {
     implementation Deps.mozilla_feature_tabs
     implementation Deps.mozilla_feature_downloads
     implementation Deps.mozilla_feature_prompts
+    implementation Deps.mozilla_feature_qr
 
     implementation Deps.mozilla_ui_autocomplete
     implementation Deps.mozilla_ui_colors

--- a/app/src/main/java/org/mozilla/reference/browser/AppPermissionCodes.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/AppPermissionCodes.kt
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser
+
+object AppPermissionCodes {
+    const val REQUEST_CODE_DOWNLOAD_PERMISSIONS = 1
+    const val REQUEST_CODE_PROMPT_PERMISSIONS = 2
+    const val REQUEST_CODE_APP_PERMISSIONS = 3
+    const val REQUEST_CODE_CAMERA_PERMISSIONS = 4
+}

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
@@ -24,6 +24,9 @@ import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.android.view.enterToImmersiveMode
 import mozilla.components.support.ktx.android.view.exitImmersiveModeIfNeeded
+import org.mozilla.reference.browser.AppPermissionCodes.REQUEST_CODE_APP_PERMISSIONS
+import org.mozilla.reference.browser.AppPermissionCodes.REQUEST_CODE_DOWNLOAD_PERMISSIONS
+import org.mozilla.reference.browser.AppPermissionCodes.REQUEST_CODE_PROMPT_PERMISSIONS
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.UserInteractionHandler
 import org.mozilla.reference.browser.ext.requireComponents
@@ -253,9 +256,6 @@ class BrowserFragment : Fragment(), BackHandler, UserInteractionHandler {
 
     companion object {
         private const val SESSION_ID = "session_id"
-        private const val REQUEST_CODE_DOWNLOAD_PERMISSIONS = 1
-        private const val REQUEST_CODE_PROMPT_PERMISSIONS = 2
-        private const val REQUEST_CODE_APP_PERMISSIONS = 3
 
         fun create(sessionId: String? = null): BrowserFragment = BrowserFragment().apply {
             arguments = Bundle().apply {

--- a/app/src/main/java/org/mozilla/reference/browser/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/BackgroundServices.kt
@@ -25,7 +25,7 @@ class BackgroundServices(
     companion object {
         const val CLIENT_ID = "3c49430b43dfba77"
         const val REDIRECT_URL = "https://accounts.firefox.com/oauth/success/$CLIENT_ID"
-        const val SUCCESS_PATH = "connect_another_device?showSuccessMessage=true"
+        const val SUCCESS_PATH = "signin_confirmed"
     }
 
     // This is slightly messy - here we need to know the union of all "scopes"

--- a/app/src/main/java/org/mozilla/reference/browser/settings/PairSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/PairSettingsFragment.kt
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.settings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import mozilla.components.feature.qr.QrFeature
+import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import org.mozilla.reference.browser.AppPermissionCodes.REQUEST_CODE_CAMERA_PERMISSIONS
+import org.mozilla.reference.browser.R
+import org.mozilla.reference.browser.ext.requireComponents
+
+class PairSettingsFragment : Fragment(), BackHandler {
+    private val qrFeature = ViewBoundFeatureWrapper<QrFeature>()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_pairing, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        qrFeature.set(
+            feature = QrFeature(
+                requireContext(),
+                fragmentManager = fragmentManager!!,
+                onNeedToRequestPermissions = { permissions ->
+                    requestPermissions(permissions, REQUEST_CODE_CAMERA_PERMISSIONS)
+                },
+                onScanResult = { pairingUrl ->
+                    requireComponents.services.accountsAuthFeature.beginPairingAuthentication(pairingUrl)
+                    activity?.finish()
+                }
+            ),
+            owner = this,
+            view = view
+        )
+
+        qrFeature.withFeature {
+            it.scan(R.id.pair_layout)
+        }
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+        when (requestCode) {
+            REQUEST_CODE_CAMERA_PERMISSIONS -> qrFeature.withFeature {
+                it.onPermissionsResult(permissions, grantResults)
+            }
+        }
+    }
+
+    override fun onBackPressed(): Boolean {
+        qrFeature.onBackPressed()
+        fragmentManager?.popBackStack()
+        return true
+    }
+}

--- a/app/src/main/java/org/mozilla/reference/browser/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/SettingsActivity.kt
@@ -8,6 +8,7 @@ import android.R.id.content
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.MenuItem
+import mozilla.components.support.base.feature.BackHandler
 
 class SettingsActivity : AppCompatActivity(), SettingsFragment.ActionBarUpdater {
 
@@ -32,5 +33,15 @@ class SettingsActivity : AppCompatActivity(), SettingsFragment.ActionBarUpdater 
 
     override fun updateTitle(titleResId: Int) {
         setTitle(titleResId)
+    }
+
+    override fun onBackPressed() {
+        supportFragmentManager.fragments.forEach {
+            if (it is BackHandler && it.onBackPressed()) {
+                return
+            } else {
+                super.onBackPressed()
+            }
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/SettingsFragment.kt
@@ -17,12 +17,14 @@ import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.R.string.pref_key_firefox_account
 import org.mozilla.reference.browser.ext.getPreferenceKey
 import org.mozilla.reference.browser.R.string.pref_key_sign_in
+import org.mozilla.reference.browser.R.string.pref_key_pair_sign_in
 import org.mozilla.reference.browser.R.string.pref_key_make_default_browser
 import org.mozilla.reference.browser.R.string.pref_key_remote_debugging
 import org.mozilla.reference.browser.R.string.pref_key_about_page
 import org.mozilla.reference.browser.R.string.pref_key_privacy
 import org.mozilla.reference.browser.ext.requireComponents
 
+@Suppress("TooManyFunctions")
 class SettingsFragment : PreferenceFragmentCompat() {
 
     interface ActionBarUpdater {
@@ -50,6 +52,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
     @Suppress("LongMethod") // Yep, this should be refactored.
     private fun setupPreferences() {
         val signInKey = context?.getPreferenceKey(pref_key_sign_in)
+        val signInPairKey = context?.getPreferenceKey(pref_key_pair_sign_in)
         val firefoxAccountKey = context?.getPreferenceKey(pref_key_firefox_account)
         val makeDefaultBrowserKey = context?.getPreferenceKey(pref_key_make_default_browser)
         val remoteDebuggingKey = context?.getPreferenceKey(pref_key_remote_debugging)
@@ -57,6 +60,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val privacyKey = context?.getPreferenceKey(pref_key_privacy)
 
         val preferenceSignIn = findPreference(signInKey)
+        val preferencePairSignIn = findPreference(signInPairKey)
         val preferenceFirefoxAccount = findPreference(firefoxAccountKey)
         val preferenceMakeDefaultBrowser = findPreference(makeDefaultBrowserKey)
         val preferenceRemoteDebugging = findPreference(remoteDebuggingKey)
@@ -66,6 +70,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val accountManager = requireComponents.backgroundServices.accountManager
         if (accountManager.authenticatedAccount() != null) {
             preferenceSignIn.isVisible = false
+            preferencePairSignIn.isVisible = false
             preferenceFirefoxAccount.summary = accountManager.accountProfile()?.email.orEmpty()
             preferenceFirefoxAccount.onPreferenceClickListener = getClickListenerForFirefoxAccount()
         } else {
@@ -73,6 +78,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
             preferenceFirefoxAccount.isVisible = false
             preferenceFirefoxAccount.onPreferenceClickListener = null
             preferenceSignIn.onPreferenceClickListener = getClickListenerForSignIn()
+            preferencePairSignIn.isVisible = true
+            preferencePairSignIn.onPreferenceClickListener = getClickListenerForPairingSignIn()
         }
 
         preferenceMakeDefaultBrowser.onPreferenceClickListener = getClickListenerForMakeDefaultBrowser()
@@ -99,6 +106,19 @@ class SettingsFragment : PreferenceFragmentCompat() {
         return OnPreferenceClickListener {
             requireComponents.services.accountsAuthFeature.beginAuthentication()
             activity?.finish()
+            true
+        }
+    }
+
+    private fun getClickListenerForPairingSignIn(): OnPreferenceClickListener {
+        return OnPreferenceClickListener {
+            fragmentManager?.beginTransaction()
+                    ?.replace(android.R.id.content, PairSettingsFragment())
+                    ?.addToBackStack(null)
+                    ?.commit()
+            getActionBarUpdater().apply {
+                updateTitle(R.string.pair_preferences)
+            }
             true
         }
     }

--- a/app/src/main/res/layout/fragment_pairing.xml
+++ b/app/src/main/res/layout/fragment_pairing.xml
@@ -1,0 +1,21 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/pair_layout" />
+
+    <TextView
+        android:id="@+id/text_view_id"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:text="@string/pair_instructions"
+        android:textSize="20sp"
+        android:gravity="center"
+        android:textColor="@color/photonWhite" />
+</RelativeLayout>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -4,6 +4,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
     <string name="pref_key_sign_in" translatable="false">pref_key_sign_in</string>
+    <string name="pref_key_pair_sign_in" translatable="false">pref_key_pair_sign_in</string>
     <string name="pref_key_sign_out" translatable="false">pref_key_sign_out</string>
     <string name="pref_key_sync_now" translatable="false">pref_key_sync_now</string>
     <string name="pref_key_firefox_account" translatable="false">pref_key_firefox_account</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,9 @@
     <!-- Preference summary for settings related sign in -->
     <string name="preferences_sign_in_summary">Sync your history</string>
 
+    <!-- Preference summary for pairing sign in -->
+    <string name="preferences_pair_sign_in_summary">Pair with Firefox Desktop</string>
+
     <!-- Preference summary for settings related to send telemetry data -->
     <string name="preferences_use_telemetry_summary">Send usage data</string>
 
@@ -41,6 +44,9 @@
 
     <!-- Preference for signing in -->
     <string name="sign_in">Sign in</string>
+
+    <!-- Preference for signing in -->
+    <string name="pair_sign_in">Sign in with a QR code</string>
 
     <!-- Preference for settings related to the signed in Firefox Account -->
     <string name="firefox_account">Firefox Account</string>
@@ -98,6 +104,10 @@
 
     <!-- Menu option on the toolbar that takes you to privacy settings page-->
     <string name="privacy_settings">Privacy Settings</string>
+
+    <!-- Menu option on the toolbar that takes you to pairing QR code page-->
+    <string name="pair_preferences">Pairing</string>
+    <string name="pair_instructions">Open accounts.firefox.com/pair in Firefox Desktop for your pairing code</string>
 
     <!-- Snackbar message when a non fatal crash happen-->
     <string name="crash_report_non_fatal_message">Sorry. We crashed</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -11,6 +11,11 @@
             android:summary="@string/preferences_sign_in_summary"/>
 
     <androidx.preference.Preference
+        android:key="@string/pref_key_pair_sign_in"
+        android:title="@string/pair_sign_in"
+        android:summary="@string/preferences_pair_sign_in_summary"/>
+
+    <androidx.preference.Preference
         android:key="@string/pref_key_firefox_account"
         android:title="@string/firefox_account" />
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -69,6 +69,7 @@ object Deps {
     const val mozilla_feature_downloads = "org.mozilla.components:feature-downloads:${Versions.mozilla_android_components}"
     const val mozilla_feature_storage = "org.mozilla.components:feature-storage:${Versions.mozilla_android_components}"
     const val mozilla_feature_prompts = "org.mozilla.components:feature-prompts:${Versions.mozilla_android_components}"
+    const val mozilla_feature_qr = "org.mozilla.components:feature-qr:${Versions.mozilla_android_components}"
 
     const val mozilla_ui_autocomplete = "org.mozilla.components:ui-autocomplete:${Versions.mozilla_android_components}"
     const val mozilla_ui_colors = "org.mozilla.components:ui-colors:${Versions.mozilla_android_components}"


### PR DESCRIPTION
Fixes #162 

Connects to https://github.com/mozilla/application-services/issues/430 
Requires https://github.com/mozilla-mobile/android-components/pull/2191
Follows https://github.com/mozilla-mobile/reference-browser/pull/293
