### PR TITLE
Uses new raptor workers, only run raptor nightly

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -111,90 +111,43 @@ tasks:
             owner: ${user}@users.noreply.github.com
             source: ${repository}/raw/${head_rev}/.taskcluster.yml
       in:
-        $if: 'tasks_for in ["github-pull-request", "github-push"]'
-        then:
-          - $if: 'tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"]'
-            then:
-              $let:
-                pull_request_title: ${event.pull_request.title}
-                pull_request_number: ${event.pull_request.number}
-                pull_request_url: ${event.pull_request.html_url}
-              in:
+        $flatten:
+          $if: 'tasks_for in ["github-pull-request", "github-push"]'
+          then:
+            - $if: 'tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"]'
+              then:
+                $let:
+                  pull_request_title: ${event.pull_request.title}
+                  pull_request_number: ${event.pull_request.number}
+                  pull_request_url: ${event.pull_request.html_url}
+                in:
+                  $mergeDeep:
+                    - {$eval: 'default_task_definition'}
+                    - scopes:
+                        - ${assume_scope_prefix}:pull-request
+                      payload:
+                        command:
+                          - >-
+                            cd ..
+                            && git clone ${repository}
+                            && cd reference-browser
+                            && git config advice.detachedHead false
+                            && git checkout ${head_rev}
+                            && python automation/taskcluster/decision_task.py pull-request
+                        env:
+                          GITHUB_PULL_TITLE: ${pull_request_title}
+                      extra:
+                        treeherder:
+                          symbol: D-PR
+                      metadata:
+                        name: 'Reference-Browser - Decision task (Pull Request #${pull_request_number})'
+                        description: 'Building and testing the Reference Browser - triggered by [#${pull_request_number}](${pull_request_url})'
+            - $if: 'tasks_for == "github-push" && head_branch[:10] != "refs/tags/"'
+              then:
                 $mergeDeep:
                   - {$eval: 'default_task_definition'}
                   - scopes:
-                      - ${assume_scope_prefix}:pull-request
-                    payload:
-                      command:
-                        - >-
-                          cd ..
-                          && git clone ${repository}
-                          && cd reference-browser
-                          && git config advice.detachedHead false
-                          && git checkout ${head_rev}
-                          && python automation/taskcluster/decision_task.py pull-request
-                      env:
-                        GITHUB_PULL_TITLE: ${pull_request_title}
-                    extra:
-                      treeherder:
-                        symbol: D-PR
-                    metadata:
-                      name: 'Reference-Browser - Decision task (Pull Request #${pull_request_number})'
-                      description: 'Building and testing the Reference Browser - triggered by [#${pull_request_number}](${pull_request_url})'
-          - $if: 'tasks_for == "github-push" && head_branch[:10] != "refs/tags/"'
-            then:
-              $mergeDeep:
-                - {$eval: 'default_task_definition'}
-                - scopes:
-                    - ${assume_scope_prefix}:branch:${short_head_branch}
-                  payload:
-                    features:
-                      chainOfTrust: true
-                    command:
-                      - >-
-                        cd ..
-                        && git clone ${repository}
-                        && cd reference-browser
-                        && git config advice.detachedHead false
-                        && git checkout ${head_rev}
-                        && python automation/taskcluster/decision_task.py push
-                    artifacts:
-                      public/task-graph.json:
-                        type: file
-                        path: /build/reference-browser/task-graph.json
-                        expires: ${expires_in}
-                      public/actions.json:
-                        type: file
-                        path: /build/reference-browser/actions.json
-                        expires: ${expires_in}
-                      public/parameters.yml:
-                        type: file
-                        path: /build/reference-browser/parameters.yml
-                        expires: ${expires_in}
-                  extra:
-                    treeherder:
-                      symbol: D
-                  metadata:
-                    name: Reference-Browser - Decision task
-                    description: Schedules the build and test tasks for Android components.
-        else:
-          - $if: 'tasks_for == "cron"'
-            then:
-              $let:
-                command_staging_flag:
-                  $if: 'trust_level == 3'
-                  then: ''
-                  else: '--staging'
-
-                assume_scope:
-                  $if: 'trust_level == 3'
-                  then: assume:hook-id:project-mobile/reference-browser-nightly
-                  else: assume:hook-id:project-mobile/reference-browser-nightly-staging
-              in:
-                $mergeDeep:
-                  - {$eval: 'default_task_definition'}
-                  - scopes:
-                      - ${assume_scope}
+                      - ${assume_scope_prefix}:branch:${short_head_branch}
                     payload:
                       features:
                         chainOfTrust: true
