### PR TITLE
Closes #736: Show snackbar on the parent view

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
@@ -95,7 +95,7 @@ class BrowserFragment : Fragment(), BackHandler, UserInteractionHandler {
                 requireFragmentManager(),
                 requireComponents.core.sessionManager,
                 requireComponents.useCases.tabsUseCases,
-                view,
+                view.parent as View,
                 sessionId),
             owner = this,
             view = view)


### PR DESCRIPTION
This isn't the ideal fix since it would probably be better if we could put the snackbar on top of the toolbar, but that seems to be non-trivial. This change fixes the functionality for now:

<img width="649" alt="Screen Shot 2019-06-05 at 11 30 44 AM" src="https://user-images.githubusercontent.com/1370580/58969484-c9598c80-8785-11e9-964e-0dae75e1da3d.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [x] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
