### PR TITLE
Loads firebase secret from Taskcluster

### DIFF
--- a/taskcluster/ci/build-bundle/kind.yml
+++ b/taskcluster/ci/build-bundle/kind.yml
@@ -41,6 +41,9 @@ jobs:
                 - path: .sentry_token
                   key: dsn
                   name: project/mobile/reference-browser/sentry
+                - path: app/src/main/res/values/firebase.xml
+                  key: firebase
+                  name: project/mobile/reference-browser/firebase
     debug:
         run-on-tasks-for: [github-push, github-pull-request]
         run:

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -45,6 +45,9 @@ jobs:
                 - path: .sentry_token
                   key: dsn
                   name: project/mobile/reference-browser/sentry
+                - path: app/src/main/res/values/firebase.xml
+                  key: firebase
+                  name: project/mobile/reference-browser/firebase
     raptor:
         run-on-tasks-for: [github-push]
         run:


### PR DESCRIPTION
Thought I'd take an attempt at loading the Firebase credentials @mitchhentges :) (needed for https://github.com/mozilla-mobile/reference-browser/pull/865)

I think this might break sentry since the `secret_index` for sentry probably needs `/sentry` or that  secret is moved to the r-b base path.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
