### PR TITLE
Move Glean init and Experiments init to the Analytics component

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
@@ -5,22 +5,13 @@
 package org.mozilla.reference.browser
 
 import android.app.Application
-import android.content.Context
-import mozilla.components.service.glean.Glean
-import mozilla.components.service.glean.config.Configuration
-import mozilla.components.service.experiments.Experiments
-import mozilla.components.service.experiments.Configuration as ExperimentsConfiguration
-import mozilla.components.support.base.facts.register
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.sink.AndroidLogSink
 import mozilla.components.support.ktx.android.content.isMainProcess
 import mozilla.components.support.ktx.android.content.runOnlyInMainProcess
 import mozilla.components.support.rustlog.RustLog
 import mozilla.components.support.rusthttp.RustHttpConfig
-import org.mozilla.reference.browser.ext.components
 import org.mozilla.reference.browser.ext.isCrashReportActive
-import org.mozilla.reference.browser.settings.Settings
-import org.mozilla.reference.browser.telemetry.GleanFactProcessor
 
 open class BrowserApplication : Application() {
     val components by lazy { Components(this) }
@@ -43,8 +34,8 @@ open class BrowserApplication : Application() {
 
         components.core.engine.warmUp()
 
-        setupGlean(this)
-        setupExperiments(this)
+        components.analytics.initializeGlean()
+        components.analytics.initializeExperiments()
     }
 
     override fun onTrimMemory(level: Int) {
@@ -63,19 +54,6 @@ private fun setupLogging() {
     // We want the log messages of all builds to go to Android logcat
     Log.addSink(AndroidLogSink())
     RustLog.enable()
-}
-
-private fun setupGlean(context: Context) {
-    Glean.setUploadEnabled(BuildConfig.TELEMETRY_ENABLED && Settings.isTelemetryEnabled(context))
-    Glean.initialize(context, Configuration(httpClient = lazy { context.components.core.client }))
-    GleanFactProcessor().register()
-}
-
-private fun setupExperiments(context: Context) {
-    Experiments.initialize(
-        context,
-        ExperimentsConfiguration(httpClient = lazy { context.components.core.client })
-    )
 }
 
 private fun setupCrashReporting(application: BrowserApplication) {

--- a/app/src/main/java/org/mozilla/reference/browser/components/Analytics.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Analytics.kt
@@ -11,11 +11,18 @@ import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.service.GleanCrashReporterService
 import mozilla.components.lib.crash.service.MozillaSocorroService
 import mozilla.components.lib.crash.service.SentryService
+import mozilla.components.service.experiments.Experiments
+import mozilla.components.service.glean.Glean
+import mozilla.components.service.glean.config.Configuration
+import mozilla.components.support.base.facts.register
 import org.mozilla.geckoview.BuildConfig.MOZ_APP_BUILDID
 import org.mozilla.geckoview.BuildConfig.MOZ_APP_VERSION
 import org.mozilla.reference.browser.BrowserApplication
 import org.mozilla.reference.browser.BuildConfig
 import org.mozilla.reference.browser.R
+import org.mozilla.reference.browser.ext.components
+import org.mozilla.reference.browser.settings.Settings
+import org.mozilla.reference.browser.telemetry.GleanFactProcessor
 
 /**
  * Component group for all functionality related to analytics e.g. crash
@@ -48,6 +55,19 @@ class Analytics(private val context: Context) {
             nonFatalCrashIntent = PendingIntent
                 .getBroadcast(context, 0, Intent(BrowserApplication.NON_FATAL_CRASH_BROADCAST), 0),
             enabled = true
+        )
+    }
+
+    internal fun initializeGlean() {
+        Glean.setUploadEnabled(BuildConfig.TELEMETRY_ENABLED && Settings.isTelemetryEnabled(context))
+        Glean.initialize(context, Configuration(httpClient = lazy { context.components.core.client }))
+        GleanFactProcessor().register()
+    }
+
+    internal fun initializeExperiments() {
+        Experiments.initialize(
+            context,
+            mozilla.components.service.experiments.Configuration(httpClient = lazy { context.components.core.client })
         )
     }
 }


### PR DESCRIPTION
This moves the Glean initialization and the Experiments initialization to the Analytics component which looks like is where they belong.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
