### PR TITLE
work on settings functional tests wth gradlew lint cleanup

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/MockWebServer.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/MockWebServer.kt
@@ -39,8 +39,10 @@ object MockWebServerHelper {
  *
  * @sample [org.mozilla.tv.firefox.ui.BasicNavigationTest.basicNavigationTest]
  */
-class AndroidAssetDispatcher : Dispatcher() {
+const val HTTP_OK = 200
+const val HTTP_NOT_FOUND = 404
 
+class AndroidAssetDispatcher : Dispatcher() {
     private val mainThreadHandler = Handler(Looper.getMainLooper())
 
     override fun dispatch(request: RecordedRequest): MockResponse {
@@ -53,9 +55,8 @@ class AndroidAssetDispatcher : Dispatcher() {
         } catch (e: IOException) { // e.g. file not found.
             // We're on a background thread so we need to forward the exception to the main thread.
             mainThreadHandler.postAtFrontOfQueue { throw e }
-            return MockResponse().setResponseCode(404)
+            return MockResponse().setResponseCode(HTTP_NOT_FOUND)
         }
-
-        return MockResponse().setResponseCode(200).setBody(assetContents)
+        return MockResponse().setResponseCode(HTTP_OK).setBody(assetContents)
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/TestAssetHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/TestAssetHelper.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit
  * Helper for hosting web pages locally for testing purposes.
  */
 object TestAssetHelper {
-
+    @Suppress("MagicNumber")
     val waitingTime: Long = TimeUnit.SECONDS.toMillis(15)
     data class TestAsset(val url: Uri, val content: String)
 
@@ -26,6 +26,7 @@ object TestAssetHelper {
      * content implementation details.
      */
     fun getGenericAssets(server: MockWebServer): List<TestAsset> {
+        @Suppress("MagicNumber")
         return (1..3).map {
             TestAsset(
                     server.url("pages/generic$it.html").toString().toUri()!!,

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
@@ -4,24 +4,29 @@
 
 package org.mozilla.reference.browser.ui
 
+import androidx.test.rule.GrantPermissionRule
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.reference.browser.helpers.BrowserActivityTestRule
 import org.mozilla.reference.browser.ui.robots.navigationToolbar
 
 /**
- *  Tests for verifying the settings view options exist as expected:
+ *   Tests for verifying the settings view options exist as expected:
  * - Appears when the settings submenu is tapped
  * - Expected options are displayed as listed below
  */
 
 class SettingsViewTest {
+    /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unrgeadable grouping.
+
+    // Grant the app access to the camera so that we can test the Firefox Accounts QR code reader
+    @Rule @JvmField
+    val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(android.Manifest.permission.CAMERA)
 
     @get:Rule val browserActivityTestRule = BrowserActivityTestRule()
-
-    /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
-    @Test
     // This test verifies settings view items are all in place
+    @Test
     fun settingsItemsTest() {
         navigationToolbar {
         }.openThreeDotMenu {
@@ -30,15 +35,42 @@ class SettingsViewTest {
             verifyNavigateUp()
             verifySyncSigninButton()
             verifySyncHistorySummary()
+            verifySyncQrCodeButton()
+            verifySyncQrSummary()
             verifyPrivacyButton()
             verifyPrivacySummary()
             verifyMakeDefaultBrowserButton()
             verifyDeveloperToolsHeading()
+            verifyRemoteDebuggingText()
             verifyRemoteDebuggingToggle()
             verifyMozillaHeading()
             verifyAboutReferenceBrowserButton()
         }
     }
+
+    @Test
+    fun openFXATest() {
+        navigationToolbar {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openFXASignin {
+            verifyFXAUrl()
+        }
+    }
+
+    // openFXAQrCodeTest tests that we get to the camera
+    // Additional tests are needed to verify that the QR code reader works
+    @Test
+    fun openFXAQrCodeTest() {
+        navigationToolbar {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openFXAQrCode {
+            verifyFxAQrCode()
+        }
+
+    }
+
     @Test
     fun privacySettingsItemsTest() {
         navigationToolbar {
@@ -54,7 +86,36 @@ class SettingsViewTest {
             verifyUseTelemetryToggle()
             verifyUseTelemetryToggle()
             verifyTelemetrySummary()
+        }
+    }
 
+    @Test
+    fun setDefaultBrowserTest() {
+        navigationToolbar {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.makeDefaultBrowser {
+            verifyAndroidDefaultApps()
+        }
+    }
+
+    @Test
+    fun remoteDebuggingViaUSB() {
+        navigationToolbar {
+        }.openThreeDotMenu {
+        }.openSettings {
+            toggleRemoteDebuggingOn()
+            toggleRemoteDebuggingOff()
+            toggleRemoteDebuggingOn()
+        }
+    }
+    @Ignore // https://github.com/mozilla-mobile/reference-browser/issues/680
+    fun aboutReferenceBrowserTest() {
+        navigationToolbar {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openAboutReferenceBrowser {
+            verifyAboutBrowser()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
@@ -181,7 +181,7 @@ class ThreeDotMenuTest {
         navigationToolbar {
         }.openThreeDotMenu {
         }.reportIssue {
-            verifyUrl()
+            verifyFXAUrl()
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
@@ -1,4 +1,3 @@
-
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -7,42 +6,40 @@ package org.mozilla.reference.browser.ui.robots
 
 import androidx.test.InstrumentationRegistry
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import androidx.test.espresso.web.model.Atoms
-import androidx.test.espresso.web.sugar.Web.onWebView
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
+import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertTrue
+import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 
 class BrowserRobot {
-
-    /**
-     * Executes the given JS string.
-     * @return if the final expression is a return statement, returns the provided String, else null.
-     */
-    fun executeJS(js: String): String? {
-        return webView()
-                .perform(Atoms.script(js))
-                .get().value as? String
-    }
-
-    /**
-     * Asserts that the text within DOM element with ID="testContent" has the given text, i.e.
-     *   document.querySelector('#testContent').innerText == expectedText
-     */
+    /* Asserts that the text within DOM element with ID="testContent" has the given text, i.e.
+    * document.querySelector('#testContent').innerText == expectedText
+    */
     fun verifyPageContent(expectedText: String) {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        val testContent = mDevice.findObject((UiSelector().textContains(expectedText)))
 
         mDevice.waitForIdle()
-        val testContent = mDevice.findObject((UiSelector().textContains(expectedText)))
         testContent.waitForExists(waitingTime)
         assertTrue(testContent.exists())
     }
 
-    fun verifyUrl() {
-        val redirectUrl = "https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fmozilla-mobile%2Freference-browser%2Fissues%2Fnew"
-        onView(withText(redirectUrl))
+    fun verifyFXAUrl() {
+        val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        val redirectUrl = "https://accounts.firefox.com/"
+
+        mDevice.waitForIdle()
+        onView(withId(R.id.mozac_browser_toolbar_url_view))
+                .check(matches(withText(containsString(redirectUrl))))
+    }
+    fun verifyAboutBrowser() {
+        // Testing About Reference Browser crashes in Java String
+        // https://github.com/mozilla-mobile/reference-browser/issues/680
     }
 
     class Transition {
@@ -61,5 +58,3 @@ fun browser(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
     BrowserRobot().interact()
     return BrowserRobot.Transition()
 }
-
-private fun webView() = onWebView()

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ContentPanelRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ContentPanelRobot.kt
@@ -5,31 +5,19 @@
 package org.mozilla.reference.browser.ui.robots
 
 import androidx.test.espresso.Espresso.onView
-import androidx.test.InstrumentationRegistry
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import androidx.test.uiautomator.UiDevice
 
 /**
  * Implementation of Robot Pattern for the Content Panel.
  */
 class ContentPanelRobot {
-
-    fun verifyContentPanel() = contentPanel()
+    fun verifyContentPanel() = shareContentPanel()
 
     class Transition {
-        private val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-
-        fun exitToNavigationToolbar(interact: NavigationToolbarRobot.() -> Unit): NavigationToolbarRobot.Transition {
-            device.pressBack()
-
-            NavigationToolbarRobot().interact()
-            return NavigationToolbarRobot.Transition()
+        fun contentPanel(interact: ContentPanelRobot.() -> Unit): ContentPanelRobot.Transition {
+            return ContentPanelRobot.Transition()
         }
     }
 }
 
-fun contentPanel(interact: ContentPanelRobot.() -> Unit) {
-    ContentPanelRobot().interact()
-}
-
-private fun contentPanel() = onView(withText("Share with..."))
+private fun shareContentPanel() = onView(withText("Share with..."))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.ui.robots
+
+import androidx.test.espresso.matcher.ViewMatchers.withText
+
+class ExternalAppsRobot {
+    fun verifyAndroidDefaultApps() = defaultAppsLayout()
+    fun verifyFxAQrCode() = fXAQrCode()
+
+    class Transition {
+        fun externalApps(interact: ExternalAppsRobot.() -> Unit): ExternalAppsRobot.Transition {
+            return ExternalAppsRobot.Transition()
+        }
+    }
+}
+
+private fun defaultAppsLayout() = withText("Default apps")
+private fun fXAQrCode() = withText("Pairing")

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/FindInPagePanelRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/FindInPagePanelRobot.kt
@@ -43,19 +43,10 @@ class FindInPagePanelRobot {
     }
 
     class Transition {
-        private val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-
-        fun exitToNavigationToolbar(interact: NavigationToolbarRobot.() -> Unit): NavigationToolbarRobot.Transition {
-            device.pressBack()
-
-            NavigationToolbarRobot().interact()
-            return NavigationToolbarRobot.Transition()
+        fun findInPage(interact: FindInPagePanelRobot.() -> Unit): FindInPagePanelRobot.Transition {
+            return FindInPagePanelRobot.Transition()
         }
     }
-}
-
-fun findInPagePanel(interact: FindInPagePanelRobot.() -> Unit) {
-    FindInPagePanelRobot().interact()
 }
 
 private fun findInPageQuery() = onView(withId(R.id.find_in_page_query_text))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NavigationToolbarRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NavigationToolbarRobot.kt
@@ -26,7 +26,6 @@ class NavigationToolbarRobot {
 
     fun verifyNewTabAddressView() = newTabAddressText()
     fun checkNumberOfTabsTabCounter(numTabs: String) = numberOfOpenTabsTabCounter.check(matches(withText(numTabs)))
-    fun verifyThreeDotMenuDoesNotExist() = threeDotMenuRecyclerViewDoesNotExist()
 
     class Transition {
 

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewPrivacyRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewPrivacyRobot.kt
@@ -6,7 +6,6 @@ package org.mozilla.reference.browser.ui.robots
 
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.matcher.ViewMatchers
-import org.mozilla.reference.browser.helpers.click
 
 /**
  * Implementation of Robot Pattern for the settings privacy menu.
@@ -19,14 +18,13 @@ class SettingsViewPrivacyRobot {
     fun verifyTPEnableInNormalBrowsing() = tpEnableInNormalBrowsing()
     fun verifyTPEnableinPrivateBrowsing() = tpEnableInPrivateBrowsing()
     fun verifyDataChoicesHeading() = dataChoicesHeading()
+    // verifyUseTelemetryToggle does not yet check that the client telemetry is disabled/enabled
     fun verifyUseTelemetryToggle() = useTelemetryToggle()
     fun verifyTelemetrySummary() = telemetrySummary()
 
     class Transition {
-        fun openSettingsRobot(interact: SettingsViewRobot.() -> Unit): SettingsViewRobot.Transition {
-            privacyUpButton().click()
-            SettingsViewRobot().interact()
-            return SettingsViewRobot.Transition()
+        fun settingsViewPrivacy(interact: SettingsViewPrivacyRobot.() -> Unit): SettingsViewPrivacyRobot.Transition {
+            return SettingsViewPrivacyRobot.Transition()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
@@ -2,46 +2,83 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:Suppress("TooManyFunctions")
+
 package org.mozilla.reference.browser.ui.robots
 
-import androidx.test.InstrumentationRegistry
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.uiautomator.UiDevice
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.click
 
 /**
  * Implementation of Robot Pattern for the settings menu.
  */
 class SettingsViewRobot {
-
     fun verifySettingsViewExists() = assertSettingsView()
     fun verifyNavigateUp() = navigateUpButton()
     fun verifySyncSigninButton() = syncSigninButton()
     fun verifySyncHistorySummary() = syncHistorySummary()
+    fun verifySyncQrCodeButton() = syncQrCodeButton()
+    fun verifySyncQrSummary() = syncQrSummary()
     fun verifyPrivacyButton() = privacyButton()
     fun verifyPrivacySummary() = privacySummary()
     fun verifyMakeDefaultBrowserButton() = makeDefaultBrowserButton()
     fun verifyDeveloperToolsHeading() = developerToolsHeading()
+    fun verifyRemoteDebuggingText() = remoteDebuggingText()
     fun verifyRemoteDebuggingToggle() = remoteDebuggingToggle()
     fun verifyMozillaHeading() = mozillaHeading()
     fun verifyAboutReferenceBrowserButton() = aboutReferenceBrowserButton()
 
+    // toggleRemoteDebugging does not yet verify that the debug service is started
+    // server runs on port 6000
+    fun toggleRemoteDebuggingOn() = {
+        Espresso.onView(ViewMatchers.withText("OFF")).check(matches(isDisplayed()))
+        remoteDebuggingToggle().click()
+        Espresso.onView(ViewMatchers.withText("ON")).check(matches(isDisplayed()))
+    }
+
+    fun toggleRemoteDebuggingOff() = {
+        Espresso.onView(ViewMatchers.withText("ON")).check(matches(isDisplayed()))
+        remoteDebuggingToggle().click()
+        Espresso.onView(ViewMatchers.withText("OFF")).check(matches(isDisplayed()))
+    }
+
     class Transition {
-        private val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        fun exitToHomeScreen() {
-            device.pressBack()
-        }
-        fun openSettingsViewPrivacy(interact: SettingsViewPrivacyRobot.() -> Unit): SettingsViewPrivacyRobot.Transition {
+        fun openSettingsViewPrivacy(interact: SettingsViewPrivacyRobot.() -> Unit):
+                SettingsViewPrivacyRobot.Transition {
             privacyButton().click()
             SettingsViewPrivacyRobot().interact()
             return SettingsViewPrivacyRobot.Transition()
         }
-    }
-}
 
-fun settingsView(interact: SettingsViewRobot.() -> Unit) {
-    SettingsViewRobot().interact()
+        fun openFXASignin(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            syncSigninButton().click()
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
+
+        fun openFXAQrCode(interact: ExternalAppsRobot.() -> Unit): ExternalAppsRobot.Transition {
+            syncQrCodeButton().click()
+            ExternalAppsRobot().interact()
+            return ExternalAppsRobot.Transition()
+        }
+
+        fun makeDefaultBrowser(interact: ExternalAppsRobot.() -> Unit):
+                ExternalAppsRobot.Transition {
+            makeDefaultBrowserButton().click()
+            ExternalAppsRobot().interact()
+            return ExternalAppsRobot.Transition()
+        }
+
+        fun openAboutReferenceBrowser(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            aboutReferenceBrowserButton().click()
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
+    }
 }
 
 private fun assertSettingsView() {
@@ -53,10 +90,13 @@ private fun assertSettingsView() {
 private fun navigateUpButton() = Espresso.onView(ViewMatchers.withContentDescription("Navigate up"))
 private fun syncSigninButton() = Espresso.onView(ViewMatchers.withText("Sign in"))
 private fun syncHistorySummary() = Espresso.onView(ViewMatchers.withText("Sync your history"))
+private fun syncQrCodeButton() = Espresso.onView(ViewMatchers.withText("Sign in with a QR code"))
+private fun syncQrSummary() = Espresso.onView(ViewMatchers.withText("Pair with Firefox Desktop"))
 private fun privacyButton() = Espresso.onView(ViewMatchers.withText("Privacy"))
 private fun privacySummary() = Espresso.onView(ViewMatchers.withText("Tracking, cookies, data choices"))
 private fun makeDefaultBrowserButton() = Espresso.onView(ViewMatchers.withText("Make default browser"))
 private fun developerToolsHeading() = Espresso.onView(ViewMatchers.withText("Developer tools"))
-private fun remoteDebuggingToggle() = Espresso.onView(ViewMatchers.withText("Remote debugging via USB"))
+private fun remoteDebuggingText() = Espresso.onView(ViewMatchers.withText("Remote debugging via USB"))
+private fun remoteDebuggingToggle() = Espresso.onView(ViewMatchers.withId(R.id.switchWidget))
 private fun mozillaHeading() = Espresso.onView(ViewMatchers.withText("Mozilla"))
 private fun aboutReferenceBrowserButton() = Espresso.onView(ViewMatchers.withText("About Reference Browser"))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMenuRobot.kt
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:Suppress("TooManyFunctions")
+
 package org.mozilla.reference.browser.ui.robots
 
 import androidx.test.espresso.Espresso.onView
@@ -29,11 +31,12 @@ class TabTrayMenuRobot {
     fun verifyCloseButtonInTabPreview() = closeTabButtonTabTray()
     fun verifyDefaultOpenTabTitle() = openTabTabTrayTitle()
     fun verifyDefaultOpenTabThumbnail() = openTabTabTrayThumbnail()
-    fun verifyRegularBrowsingButton(regularBrowsingButtonChecked: Boolean) = regularBrowsingButton().assertIsChecked(regularBrowsingButtonChecked)
-    fun verifyPrivateBrowsingButton(privateButtonChecked: Boolean) = privateBrowsingButton().assertIsChecked(privateButtonChecked)
+    fun verifyRegularBrowsingButton(regularBrowsingButtonChecked: Boolean) =
+            regularBrowsingButton().assertIsChecked(regularBrowsingButtonChecked)
+    fun verifyPrivateBrowsingButton(privateButtonChecked: Boolean) =
+            privateBrowsingButton().assertIsChecked(privateButtonChecked)
 
     fun verifyThereAreNotPrivateTabsOpen() = privateTabs().check(doesNotExist())
-    fun verifyThereAreNoRegularTabsOpen() = regularTabs().check(doesNotExist())
     fun verifyThereIsOnePrivateTabOpen() = privateTabs().check(matches(isDisplayed()))
     fun verifyThereIsOneTabOpen() = regularTabs().check(matches(isDisplayed()))
 
@@ -55,7 +58,8 @@ class TabTrayMenuRobot {
             return NavigationToolbarRobot.Transition()
         }
 
-        fun openMoreOptionsMenu(interact: TabTrayMoreOptionsMenuRobot.() -> Unit): TabTrayMoreOptionsMenuRobot.Transition {
+        fun openMoreOptionsMenu(interact: TabTrayMoreOptionsMenuRobot.() -> Unit):
+                TabTrayMoreOptionsMenuRobot.Transition {
             menuButton().click()
             TabTrayMoreOptionsMenuRobot().interact()
             return TabTrayMoreOptionsMenuRobot.Transition()
@@ -73,10 +77,6 @@ class TabTrayMenuRobot {
             return NavigationToolbarRobot.Transition()
         }
     }
-}
-
-fun tabTray(interact: TabTrayMenuRobot.() -> Unit) {
-    TabTrayMenuRobot().interact()
 }
 
 private fun regularBrowsingButton() = onView(withId(R.id.button_tabs))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMoreOptionsMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMoreOptionsMenuRobot.kt
@@ -34,9 +34,5 @@ class TabTrayMoreOptionsMenuRobot {
     }
 }
 
-fun tabTrayMoreOptionsMenu(interact: TabTrayMoreOptionsMenuRobot.() -> Unit) {
-    TabTrayMoreOptionsMenuRobot().interact()
-}
-
 private fun closeAllTabsButton() = onView(ViewMatchers.withText("Close All Tabs"))
 private fun closeAllPrivateTabsButton() = onView(ViewMatchers.withText("Close Private Tabs"))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:Suppress("TooManyFunctions")
+
 package org.mozilla.reference.browser.ui.robots
 
 import androidx.test.espresso.Espresso.onView
@@ -101,5 +103,6 @@ private fun findInPageButton() = onView(ViewMatchers.withText("Find in Page"))
 private fun reportIssueButton() = onView(ViewMatchers.withText("Report issue"))
 private fun settingsButton() = onView(ViewMatchers.withText("Settings"))
 private fun assertShareButtonDoesntExist() = shareButton().check(ViewAssertions.doesNotExist())
-private fun assertRequestDesktopSiteToggleDoesntExist() = requestDesktopSiteToggle().check(ViewAssertions.doesNotExist())
+private fun assertRequestDesktopSiteToggleDoesntExist() =
+        requestDesktopSiteToggle().check(ViewAssertions.doesNotExist())
 private fun assertFindInPageButtonDoesntExist() = findInPageButton().check(ViewAssertions.doesNotExist())


### PR DESCRIPTION
Added tests for the functionality of the settings of Reference Browser. Along with cleanup of a lot of ktlint/detekt failures.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [x] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
