### PR TITLE
Use and install browser-icons extension for fetching website icons.

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/components/Core.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Core.kt
@@ -7,6 +7,7 @@ package org.mozilla.reference.browser.components
 import android.content.Context
 import android.content.SharedPreferences
 import android.preference.PreferenceManager
+import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.storage.SessionStorage
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
@@ -68,6 +69,9 @@ class Core(private val context: Context) {
                 .periodicallyInForeground(interval = 30, unit = TimeUnit.SECONDS)
                 .whenGoingToBackground()
                 .whenSessionsChange()
+
+            // Install the "icons" WebExtension to automatically load icons for every visited website.
+            icons.install(engine, sessionManager = this)
         }
     }
 
@@ -76,6 +80,11 @@ class Core(private val context: Context) {
      * private sessions).
      */
     val historyStorage by lazy { PlacesHistoryStorage(context) }
+
+    /**
+     * Icons component for loading, caching and processing website icons.
+     */
+    val icons by lazy { BrowserIcons(context, client) }
 
     /**
      * Constructs a [TrackingProtectionPolicy] based on current preferences.


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
