### PR TITLE
Fix blank custom tabs following an NPE.

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/IntentReceiverActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/IntentReceiverActivity.kt
@@ -16,9 +16,10 @@ class IntentReceiverActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        val intent = intent?.let { Intent(it) } ?: Intent()
+
         components.utils.intentProcessor.process(intent)
 
-        val intent = Intent(intent)
         if (CustomTabConfig.isCustomTabIntent(SafeIntent(intent))) {
             intent.setClassName(applicationContext, CustomTabActivity::class.java.name)
         } else {


### PR DESCRIPTION
Fixes #586.

This PR protects against the initial `NullPointerException` ever happening.

This is a rare case, and we do not have anything to go on at this point, so we fallback to a new intent, and the user is routed to the home activity.