### PR TITLE
Add GleanFactProcessor to instrument toolbar component event

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+
+toolbar.events:
+  url_committed:
+    type: event
+    description: >
+      Records `url_committed` when a URL is committed (loaded) from the browser toolbar component by
+      normal means. This records only the standard glean event information with no additional glean
+      event extra keys information.
+    bugs:
+      - 1539080
+    data_reviews:
+      - https://github.com/mozilla-mobile/reference-browser/pull/677#pullrequestreview-220802676
+    notification_emails:
+      - tlong@mozilla.com
+      - aplacitelli@mozilla.com
+    expires: 2019-10-01

--- a/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
@@ -8,6 +8,7 @@ import android.app.Application
 import android.content.Context
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
+import mozilla.components.support.base.facts.register
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.log.sink.AndroidLogSink
@@ -17,6 +18,7 @@ import mozilla.components.support.rustlog.RustLog
 import org.mozilla.reference.browser.ext.components
 import org.mozilla.reference.browser.ext.isCrashReportActive
 import org.mozilla.reference.browser.settings.Settings
+import org.mozilla.reference.browser.telemetry.GleanFactProcessor
 
 open class BrowserApplication : Application() {
     val components by lazy { Components(this) }
@@ -67,6 +69,7 @@ private fun setupLogging(megazordEnabled: Boolean) {
 private fun setupGlean(context: Context) {
     Glean.initialize(context, Configuration(httpClient = lazy { context.components.core.client }))
     Glean.setUploadEnabled(BuildConfig.TELEMETRY_ENABLED && Settings.isTelemetryEnabled(context))
+    GleanFactProcessor().register()
 }
 
 private fun setupCrashReporting(application: BrowserApplication) {

--- a/app/src/main/java/org/mozilla/reference/browser/telemetry/GleanFactProcessor.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/telemetry/GleanFactProcessor.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.telemetry
+
+import mozilla.components.support.base.Component
+import mozilla.components.support.base.facts.Action
+import mozilla.components.support.base.facts.Fact
+import mozilla.components.support.base.facts.FactProcessor
+import org.mozilla.reference.browser.GleanMetrics.ToolbarEvents
+
+class GleanFactProcessor : FactProcessor {
+    /**
+     * If the given [Fact] is relevant to a glean metric, use it to trigger a record.
+     */
+    override fun process(fact: Fact) {
+        // Check for URL Committed event from the toolbar component
+        if (fact.component == Component.BROWSER_TOOLBAR &&
+            fact.action == Action.COMMIT &&
+            fact.item == "toolbar"
+        ) {
+            ToolbarEvents.urlCommitted.record()
+        }
+    }
+}


### PR DESCRIPTION
Add a GleanFactProcessor and a toolbar `urlCommitted` event to faciliate testing glean metrics scheduling.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [x] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
