### PR TITLE
Lazily load default search engine when intializing AwesomeBar

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
@@ -30,7 +30,8 @@ class BrowserFragment : BaseBrowserFragment(), BackHandler, UserInteractionHandl
 
         AwesomeBarFeature(awesomeBar, toolbar, engineView)
             .addSearchProvider(
-                requireComponents.search.searchEngineManager.getDefaultSearchEngine(requireContext()),
+                requireContext(),
+                requireComponents.search.searchEngineManager,
                 requireComponents.useCases.searchUseCases.defaultSearch,
                 requireComponents.core.client)
             .addSessionProvider(


### PR DESCRIPTION
This follows https://github.com/mozilla-mobile/android-components/pull/4089. We don't need to block on loading the search plugins when initializing the `BrowserFragment`.