### PR TITLE
Update to latest a-c (0.51.0-SNAPSHOT) and a-s (0.25.2)

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
@@ -6,6 +6,8 @@ package org.mozilla.reference.browser
 
 import android.app.Application
 import android.content.Context
+import mozilla.components.concept.fetch.Client
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.support.base.facts.register
@@ -104,8 +106,9 @@ private fun setupMegazord(): Boolean {
     // See https://github.com/mozilla-mobile/reference-browser/pull/356.
     return try {
         val megazordClass = Class.forName("mozilla.appservices.ReferenceBrowserMegazord")
-        val megazordInitMethod = megazordClass.getDeclaredMethod("init")
-        megazordInitMethod.invoke(megazordClass)
+        val megazordInitMethod = megazordClass.getDeclaredMethod("init", Lazy::class.java)
+        val client: Lazy<Client> = lazy { HttpURLConnectionClient() }
+        megazordInitMethod.invoke(megazordClass, client)
         true
     } catch (e: ClassNotFoundException) {
         Logger.info("mozilla.appservices.ReferenceBrowserMegazord not found; skipping megazord init.")

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -15,9 +15,9 @@ private object Versions {
     const val google_material = "1.0.0"
 
     const val android_gradle_plugin = "3.2.1"
-    const val appservices_gradle_plugin = "0.4.2"
+    const val appservices_gradle_plugin = "0.4.4"
 
-    const val mozilla_android_components = "0.50.0-SNAPSHOT"
+    const val mozilla_android_components = "0.51.0-SNAPSHOT"
 
     const val thirdparty_sentry = "1.7.10"
 


### PR DESCRIPTION
The megazord changes are required for the latest A-C snapshots. For now, we're gonna have to use `HttpUrlConnectionClient` until https://github.com/mozilla-mobile/android-components/issues/2715 is resolved.