### PR TITLE
Keep all version info together on About page

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/settings/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/AboutFragment.kt
@@ -40,10 +40,10 @@ class AboutFragment : Fragment() {
 
         val aboutText = try {
             val packageInfo = requireContext().packageManager.getPackageInfo(requireContext().packageName, 0)
-            val geckoVersion = PackageInfoCompat.getLongVersionCode(packageInfo).toString() + " \uD83E\uDD8E " +
+            val geckoVersion = PackageInfoCompat.getLongVersionCode(packageInfo).toString() + " GV: " +
                 MOZ_APP_VERSION + "-" + MOZ_APP_BUILDID
             String.format(
-                "%s (Build #%s)",
+                "%s (Build #%s)\n",
                 packageInfo.versionName,
                 geckoVersion
             )
@@ -51,22 +51,27 @@ class AboutFragment : Fragment() {
             ""
         }
 
-        val versionInfo =
-            "\uD83D\uDCE6: ${Build.version}, ${Build.gitHash}\n\uD83D\uDEA2: ${Build.applicationServicesVersion}"
+        val versionInfo = String.format(
+            "%s \uD83D\uDCE6: %s, %s\n\uD83D\uDEA2: %s",
+            aboutText,
+            Build.version,
+            Build.gitHash,
+            Build.applicationServicesVersion
+        )
         val content = HtmlCompat.fromHtml(
             resources.getString(R.string.about_content, appName),
             FROM_HTML_SEPARATOR_LINE_BREAK_LIST_ITEM
         )
 
-        about_text.text = aboutText
         about_content.text = content
         version_info.text = versionInfo
 
-        version_info.setOnClickListener {
+        version_info.setOnTouchListener { _, _ ->
             val clipBoard = requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
             clipBoard.primaryClip = ClipData.newPlainText(versionInfo, versionInfo)
 
             Toast.makeText(requireContext(), getString(R.string.toast_copied), Toast.LENGTH_SHORT).show()
+            true
         }
     }
 }

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -12,18 +12,6 @@
     tools:context="org.mozilla.reference.browser.settings.AboutFragment">
 
     <TextView
-        android:id="@+id/about_text"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:textAlignment="center"
-        android:textSize="16sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_percent="0.8" />
-
-    <TextView
         android:id="@+id/about_content"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -32,8 +20,7 @@
         android:textSize="12sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/about_text"
-        app:layout_constraintWidth_percent="0.8" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/version_info"
@@ -45,7 +32,6 @@
         android:textIsSelectable="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/about_content"
-        app:layout_constraintWidth_percent="0.8" />
+        app:layout_constraintTop_toBottomOf="@id/about_content" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Can't find a good reason to leave these version numbers separate. They can both be easily copied together for reporting bugs now! 🙌 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [x] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
