### PR TITLE
Upgrade to GV nightly 68.0.20190422094240

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
@@ -7,7 +7,6 @@ package org.mozilla.reference.browser
 import android.app.Application
 import android.content.Context
 import mozilla.components.concept.fetch.Client
-import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.support.base.facts.register
@@ -30,7 +29,7 @@ open class BrowserApplication : Application() {
 
         setupCrashReporting(this)
 
-        val megazordEnabled = setupMegazord()
+        val megazordEnabled = setupMegazord(components)
         setupLogging(megazordEnabled)
 
         if (!isMainProcess()) {
@@ -96,7 +95,7 @@ private fun setupCrashReporting(application: BrowserApplication) {
  *
  * @return Boolean indicating if we're in a megazord.
  */
-private fun setupMegazord(): Boolean {
+private fun setupMegazord(components: Components): Boolean {
     // mozilla.appservices.ReferenceBrowserMegazord will be missing if we're doing an application-services
     // dependency substitution locally. That class is supplied dynamically by the org.mozilla.appservices
     // gradle plugin, and that won't happen if we're not megazording. We won't megazord if we're
@@ -107,7 +106,7 @@ private fun setupMegazord(): Boolean {
     return try {
         val megazordClass = Class.forName("mozilla.appservices.ReferenceBrowserMegazord")
         val megazordInitMethod = megazordClass.getDeclaredMethod("init", Lazy::class.java)
-        val client: Lazy<Client> = lazy { HttpURLConnectionClient() }
+        val client: Lazy<Client> = lazy { components.core.client }
         megazordInitMethod.invoke(megazordClass, client)
         true
     } catch (e: ClassNotFoundException) {

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object GeckoVersions {
-    const val nightly_version = "68.0.20190417214729"
+    const val nightly_version = "68.0.20190422094240"
 }
 
 object Gecko {


### PR DESCRIPTION
This now also switches our megazord fetch client to GV fetch. I've verified that this resolves https://github.com/mozilla-mobile/android-components/issues/2715