### PR TITLE
Remove custom appservices repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,13 +21,6 @@ allprojects {
     repositories {
         google()
 
-        // Currently the main repository where appservices artifacts are published.
-        // This will eventually move to maven.mozilla.org
-        // See https://github.com/mozilla/application-services/issues/252
-        maven {
-            url "https://dl.bintray.com/mozilla-appservices/application-services"
-        }
-
         maven {
             url "https://snapshots.maven.mozilla.org/maven2"
         }


### PR DESCRIPTION
Appservices artifacts are now being manually mirrored to m.m.o. from the repository to which they're currently published, which means we don't need to manually specify a custom repository. It may still be useful if the mirroring isn't taking place after an appservices release, but it's better to know that the mirroring is broken than have silent, potentially costly fallbacks.

Eventually appservices releases will be published to m.m.o. automatically, removing these concerns. At that point, no changes to this repository should be necessary.