### PR TITLE
Add transparent experiment to test service-experiments integration.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -19,3 +19,19 @@ toolbar.events:
       - tlong@mozilla.com
       - aplacitelli@mozilla.com
     expires: 2019-10-01
+experiments.metrics:
+  active_experiment:
+    type: string
+    description: >
+      Records the branch name of the active experiment, if the client is enrolled in any experiments.
+      This is intended to validate that the service-experiments library properly matches clients to
+      experiments and can take action based on a multi-branched experiment. This is done by recording
+      the experiment branch name in this string metric which allows the experiment to be transparent
+      and unobtrusive to the user.
+    bugs:
+      - 1556751
+    data_reviews:
+      - TBD
+    notification_emails:
+      - tlong@mozilla.com
+    expires: 2019-10-01

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -23,11 +23,11 @@ experiments.metrics:
   active_experiment:
     type: string
     description: >
-      Records the branch name of the active experiment, if the client is enrolled in any experiments.
-      This is intended to validate that the service-experiments library properly matches clients to
-      experiments and can take action based on a multi-branched experiment. This is done by recording
-      the experiment branch name in this string metric which allows the experiment to be transparent
-      and unobtrusive to the user.
+      Records the branch name of the active experiment, if the client is enrolled in the
+      `reference-browser-test` experiment. This is intended to validate that the service-experiments
+      library properly matches clients to experiments and can take action based on a multi-branched
+      experiment. This is done by recording the experiment branch name in this string metric which
+      allows the experiment to be transparent and unobtrusive to the user.
     bugs:
       - 1556751
     data_reviews:

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -31,7 +31,7 @@ experiments.metrics:
     bugs:
       - 1556751
     data_reviews:
-      - TBD
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1556751#c6
     notification_emails:
       - tlong@mozilla.com
     expires: 2019-10-01

--- a/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
@@ -86,10 +86,8 @@ private fun setupGlean(context: Context) {
     // following code will not be executed as this only gets called on startup, so it will be on
     // the next application launch following enrollment that the code below will be executed and the
     // metric recorded.
-    Experiments.withExperiment("reference-browser-test") {
-        // If we match the 'reference-browser-test' experiment, 'it' will be the branch name that
-        // we were enrolled in.
-        ExperimentsMetrics.activeExperiment.set(it)
+    Experiments.withExperiment("reference-browser-test") { branchName ->
+        ExperimentsMetrics.activeExperiment.set(branchName)
     }
 }
 


### PR DESCRIPTION
This is intended to validate that the service-experiments library properly matches clients to experiments and can take action based on a multi-branched experiment. This is done by recording the experiment branch name in this string metric which allows the experiment to be transparent and unobtrusive to the user.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
