### PR TITLE
Reverts "skipSplit" property and instead disables testing binary resources

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,7 +84,7 @@ android {
 
     splits {
         abi {
-            enable !project.hasProperty("skipSplitApk")
+            enable true
 
             reset()
 

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -115,7 +115,7 @@ class TaskBuilder(object):
         return self._craft_clean_gradle_task(
             name='test: {}'.format(variant.name),
             description='Building and testing variant {}'.format(variant.name),
-            gradle_task='test{}UnitTest -PskipSplitApk'.format(variant.build_type),
+            gradle_task='test{}UnitTest'.format(variant.build_type),
             treeherder={
                 'groupSymbol': variant.build_type,
                 'jobKind': 'test',

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,5 @@ org.gradle.parallel=true
 android.useAndroidX=true
 android.enableJetifier=true
 
+# TODO resolve `./gradlew test` failing when the following isn't set
+android.enableUnitTestBinaryResources=false


### PR DESCRIPTION
Fixes #837

The `-PskipSplitApk` technique didn't work for nightly builds, where we test and build in a single command (`./gradlew test assembleNightly`), and it isn't ideal to change that chunk into multiple commands.

The only online posts I found that ran into the same issue (`expected one element but was: <BuildOutput ...>`) were related to RoboElectric, but we're not using it :thinking: 
Interesting, disabling testing binary resources with `android.enableUnitTestBinaryResources=false` solves the build tools error.

FWIW, I tried updating the Android Gradle plugin to `3.4.2` and `gradle` to `5.5.1`, but the problem remains.
Adding the flag to `gradle.properties` wasn't required for a project I created and quickly added APK splitting for, so there's definitely something in our `reference-browser` config that's triggering the issue.
For now, I think we should add the flag to `gradle.properties` so things "just work", but it's worth having a `gradle`-proficient `reference-browser`-er to take a closer look.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [x] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
