### PR TITLE
Generate dependencies list as an artifact

### DIFF
--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -73,6 +73,8 @@ def pr():
     ):
         other_tasks[taskcluster.slugId()] = craft_function()
 
+    other_tasks[taskcluster.slugId()] = BUILDER.craft_dependencies_task()
+
     return (build_tasks, signing_tasks, other_tasks)
 
 
@@ -136,6 +138,7 @@ def nightly(is_staging):
     push_tasks[push_task_id] = BUILDER.craft_push_task(signing_task_id, variant, is_staging)
 
     other_tasks[taskcluster.slugId()] = BUILDER.craft_upload_apk_nimbledroid_task(assemble_task_id)
+    other_tasks[taskcluster.slugId()] = BUILDER.craft_dependencies_task()
 
     return (build_tasks, signing_tasks, push_tasks, other_tasks)
 

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -185,6 +185,35 @@ class TaskBuilder(object):
             treeherder=treeherder,
         )
 
+    def craft_dependencies_task(self):
+        # Output the dependencies to an artifact.  This is used by the
+        # telemetry probe scraper to determine all of the metrics that
+        # &browser might send (both from itself and any of its dependent
+        # libraries that use Glean).
+        return self._craft_clean_gradle_task(
+            name='dependencies',
+            description='Write dependencies to a build artifact',
+            gradle_task='app:dependencies --configuration implementation > dependencies.txt',
+            treeherder={
+                'jobKind': 'test',
+                'machine': {
+                    'platform': 'lint',
+                },
+                'symbol': 'dependencies',
+                'tier': 1,
+            },
+            routes=[
+                'index.project.mobile.reference-browser.v2.branch.master.revision.{}'.format(self.commit)
+            ],
+            artifacts={
+                'public/dependencies.txt': {
+                    "type": 'file',
+                    "path": '/build/reference-browser/dependencies.txt',
+                    "expires": taskcluster.stringDate(taskcluster.fromNow(DEFAULT_EXPIRES_IN)),
+                }
+            },
+        )
+
     def craft_compare_locales_task(self):
         return self._craft_build_ish_task(
             name='compare-locales',


### PR DESCRIPTION
This fixes https://github.com/mozilla/probe-scraper/issues/96 and is a port of an analogous change in Fenix here: https://github.com/mozilla-mobile/fenix/pull/1996/files

This writes out the dependencies of the application as an artifact in treeherder so that the telemetry [probe-scraper](https://github.com/mozilla/probe-scraper) can determine all of the Glean metrics that the application emits.

(Until recently, reference-browser only collected metrics itself and from the Glean library. lib-crash -- merged recently -- is now a third-party library that also collects metrics.)

Cc: @fbertsch, @travis79 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
