### PR TITLE
Bug 1575019 - Remove dummy experiment

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -19,19 +19,3 @@ toolbar.events:
       - tlong@mozilla.com
       - aplacitelli@mozilla.com
     expires: 2019-10-01
-experiments.metrics:
-  active_experiment:
-    type: string
-    description: >
-      Records the branch name of the active experiment, if the client is enrolled in the
-      `reference-browser-test` experiment. This is intended to validate that the service-experiments
-      library properly matches clients to experiments and can take action based on a multi-branched
-      experiment. This is done by recording the experiment branch name in this string metric which
-      allows the experiment to be transparent and unobtrusive to the user.
-    bugs:
-      - 1556751
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1556751#c6
-    notification_emails:
-      - tlong@mozilla.com
-    expires: 2019-10-01


### PR DESCRIPTION
Due to the experiment ending, this removes the dummy A/A/A experiment and the associated Glean metric from the metrics.yaml as part of cleaning up after the test was completed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
