### PR TITLE
Add x86_64 to the supported architectures

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,16 +78,22 @@ android {
                 abiFilter "armeabi-v7a"
             }
         }
+        aarch64 {
+            dimension "abi"
+            ndk {
+                abiFilter "arm64-v8a"
+            }
+        }
         x86 {
             dimension "abi"
             ndk {
                 abiFilter "x86"
             }
         }
-        aarch64 {
+        x86_64 {
             dimension "abi"
             ndk {
-                abiFilter "arm64-v8a"
+                abiFilter "x86_64"
             }
         }
     }
@@ -155,7 +161,9 @@ if (project.hasProperty("telemetry") && project.property("telemetry") == "true")
         // Our x86 builds need a higher version code to avoid installing ARM builds on an x86 device
         // with ARM compatibility mode.
 
-        if (variant.flavorName.contains("x86")) {
+        if (variant.flavorName.contains("x86_64")) {
+            versionCode = versionCode + 3
+	} else if (variant.flavorName.contains("x86")) {
             versionCode = versionCode + 2
         } else if (variant.flavorName.contains("aarch64")) {
             versionCode = versionCode + 1
@@ -234,8 +242,9 @@ dependencies {
 
     implementation Deps.mozilla_browser_engine_gecko_nightly
     armImplementation Gecko.geckoview_nightly_arm
-    x86Implementation Gecko.geckoview_nightly_x86
     aarch64Implementation Gecko.geckoview_nightly_aarch64
+    x86Implementation Gecko.geckoview_nightly_x86
+    x86_64Implementation Gecko.geckoview_nightly_x86_64
 
     implementation Deps.kotlin_stdlib
     implementation Deps.kotlin_coroutines

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -21,7 +21,7 @@ _OFFICIAL_REPO_URL = 'https://github.com/mozilla-mobile/reference-browser'
 _DEFAULT_TASK_URL = 'https://queue.taskcluster.net/v1/task'
 
 _ARCH_APK_LOCATION_PATTERN = 'public/target.{}.apk'
-_SUPPORTED_ARCHITECTURES = ('aarch64', 'arm', 'x86')
+_SUPPORTED_ARCHITECTURES = ('aarch64', 'arm', 'x86', 'x86_64')
 _APKS_PATHS = [_ARCH_APK_LOCATION_PATTERN.format(arch) for arch in _SUPPORTED_ARCHITECTURES]
 
 class TaskBuilder(object):

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -8,6 +8,7 @@ object GeckoVersions {
 
 object Gecko {
     const val geckoview_nightly_arm = "org.mozilla.geckoview:geckoview-nightly-armeabi-v7a:${GeckoVersions.nightly_version}"
-    const val geckoview_nightly_x86 = "org.mozilla.geckoview:geckoview-nightly-x86:${GeckoVersions.nightly_version}"
     const val geckoview_nightly_aarch64 = "org.mozilla.geckoview:geckoview-nightly-arm64-v8a:${GeckoVersions.nightly_version}"
+    const val geckoview_nightly_x86 = "org.mozilla.geckoview:geckoview-nightly-x86:${GeckoVersions.nightly_version}"
+    const val geckoview_nightly_x86_64 = "org.mozilla.geckoview:geckoview-nightly-x86_64:${GeckoVersions.nightly_version}"
 }


### PR DESCRIPTION
This patch adds support for `x86_64`.