@@ -203,10 +156,9 @@ tasks:
                           cd ..
                           && git clone ${repository}
                           && cd reference-browser
-                          && git checkout ${event.release.tag_name}
-                          && python automation/taskcluster/decision_task.py \
-                            nightly \
-                            ${command_staging_flag}
+                          && git config advice.detachedHead false
+                          && git checkout ${head_rev}
+                          && python automation/taskcluster/decision_task.py push
                       artifacts:
                         public/task-graph.json:
                           type: file
@@ -221,10 +173,99 @@ tasks:
                           path: /build/reference-browser/parameters.yml
                           expires: ${expires_in}
                     extra:
-                      cron: {$json: {$eval: 'cron'}}
-                      tasks_for: ${tasks_for}
                       treeherder:
-                        symbol: N
+                        symbol: D
                     metadata:
-                      name: Reference-Browser - Nightly Decision Task
-                      description: Decision task scheduled by cron task [${cron.task_id}](https://tools.taskcluster.net/tasks/${cron.task_id})
+                      name: Reference-Browser - Decision task
+                      description: Schedules the build and test tasks for Android components.
+          else:
+            - $if: 'tasks_for == "cron"'
+              then:
+                $let:
+                  staging_flag:
+                    $if: 'trust_level == 3'
+                    then: ''
+                    else: '--staging'
+                in:
+                  - $if: 'cron.name == "nightly"'
+                    then:
+                      $mergeDeep:
+                        - {$eval: 'default_task_definition'}
+                        - scopes:
+                            - $if: 'trust_level == 3'
+                              then: assume:hook-id:project-mobile/reference-browser-nightly
+                              else: assume:hook-id:project-mobile/reference-browser-nightly-staging
+                          payload:
+                            features:
+                              chainOfTrust: true
+                            command:
+                              - >-
+                                cd ..
+                                && git clone ${repository}
+                                && cd reference-browser
+                                && git checkout ${event.release.tag_name}
+                                && python automation/taskcluster/decision_task.py \
+                                  nightly \
+                                  ${staging_flag}
+                            artifacts:
+                              public/task-graph.json:
+                                type: file
+                                path: /build/reference-browser/task-graph.json
+                                expires: ${expires_in}
+                              public/actions.json:
+                                type: file
+                                path: /build/reference-browser/actions.json
+                                expires: ${expires_in}
+                              public/parameters.yml:
+                                type: file
+                                path: /build/reference-browser/parameters.yml
+                                expires: ${expires_in}
+                          extra:
+                            cron: {$json: {$eval: 'cron'}}
+                            tasks_for: ${tasks_for}
+                            treeherder:
+                              symbol: nightly-D
+                          metadata:
+                            name: Reference-Browser - Nightly Decision Task
+                            description: Decision task scheduled by cron task [${cron.task_id}](https://tools.taskcluster.net/tasks/${cron.task_id})
+                  - $if: 'cron.name == "raptor"'
+                    then:
+                      $mergeDeep:
+                        - {$eval: 'default_task_definition'}
+                        - scopes:
+                            - $if: 'trust_level == 3'
+                              then: assume:hook-id:project-mobile/reference-browser-raptor
+                              else: assume:hook-id:project-mobile/reference-browser-raptor-staging
+                          payload:
+                            features:
+                              chainOfTrust: true
+                            command:
+                              - >-
+                                cd ..
+                                && git clone ${repository}
+                                && cd reference-browser
+                                && git checkout ${event.release.tag_name}
+                                && python automation/taskcluster/decision_task.py \
+                                  raptor \
+                                  ${staging_flag}
+                            artifacts:
+                              public/task-graph.json:
+                                type: file
+                                path: /build/reference-browser/task-graph.json
+                                expires: ${expires_in}
+                              public/actions.json:
+                                type: file
+                                path: /build/reference-browser/actions.json
+                                expires: ${expires_in}
+                              public/parameters.yml:
+                                type: file
+                                path: /build/reference-browser/parameters.yml
+                                expires: ${expires_in}
+                          extra:
+                            cron: {$json: {$eval: 'cron'}}
+                            tasks_for: ${tasks_for}
+                            treeherder:
+                              symbol: raptor-D
+                          metadata:
+                            name: Reference-Browser - Raptor Decision Task
+                            description: Decision task scheduled by cron task [${cron.task_id}](https://tools.taskcluster.net/tasks/${cron.task_id})

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,7 @@ android {
             applicationIdSuffix ".debug"
         }
         raptor releaseTemplate >> { // the ">>" concatenates the raptor-specific options with the template
+            applicationIdSuffix ".raptor"
             manifestPlaceholders.isRaptorEnabled = "true"
             matchingFallbacks = ['release']
         }
@@ -279,10 +280,13 @@ dependencies {
 // -------------------------------------------------------------------------------------------------
 task printBuildVariants {
     doLast {
-        def buildVariants = android.applicationVariants.collect { variant ->
-            variant.name
-        }
-        println "variants: " + groovy.json.JsonOutput.toJson(buildVariants)
+        def variantData = android.applicationVariants.collect { variant -> [
+            name: variant.name,
+            buildType: variant.buildType.name,
+            abi: variant.productFlavors.find { it.dimension == 'abi' }.name,
+            isSigned: variant.signingReady,
+        ]}
+        println "variants: " + groovy.json.JsonOutput.toJson(variantData)
     }
 }
 

--- a/automation/taskcluster/lib/gradle.py
+++ b/automation/taskcluster/lib/gradle.py
@@ -6,8 +6,10 @@ from __future__ import print_function
 import json
 import subprocess
 
+from lib.variant import Variant
 
-def get_build_variants():
+
+def get_debug_variants():
     print("Fetching build variants from gradle")
     output = _run_gradle_process('printBuildVariants')
     content = _extract_content_from_command_output(output, prefix='variants: ')
@@ -16,9 +18,11 @@ def get_build_variants():
     if len(variants) == 0:
         raise ValueError("Could not get build variants from gradle")
 
-    print("Got variants: {}".format(' '.join(variants)))
-
-    return variants
+    print("Got variants: {}".format(variants))
+    return [Variant(variant_dict['name'], variant_dict['abi'], variant_dict['isSigned'],
+                    variant_dict['buildType'])
+            for variant_dict in variants
+            if variant_dict['buildType'] == 'debug']
 
 
 def get_geckoview_versions():

--- a/automation/taskcluster/lib/variant.py
+++ b/automation/taskcluster/lib/variant.py
@@ -1,0 +1,20 @@
+class Variant:
+    def __init__(self, raw, abi, is_signed, build_type):
+        self.raw = raw
+        self.abi = abi
+        self.build_type = build_type
+        self._is_signed = is_signed
+        self.for_gradle_command = raw[:1].upper() + raw[1:]
+        self.platform = 'android-{}-{}'.format(self.abi, self.build_type)
+
+    def apk_absolute_path(self):
+        return '/build/reference-browser/app/build/outputs/apk/{abi}/{build_type}/app-{abi}-{build_type}{unsigned}.apk'.format(
+            build_type=self.build_type,
+            abi=self.abi,
+            unsigned='' if self._is_signed else '-unsigned',
+        )
+
+    @staticmethod
+    def from_values(abi, is_signed, build_type):
+        raw = abi + build_type[:1].upper() + build_type[1:]
+        return Variant(raw, abi, is_signed, build_type)


### PR DESCRIPTION
Fixes #770

We now have two different cron jobs that use hooks to perform the jobs on a schedule:
* Daily: release nightly
* Daily (may change in the future): run raptor performance tests

This modifies automation to allow raptor jobs to be scheduled independently, while also adding logic to handle multiple different hooks scheduling different graphs.
Additionally, this migrates work to the new Raptor workers.

### Pull Request checklist
- [x] [This task group must be green](https://taskcluster-ui.herokuapp.com/tasks/groups/HfbsF3vCShu26zWicmPFGQ)
- [x] [This `m-c` patchset must be approved](https://phabricator.services.mozilla.com/D32815)

### After Merge checklist
- [ ] Update Nightly hooks to add `nightly` argument when calling `schedule_nightly_graph.py`
- [ ] Run `reference-browser-raptor` hook, enable cron schedule
- [ ] Merge [this `m-c` patchset](https://phabricator.services.mozilla.com/D32815)