### PR TITLE
Removes ABI flavour and uses APK splitting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,7 @@ apply from: "$project.rootDir/automation/gradle/versionCode.gradle"
 apply plugin: 'org.mozilla.appservices'
 
 import com.android.build.gradle.internal.tasks.AppPreBuildTask
+import com.android.build.OutputFile
 
 appservices {
     defaultConfig {
@@ -68,36 +69,6 @@ android {
         execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
 
-    flavorDimensions "abi"
-
-    productFlavors {
-        // Processor architectures
-        arm {
-            dimension "abi"
-            ndk {
-                abiFilter "armeabi-v7a"
-            }
-        }
-        aarch64 {
-            dimension "abi"
-            ndk {
-                abiFilter "arm64-v8a"
-            }
-        }
-        x86 {
-            dimension "abi"
-            ndk {
-                abiFilter "x86"
-            }
-        }
-        x86_64 {
-            dimension "abi"
-            ndk {
-                abiFilter "x86_64"
-            }
-        }
-    }
-
     lintOptions {
         lintConfig file("lint.xml")
     }
@@ -110,7 +81,19 @@ android {
     packagingOptions {
         exclude 'META-INF/atomicfu.kotlin_module'
     }
+
+    splits {
+        abi {
+            enable true
+
+            reset()
+
+            include "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
+        }
+    }
 }
+
+def baseVersionCode = generatedVersionCode
 
 android.applicationVariants.all { variant ->
 
@@ -149,11 +132,7 @@ if (project.hasProperty("telemetry") && project.property("telemetry") == "true")
 // -------------------------------------------------------------------------------------------------
 // Generating version codes for Google Play
 // -------------------------------------------------------------------------------------------------
-    def buildType = variant.buildType.name
-
     if (variant.buildType.buildConfigFields['IS_RELEASED']?.value) {
-        def versionCode = generatedVersionCode
-
         // The Google Play Store does not allow multiple APKs for the same app that all have the
         // same version code. Therefore we need to have different version codes for our ARM and x86
         // builds.
@@ -161,17 +140,29 @@ if (project.hasProperty("telemetry") && project.property("telemetry") == "true")
         // Our x86 builds need a higher version code to avoid installing ARM builds on an x86 device
         // with ARM compatibility mode.
 
-        if (variant.flavorName.contains("x86_64")) {
-            versionCode = versionCode + 3
-	} else if (variant.flavorName.contains("x86")) {
-            versionCode = versionCode + 2
-        } else if (variant.flavorName.contains("aarch64")) {
-            versionCode = versionCode + 1
-        }
+        def versionName = Config.releaseVersionName(project)
 
-        variant.outputs.all { output ->
-            versionCodeOverride = versionCode
-            versionNameOverride = Config.releaseVersionName(project)
+        variant.outputs.each { output ->
+            def abi = output.getFilter(OutputFile.ABI)
+
+            def versionCodeOverride
+
+            if (abi == "x86_64") {
+                versionCodeOverride = baseVersionCode + 3
+            } else if (abi == "x86") {
+                versionCodeOverride = baseVersionCode + 2
+            } else if (abi == "arm64-v8a") {
+                versionCodeOverride = baseVersionCode + 1
+            } else if (abi == "armeabi-v7a") {
+                versionCodeOverride = baseVersionCode
+            } else {
+                throw RuntimeException("Unknown ABI: $abi")
+            }
+
+            println("versionCode for $abi = $versionCodeOverride")
+
+            output.versionNameOverride = versionName
+            output.versionCodeOverride = versionCodeOverride
         }
 
         // If this is a release build, validate that "versionName" is set

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,7 +84,7 @@ android {
 
     splits {
         abi {
-            enable true
+            enable !project.hasProperty("skipSplitApk")
 
             reset()
 
@@ -145,7 +145,7 @@ if (project.hasProperty("telemetry") && project.property("telemetry") == "true")
         variant.outputs.each { output ->
             def abi = output.getFilter(OutputFile.ABI)
 
-            def versionCodeOverride
+            def versionCodeOverride = baseVersionCode
 
             if (abi == "x86_64") {
                 versionCodeOverride = baseVersionCode + 3
@@ -155,8 +155,6 @@ if (project.hasProperty("telemetry") && project.property("telemetry") == "true")
                 versionCodeOverride = baseVersionCode + 1
             } else if (abi == "armeabi-v7a") {
                 versionCodeOverride = baseVersionCode
-            } else {
-                throw RuntimeException("Unknown ABI: $abi")
             }
 
             println("versionCode for $abi = $versionCodeOverride")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -279,17 +279,19 @@ dependencies {
 }
 
 // -------------------------------------------------------------------------------------------------
-// Task for printing all vuild variants to build variants in parallel in automation
+// Task for printing APK information for the requested variant
+// Usage: "./gradlew printVariant -PvariantBuildType=nightly"
 // -------------------------------------------------------------------------------------------------
-task printBuildVariants {
+task printVariant {
     doLast {
-        def variantData = android.applicationVariants.collect { variant -> [
-            name: variant.name,
-            buildType: variant.buildType.name,
-            abi: variant.productFlavors.find { it.dimension == 'abi' }.name,
-            isSigned: variant.signingReady,
-        ]}
-        println "variants: " + groovy.json.JsonOutput.toJson(variantData)
+        def rawVariant = android.applicationVariants.find { it.buildType.name == variantBuildType }
+        println "variant: " + groovy.json.JsonOutput.toJson([
+            name: rawVariant.name,
+            apks: rawVariant.variantData.outputScope.apkDatas.collect { [
+                abi: it.filters.find { it.filterType == 'ABI' }.identifier,
+                fileName: it.outputFileName
+            ] }
+        ])
     }
 }
 

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -115,7 +115,7 @@ class TaskBuilder(object):
         return self._craft_clean_gradle_task(
             name='test: {}'.format(variant.name),
             description='Building and testing variant {}'.format(variant.name),
-            gradle_task='test{}UnitTest'.format(variant.build_type),
+            gradle_task='test{}UnitTest -PskipSplitApk'.format(variant.build_type),
             treeherder={
                 'groupSymbol': variant.build_type,
                 'jobKind': 'test',

--- a/automation/taskcluster/lib/variant.py
+++ b/automation/taskcluster/lib/variant.py
@@ -1,20 +1,19 @@
-class Variant:
-    def __init__(self, raw, abi, is_signed, build_type):
-        self.raw = raw
+class VariantApk:
+    def __init__(self, abi, file_name):
         self.abi = abi
-        self.build_type = build_type
-        self._is_signed = is_signed
-        self.for_gradle_command = raw[:1].upper() + raw[1:]
-        self.platform = 'android-{}-{}'.format(self.abi, self.build_type)
+        self._file_name = file_name
+        self.taskcluster_path = 'public/target.{}.apk'.format(abi)
 
-    def apk_absolute_path(self):
-        return '/build/reference-browser/app/build/outputs/apk/{abi}/{build_type}/app-{abi}-{build_type}{unsigned}.apk'.format(
-            build_type=self.build_type,
-            abi=self.abi,
-            unsigned='' if self._is_signed else '-unsigned',
+    def absolute_path(self, build_type):
+        return '/build/reference-browser/app/build/outputs/apk/{build_type}/{file_name}'.format(
+            build_type=build_type,
+            file_name=self._file_name
         )
 
-    @staticmethod
-    def from_values(abi, is_signed, build_type):
-        raw = abi + build_type[:1].upper() + build_type[1:]
-        return Variant(raw, abi, is_signed, build_type)
+
+class Variant:
+    def __init__(self, name, build_type, apks):
+        self.name = name
+        self.build_type = build_type
+        self.apks = apks
+        self.taskcluster_apk_paths = ['public/target.{}.apk'.format(apk.abi) for apk in apks]


### PR DESCRIPTION
Previous discussion [here](https://github.com/mozilla-mobile/reference-browser/pull/814)

This PR:
* Modifies `gradle` config to do apk splitting instead of representing each architecture with flavours
* Updates automation to no longer distribute tasks by ABI (APK splitting should be done at once, and it no longer makes sense to parallelize signing and pushing if the build is a single task)
* Updates automation to no longer manually determine apk file names - just ask gradle instead!

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [x] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
- [x] [Passed staging nightly](https://tools.taskcluster.net/groups/bToChvB0TLSvHbsHOjzYKQ) (nimbledroid failed, but that's a separate issue - it shouldn't have been scheduled for a staging run)
- [x] [Passed staging raptor](https://tools.taskcluster.net/groups/Ku9OMBoWRL2UG7qi-qystw)
