### PR TITLE
taskcluster.yml: Use ${event.pusher.name}

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -9,8 +9,10 @@ tasks:
     decision_task_id: {$eval: as_slugid("decision_task")}
     expires_in: {$fromNow: '1 year'}
 
-    # We may need to change the following line because of https://github.com/mozilla-releng/scriptworker/issues/326
-    user: ${event.sender.login}
+    user:
+      $if: 'tasks_for == "github-push"'
+      then: ${event.pusher.name}
+      else: ${event.sender.login}
 
     # We define the following variable at the very top, because they are used in the
     # default definition


### PR DESCRIPTION
Follows #715 up. This will need a scriptworker patch, but let's see if the variable behaves the way I think 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
