### PR TITLE
Closes #667: Raptor performance tests can no longer be executed

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
@@ -65,7 +65,7 @@ private fun setupLogging(megazordEnabled: Boolean) {
 }
 
 private fun setupGlean(context: Context) {
-    Glean.initialize(context, Configuration(httpClient = context.components.core.client))
+    Glean.initialize(context, Configuration(httpClient = lazy { context.components.core.client }))
     Glean.setUploadEnabled(BuildConfig.TELEMETRY_ENABLED && Settings.isTelemetryEnabled(context))
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,13 @@ allprojects {
     repositories {
         google()
 
+        // Currently the main repository where appservices artifacts are published.
+        // This will eventually move to maven.mozilla.org
+        // See https://github.com/mozilla/application-services/issues/252
+        maven {
+            url "https://dl.bintray.com/mozilla-appservices/application-services"
+        }
+
         maven {
             url "https://snapshots.maven.mozilla.org/maven2"
         }


### PR DESCRIPTION
This requires https://github.com/mozilla-mobile/android-components/pull/2472 and https://github.com/mozilla-mobile/reference-browser/pull/669 to be merged first.  