### PR TITLE
Color the system bars in custom tabs

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/CustomTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/CustomTabsIntegration.kt
@@ -107,7 +107,9 @@ class CustomTabsIntegration(
         toolbar,
         sessionId,
         menuBuilder,
-        closeListener = { activity?.finish() })
+        window = activity?.window,
+        closeListener = { activity?.finish() }
+    )
 
     override fun start() {
         feature.start()


### PR DESCRIPTION
<img height="490" alt="Screen Shot 2019-08-19 at 1 24 48 PM" src="https://user-images.githubusercontent.com/1782266/63285881-bdf60780-c284-11e9-9965-1b1bb4b65f02.png">

Makes the status bar color match the toolbar color. Also allows the navigation bar color to be set.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
