### PR TITLE
Add GleanCrashReporterService

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
@@ -71,8 +71,8 @@ private fun setupLogging(megazordEnabled: Boolean) {
 }
 
 private fun setupGlean(context: Context) {
-    Glean.initialize(context, Configuration(httpClient = lazy { context.components.core.client }))
     Glean.setUploadEnabled(BuildConfig.TELEMETRY_ENABLED && Settings.isTelemetryEnabled(context))
+    Glean.initialize(context, Configuration(httpClient = lazy { context.components.core.client }))
     GleanFactProcessor().register()
     Experiments.initialize(
         context,

--- a/app/src/main/java/org/mozilla/reference/browser/components/Analytics.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Analytics.kt
@@ -8,6 +8,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import mozilla.components.lib.crash.CrashReporter
+import mozilla.components.lib.crash.service.GleanCrashReporterService
 import mozilla.components.lib.crash.service.MozillaSocorroService
 import mozilla.components.lib.crash.service.SentryService
 import org.mozilla.geckoview.BuildConfig.MOZ_APP_BUILDID
@@ -35,8 +36,10 @@ class Analytics(private val context: Context) {
 
         val socorroService = MozillaSocorroService(context, "ReferenceBrowser")
 
+        val gleanCrashReporter = GleanCrashReporterService(context)
+
         CrashReporter(
-            services = listOf(sentryService, socorroService),
+            services = listOf(sentryService, socorroService, gleanCrashReporter),
             shouldPrompt = CrashReporter.Prompt.ALWAYS,
             promptConfiguration = CrashReporter.PromptConfiguration(
                 appName = context.getString(R.string.app_name),


### PR DESCRIPTION
This adds a `GleanCrashReporterService` to the registered `CrashReporters` in order to record crash counts into Glean.

Since this adds to the data that is collected, data review will be required.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
