### PR TITLE
Closes #464: Use EngineViewBottomBehavior to draw bottom-aligned web content above the toolbar.

### DIFF
--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -11,26 +11,22 @@
     android:layout_height="match_parent"
     tools:context=".BrowserActivity">
 
-    <FrameLayout
+    <mozilla.components.concept.engine.EngineView
+        android:id="@+id/engineView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        app:layout_behavior="mozilla.components.feature.session.behavior.EngineViewBottomBehavior" />
 
-        <mozilla.components.concept.engine.EngineView
-            android:id="@+id/engineView"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-
-        <mozilla.components.browser.awesomebar.BrowserAwesomeBar
-            android:id="@+id/awesomeBar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:padding="4dp"
-            android:visibility="gone"
-            mozac:awesomeBarTitleTextColor="#ffffff"
-            mozac:awesomeBarDescriptionTextColor="#dddddd"
-            mozac:awesomeBarChipTextColor="#ffffff"
-            mozac:awesomeBarChipBackgroundColor="#444444" />
-    </FrameLayout>
+    <mozilla.components.browser.awesomebar.BrowserAwesomeBar
+        android:id="@+id/awesomeBar"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="4dp"
+        android:visibility="gone"
+        mozac:awesomeBarTitleTextColor="#ffffff"
+        mozac:awesomeBarDescriptionTextColor="#dddddd"
+        mozac:awesomeBarChipTextColor="#ffffff"
+        mozac:awesomeBarChipBackgroundColor="#444444" />
 
     <mozilla.components.feature.findinpage.view.FindInPageBar
         android:id="@+id/findInPageBar"


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
