### PR TITLE
Closes #614: Process Custom Tab intent again if activity is recreated

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/CustomTabActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/CustomTabActivity.kt
@@ -4,4 +4,15 @@
 
 package org.mozilla.reference.browser
 
-class CustomTabActivity : BrowserActivity()
+import android.os.Bundle
+import org.mozilla.reference.browser.ext.components
+
+class CustomTabActivity : BrowserActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+
+        // If a Custom Tab is restored by the OS after low memory, we need to process the intent again.
+        components.utils.intentProcessor.process(intent)
+
+        super.onCreate(savedInstanceState)
+    }
+}


### PR DESCRIPTION
See https://github.com/mozilla-mobile/android-components/issues/3773#issuecomment-517043220 for a detailed explanation for this change.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [x] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
