### PR TITLE
Add engine warmup

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
@@ -43,6 +43,8 @@ open class BrowserApplication : Application() {
             return
         }
 
+        components.core.engine.warmUp()
+
         setupGlean(this)
     }
 


### PR DESCRIPTION
This is to ensure the engine is initialized on the main thread and ready-to-use by other components.