### PR TITLE
Resolves tasks not being reported to treeherder

### DIFF
--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -46,7 +46,7 @@ BUILDER = TaskBuilder(
     scheduler_id=os.environ.get('SCHEDULER_ID', 'taskcluster-github'),
     tasks_priority=os.environ.get('TASKS_PRIORITY'),
     date_string=os.environ.get('BUILD_DATE'),
-    trust_level=os.environ.get('TRUST_LEVEL'),
+    trust_level=int(os.environ.get('TRUST_LEVEL')),
 )
 
 


### PR DESCRIPTION
Fixes #820.
I'm not really happy with passing values via environment variables for 2 reasons: they can implicitly affect logic deep in a library (they're globals), and the conventions for parsing them aren't as strong (`argparse` makes CLI arguments way more ergonomic than passing by environment).

We got bit by that second reason here, and this PR fixes this specific symptom

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [x] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
