### PR TITLE
Add UI tests to taskcluster job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ captures/
 *.iml
 .idea/
 
+# Vim swap files
+*.sw[op]
+
 # Keystore files
 *.jks
 
@@ -53,3 +56,11 @@ jacoco.exec
 
 # Sentry token file
 .sentry_token
+
+# UI test artifacts 
+.firebase_token*
+results/
+test_artifacts/
+google-cloud-sdk/
+*.jar
+*.gz

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -79,8 +79,12 @@ tasks:
           requires: all-completed   # Must be explicit because of Chain of Trust
           retries: 5
           routes:
-            - statuses  # Automatically added by taskcluster-github. It must be explicit because of Chain of Trust
-            - tc-treeherder.v2.reference-browser.${head_rev}
+            $flatten:
+              - statuses  # Automatically added by taskcluster-github. It must be explicit because of Chain of Trust
+              - $if: 'trust_level == 3'
+                then:
+                    - tc-treeherder.v2.fenix.${head_rev}
+                else: []
           payload:
             maxRunTime: 600   # Decision should remain fast enough to schedule a handful of tasks
             image: mozillamobile/android-components:1.15 # TODO Stop using the android-components docker image.

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
@@ -187,7 +187,7 @@ class ThreeDotMenuTest {
         }.openNavigationToolbar {
         }.openThreeDotMenu {
         }.reportIssue {
-            verifyFXAUrl()
+            verifyGithubUrl()
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AwesomeBarRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AwesomeBarRobot.kt
@@ -11,7 +11,6 @@ import org.mozilla.reference.browser.R
 /**
  * Implementation of Robot Pattern for awesomebar.
  */
-
 class AwesomeBarRobot {
 
     class Transition {

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
@@ -11,36 +11,42 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers.containsString
-import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.R
+import org.mozilla.reference.browser.helpers.TestAssetHelper
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 
+/**
+ * Implementation of Robot Pattern for browser action.
+ */
 class BrowserRobot {
     /* Asserts that the text within DOM element with ID="testContent" has the given text, i.e.
     * document.querySelector('#testContent').innerText == expectedText
     */
     fun verifyPageContent(expectedText: String) {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        val testContent = mDevice.findObject((UiSelector().textContains(expectedText)))
-
-        testContent.waitForExists(waitingTime)
-        assertTrue(testContent.exists())
+        mDevice.wait(Until.findObject(By.res(expectedText)), TestAssetHelper.waitingTime)
     }
 
     fun verifyFXAUrl() {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        // if WIFI off
-        val redirectUrl = "https://github.com/login"
-        // if WIFI on
-        // val redirectUrl = "https://accounts.firefox.com"
+        val redirectUrl = "https://accounts.firefox.com"
 
         mDevice.wait(Until.findObject(By.res("mozac_browser_toolbar_url_view")), waitingTime)
         onView(withId(R.id.mozac_browser_toolbar_url_view))
                 .check(matches(withText(containsString(redirectUrl))))
     }
+
+    fun verifyGithubUrl() {
+        val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        val redirectUrl = "https://github.com/login"
+
+        mDevice.wait(Until.findObject(By.res("mozac_browser_toolbar_url_view")), waitingTime)
+        onView(withId(R.id.mozac_browser_toolbar_url_view))
+                .check(matches(withText(containsString(redirectUrl))))
+    }
+
     fun verifyAboutBrowser() {
         // Testing About Reference Browser crashes in Java String
         // https://github.com/mozilla-mobile/reference-browser/issues/680

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ContentPanelRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ContentPanelRobot.kt
@@ -10,7 +10,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 
 /**
- * Implementation of Robot Pattern for the Content Panel.
+ * Implementation of Robot Pattern for the content panel.
  */
 class ContentPanelRobot {
     fun verifyContentPanel() = shareContentPanel()

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
@@ -11,6 +11,9 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.Until
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTimeShort
 
+/**
+ * Implementation of Robot Pattern for any non-Reference Browser (external) apps.
+ */
 class ExternalAppsRobot {
     fun verifyAndroidDefaultApps() = assertDefaultAppsLayout()
     fun verifyFxAQrCode() = assertFXAQrCode()

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NavigationToolbarRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NavigationToolbarRobot.kt
@@ -22,7 +22,7 @@ import androidx.test.uiautomator.Until
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 
 /**
- * Implementation of Robot Pattern for the navigation toolbar  menu.
+ * Implementation of Robot Pattern for the navigation toolbar menu.
  */
 class NavigationToolbarRobot {
 

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewPrivacyRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewPrivacyRobot.kt
@@ -7,6 +7,9 @@ package org.mozilla.reference.browser.ui.robots
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Until
+import org.mozilla.reference.browser.helpers.TestAssetHelper
 
 /**
  * Implementation of Robot Pattern for the settings privacy menu.
@@ -39,9 +42,9 @@ private fun tpEnableInPrivateBrowsing() = Espresso.onView(ViewMatchers.withText(
 private fun dataChoicesHeading() = Espresso.onView(ViewMatchers.withText("Data Choices"))
 private fun useTelemetryToggle() = Espresso.onView(ViewMatchers.withText("Use Telemetry"))
 private fun telemetrySummary() = Espresso.onView(ViewMatchers.withText("Send usage data"))
-
-private fun assertPrivacyUpButton() = privacyUpButton()
-        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertPrivacyUpButton() {
+    mDevice.wait(Until.findObject(By.text("Navigate up")), TestAssetHelper.waitingTimeShort)
+}
 private fun assertPrivacySettingsView() = privacySettingsView()
         .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 private fun assertTrackingProtectionHeading() = trackingProtectionHeading()

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
@@ -11,7 +11,10 @@ import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Until
 import org.mozilla.reference.browser.R
+import org.mozilla.reference.browser.helpers.TestAssetHelper
 import org.mozilla.reference.browser.helpers.click
 
 /**
@@ -103,8 +106,9 @@ private fun remoteDebuggingToggle() = Espresso.onView(ViewMatchers.withId(R.id.s
 private fun mozillaHeading() = Espresso.onView(ViewMatchers.withText("Mozilla"))
 private fun aboutReferenceBrowserButton() = Espresso.onView(ViewMatchers.withText("About Reference Browser"))
 
-private fun assertNavigateUpButton() = navigateUpButton()
-        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertNavigateUpButton() {
+    mDevice.wait(Until.findObject(By.text("Navigate up")), TestAssetHelper.waitingTimeShort)
+}
 private fun assertSyncSigninButton() = syncSigninButton()
         .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 private fun assertSyncHistorySummary() = syncHistorySummary()

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMenuRobot.kt
@@ -24,7 +24,7 @@ import org.mozilla.reference.browser.helpers.assertIsChecked
 import org.mozilla.reference.browser.helpers.click
 
 /**
- * Implementation of Robot Pattern for the tab tray  menu.
+ * Implementation of Robot Pattern for the tab tray menu.
  */
 
 val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMoreOptionsMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMoreOptionsMenuRobot.kt
@@ -8,11 +8,14 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
+import org.mozilla.reference.browser.helpers.TestAssetHelper
 import org.mozilla.reference.browser.helpers.click
 
 /**
- * Implementation of Robot Pattern for the menun in tab tray that shows more options.
+ * Implementation of Robot Pattern for menu in tab tray that shows more options.
  * So far only Close All Tabs is implemented.
  */
 
@@ -42,8 +45,9 @@ class TabTrayMoreOptionsMenuRobot {
 
 private fun closeAllTabsButton() = onView(ViewMatchers.withText("Close All Tabs"))
 private fun closeAllPrivateTabsButton() = onView(ViewMatchers.withText("Close Private Tabs"))
-
-private fun assertCloseAllTabsButton() = closeAllTabsButton()
-        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertCloseAllTabsButton() {
+    val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    mDevice.wait(Until.findObject(By.res("Close All Tabs")), TestAssetHelper.waitingTime)
+}
 private fun assertCloseAllPrivateTabsButton() = closeAllPrivateTabsButton()
         .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
@@ -17,6 +17,9 @@ import androidx.test.uiautomator.UiDevice
 import org.mozilla.reference.browser.helpers.click
 import org.mozilla.reference.browser.R
 
+/**
+ * Implementation of Robot Pattern for three dot menu.
+ */
 class ThreeDotMenuRobot {
 
     fun verifyThreeDotMenuExists() = threeDotMenuRecyclerViewExists()

--- a/automation/taskcluster/androidTest/flank-arm.yml
+++ b/automation/taskcluster/androidTest/flank-arm.yml
@@ -1,0 +1,56 @@
+# gcloud args match the official gcloud cli
+# https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
+gcloud:
+  results-bucket: reference-browser_test_artifacts
+  record-video: true
+
+  # The maximum possible testing time is 30m on physical devices and 60m on virtual devices.
+  timeout: 30m
+  # will start test then close socket. no reports will be generated.
+  # to retrieve results later, use the "refresh" command
+  # reports will be generated from /results/matrix_ids.json
+  #async: true 
+  # will start test then leave socket open. reports will be published
+  # to /results
+  # see: https://github.com/TestArmada/flank/issues/339
+  async: false 
+
+  # results-history-name
+  # by default, set to app name
+  # declare results-history-name to create a separate dropdown menu in Firebase 
+  # see: https://github.com/TestArmada/flank/issues/341
+  #results-history-name: tmp_parallel 
+
+  # test and app are the only required args
+  app: /APP/PATH
+  test: /TEST/PATH
+
+  auto-google-login: true
+  use-orchestrator: true
+  environment-variables:
+    clearPackageData: true
+  directories-to-pull:
+    - /sdcard/screenshots
+  performance-metrics: true
+
+  device:
+   - model: shamu
+     version: 21
+   - model: sailfish 
+     version: 25
+   - model: sailfish 
+     version: 28
+
+flank:
+  project: GOOGLE_PROJECT
+  # test shards - the amount of groups to split the test suite into
+  # set to -1 to use one shard per test.
+  max-test-shards: -1 
+  # repeat tests - the amount of times to run the tests.
+  # 1 runs the tests once. 10 runs all the tests 10x
+  repeat-tests: 1
+  # always run - these tests are inserted at the beginning of every shard
+  # useful if you need to grant permissions or login before other tests run
+  #test-targets-always-run:
+    #- class com.example.app.ExampleUiTest#testPasses
+    # - class org.mozilla.focus.activty.SwitchContextTest#testPasses

--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -1,0 +1,52 @@
+# gcloud args match the official gcloud cli
+# https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
+gcloud:
+  results-bucket: reference-browser_test_artifacts
+  record-video: true
+
+  # The maximum possible testing time is 30m on physical devices and 60m on virtual devices.
+  timeout: 30m
+  # will start test then close socket. no reports will be generated.
+  # to retrieve results later, use the "refresh" command
+  # reports will be generated from /results/matrix_ids.json
+  #async: true 
+  # will start test then leave socket open. reports will be published
+  # to /results
+  # see: https://github.com/TestArmada/flank/issues/339
+  async: false 
+
+  # results-history-name
+  # by default, set to app name
+  # declare results-history-name to create a separate dropdown menu in Firebase 
+  # see: https://github.com/TestArmada/flank/issues/341
+  #results-history-name: tmp_parallel 
+
+  # test and app are the only required args
+  app: /app/path 
+  test: /test/path
+
+  auto-google-login: true
+  use-orchestrator: true
+  environment-variables:
+    clearPackageData: true
+  directories-to-pull:
+    - /sdcard/screenshots
+  performance-metrics: true
+
+  device:
+   - model: Nexus7
+     version: 21
+
+flank:
+  project: GOOGLE_PROJECT
+  # test shards - the amount of groups to split the test suite into
+  # set to -1 to use one shard per test.
+  max-test-shards: -1 
+  # repeat tests - the amount of times to run the tests.
+  # 1 runs the tests once. 10 runs all the tests 10x
+  repeat-tests: 1
+  # always run - these tests are inserted at the beginning of every shard
+  # useful if you need to grant permissions or login before other tests run
+  #test-targets-always-run:
+    #- class com.example.app.ExampleUiTest#testPasses
+    # - class org.mozilla.focus.activty.SwitchContextTest#testPasses

--- a/automation/taskcluster/androidTest/ui-test.sh
+++ b/automation/taskcluster/androidTest/ui-test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This script does the following:
+# 1. Retrieves glcoud service account token
+# 2. Activates gcloud service account
+# 3. Connects to google Firebase (using TestArmada's Flank tool)
+# 4. Executes UI tests
+# 5. Puts test artifacts into the test_artifacts folder
+
+# NOTE:
+# Flank supports sharding across multiple devices at a time, but gcloud API
+# only supports 1 defined APK per test run.
+
+
+# If a command fails then do not proceed and fail this script too.
+set -e
+
+#########################
+# The command line help #
+#########################
+display_help() {
+    echo "Usage: $0 Build_Variant [Number_Shards...]"
+    echo
+    echo "Examples:"
+    echo "To run UI tests on ARM device shard (1 test / shard)"
+    echo "$ ui-test.sh component arm"
+    echo
+    echo "To run UI tests on X86 device (on 3 shards)"
+    echo "$ ui-test.sh x86 3"
+    echo
+}
+
+# Basic parameter check
+if [[ $# -lt 1 ]]; then
+    echo "Your command line contains $# arguments"
+    display_help
+    exit 1
+fi
+
+device_type="$1"  # arm | x86
+if [[ ! -z "$2" ]]; then
+    num_shards=$2
+fi
+
+JAVA_BIN="/usr/bin/java"
+PATH_TEST="./automation/taskcluster/androidTest"
+FLANK_BIN="/build/test-tools/flank.jar"
+FLANK_CONF_ARM="${PATH_TEST}/flank-arm.yml"
+FLANK_CONF_X86="${PATH_TEST}/flank-x86.yml"
+
+echo
+echo "RETRIEVE SERVICE ACCT TOKEN"
+echo
+python automation/taskcluster/helper/get-secret.py -s project/mobile/reference-browser/firebase -k firebaseToken  -f $GOOGLE_APPLICATION_CREDENTIALS 
+echo
+echo
+
+echo
+echo "ACTIVATE SERVICE ACCT"
+echo
+# this is where the Google Testcloud project ID is set
+gcloud config set project "$GOOGLE_PROJECT" 
+echo
+
+gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS" 
+echo
+echo
+
+# From now on disable exiting on error. If the tests fail we want to continue
+# and try to download the artifacts. We will exit with the actual error code later.
+set +e
+
+if [[ "${device_type,,}" == "x86" ]]
+then
+    deviceType="X86"
+    flank_template="$FLANK_CONF_X86"
+else
+    deviceType="Arm"
+    flank_template="$FLANK_CONF_ARM"
+fi
+
+APK_APP="./app/build/outputs/apk/${deviceType,,}/debug/app-${deviceType,,}-debug.apk"
+APK_TEST="./app/build/outputs/apk/androidTest/${deviceType,,}/debug/app-${deviceType,,}-debug-androidTest.apk"
+
+# keep running script on failure, so we can capture the failure and do some
+# final output
+set +e
+# function to exit script with exit code from test run.
+# (Only 0 if all test executions passed)
+function failure_check() {
+    if [[ $exitcode -ne 0 ]]; then
+        echo
+        echo
+	echo "ERROR: UI test run failed, please check above URL"
+    fi
+    exit $exitcode
+}
+
+echo
+echo "EXECUTE TEST(S)"
+echo
+$JAVA_BIN -jar $FLANK_BIN android run --config=$flank_template --max-test-shards=$num_shards --app=$APK_APP --test=$APK_TEST --project=$GOOGLE_PROJECT
+exitcode=$?
+echo
+echo
+failure_check
+echo
+echo
+
+echo
+echo "COPY ARTIFACTS"
+echo
+cp -r "./results" "./test_artifacts"
+exitcode=$?
+failure_check
+echo
+echo
+
+echo
+echo "RESULTS"
+echo
+ls -la ./results
+echo 
+echo
+
+echo
+echo "RESULTS"
+echo
+ls -la ./test_results
+
+echo "All UI test(s) have passed!"
+echo
+echo

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -50,7 +50,7 @@ BUILDER = TaskBuilder(
 )
 
 
-def pr_or_push():
+def pr():
     if SKIP_TASKS_TRIGGER in PR_TITLE:
         print("Pull request title contains", SKIP_TASKS_TRIGGER)
         print("Exit")
@@ -74,6 +74,13 @@ def pr_or_push():
         other_tasks[taskcluster.slugId()] = craft_function()
 
     return (build_tasks, signing_tasks, other_tasks)
+
+
+def push():
+    all_tasks = pr()
+    other_tasks = all_tasks[-1]
+    other_tasks[taskcluster.slugId()] = BUILDER.craft_ui_tests_task()
+    return all_tasks 
 
 
 def raptor(is_staging):
@@ -154,8 +161,10 @@ if __name__ == "__main__":
 
     command = result.command
 
-    if command in ('pull-request', 'push'):
-        ordered_groups_of_tasks = pr_or_push()
+    if command in ('pull-request'):
+        ordered_groups_of_tasks = pr()
+    elif command in ('push'):
+        ordered_groups_of_tasks = push()
     elif command == 'raptor':
         ordered_groups_of_tasks = raptor(result.staging)
     elif command == 'nightly':

--- a/automation/taskcluster/helper/get-secret.py
+++ b/automation/taskcluster/helper/get-secret.py
@@ -5,6 +5,7 @@
 import argparse
 import base64
 import os
+import json
 import taskcluster
 
 def write_secret_to_file(path, data, key, base64decode=False, append=False, prefix=''):
@@ -13,7 +14,12 @@ def write_secret_to_file(path, data, key, base64decode=False, append=False, pref
         value = data['secret'][key]
         if base64decode:
             value = base64.b64decode(value)
-        f.write(prefix + value)
+
+        try:
+            json_string = json.dumps(value)
+            f.write(prefix + json_string)
+        except ValueError as e:
+            f.write(prefix + value)
 
 
 def fetch_secret_from_taskcluster(name):


### PR DESCRIPTION
This pull request enables UI test automation to be run via taskcluster job on github "push."
UI tests run asyncronously on individual shards and should each complete in under 1 minute.  However, since we are running our tests on Firebase ARM devices, occasionally there can be user traffic jams on a given API and the entire run may go on as long as 15 minutes.

To view test results, wait for taskcluster UI test task to complete.  If task is marked fail, results can be best viewed in the Firebase dashboard.

NOTE:
I've worked out most of the test flakiness.  Please file a separate issue for any flaky test and fix test or disable to prevent builds from being perma-red.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [x] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
