### PR TITLE
Add "Add to homescreen" menu option

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -233,6 +233,7 @@ dependencies {
     implementation Deps.mozilla_feature_tabs
     implementation Deps.mozilla_feature_downloads
     implementation Deps.mozilla_feature_prompts
+    implementation Deps.mozilla_feature_pwa
     implementation Deps.mozilla_feature_qr
     implementation Deps.mozilla_feature_readerview
 

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
@@ -85,6 +85,7 @@ class BrowserFragment : Fragment(), BackHandler, UserInteractionHandler {
                 requireComponents.core.sessionManager,
                 requireComponents.useCases.sessionUseCases,
                 requireComponents.useCases.tabsUseCases,
+                requireComponents.useCases.webAppUseCases,
                 sessionId),
             owner = this,
             view = view)
@@ -249,19 +250,12 @@ class BrowserFragment : Fragment(), BackHandler, UserInteractionHandler {
         }
     }
 
-    @Suppress("ReturnCount")
     override fun onBackPressed(): Boolean {
-        return backButtonHandler.firstOrNull { it.onBackPressed() } != null
+        return backButtonHandler.any { it.onBackPressed() }
     }
 
     override fun onHomePressed(): Boolean {
-        var handled = false
-
-        pictureInPictureIntegration.withFeature {
-            handled = it.onHomePressed()
-        }
-
-        return handled
+        return pictureInPictureIntegration.get()?.onHomePressed() ?: false
     }
 
     override fun onPictureInPictureModeChanged(enabled: Boolean) {

--- a/app/src/main/java/org/mozilla/reference/browser/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/UseCases.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Settings
+import mozilla.components.feature.pwa.WebAppUseCases
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.session.SettingsUseCases
@@ -42,4 +43,9 @@ class UseCases(
      * Use cases that provide settings management.
      */
     val settingsUseCases by lazy { SettingsUseCases(engineSettings, sessionManager) }
+
+    /**
+     * Use cases that provide shortcut and progressive web app management.
+     */
+    val webAppUseCases by lazy { WebAppUseCases(context, sessionManager) }
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -71,6 +71,7 @@ object Deps {
     const val mozilla_feature_downloads = "org.mozilla.components:feature-downloads:${Versions.mozilla_android_components}"
     const val mozilla_feature_storage = "org.mozilla.components:feature-storage:${Versions.mozilla_android_components}"
     const val mozilla_feature_prompts = "org.mozilla.components:feature-prompts:${Versions.mozilla_android_components}"
+    const val mozilla_feature_pwa = "org.mozilla.components:feature-pwa:${Versions.mozilla_android_components}"
     const val mozilla_feature_qr = "org.mozilla.components:feature-qr:${Versions.mozilla_android_components}"
     const val mozilla_feature_readerview = "org.mozilla.components:feature-readerview:${Versions.mozilla_android_components}"
 


### PR DESCRIPTION
When used, this option creates a shortcut on the user's homescreen. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
