### PR TITLE
Overwrites push_apk worker-implementation so scriptworker isn't confused

### DIFF
--- a/taskcluster/rb_taskgraph/worker_types.py
+++ b/taskcluster/rb_taskgraph/worker_types.py
@@ -78,6 +78,8 @@ def build_scriptworker_signing_payload(config, task, task_def):
 def build_push_apk_payload(config, task, task_def):
     worker = task["worker"]
 
+    task_def["tags"]["worker-implementation"] = "scriptworker"
+
     task_def["payload"] = {
         "commit": worker["commit"],
         "upstreamArtifacts": worker["upstream-artifacts"],


### PR DESCRIPTION
@escapewindow, would you be able to review this?

I was getting a [pushapk task failure](https://tools.taskcluster.net/groups/KWLwDCsLTuORTpQ0myB7xg/tasks/GBYK0Y6sRVSIVocfRhPRYg/details) with the error message:
```
2019-08-21T23:27:26 CRITICAL - guess_worker_impl: too many matches for pushapk: {'scriptworker', 'scriptworker-pushapk'}!
{'provisionerId': 'scriptworker-prov-v1', 'workerType': 'mobile-pushapk-v1', 'schedulerId': 'mobile-level-3', 'taskGroupId': 'KWLwDCsLTuORTpQ0myB7xg', 'dependencies': ['UO6exEhES7inQrP1iwl0gw'], 'requires': 'all-completed', 'routes': ['tc-treeherder.v2.reference-browser.ceb89d3f24dea012de688fe1f23d81fe608af39b.0', 'checks'], 'priority': 'lowest', 'retries': 5, 'created': '2019-08-21T23:08:00.330Z', 'deadline': '2019-08-22T23:08:00.330Z', 'expires': '2020-08-20T23:08:00.330Z', 'scopes': ['project:mobile:reference-browser:releng:googleplay:product:reference-browser'], 'payload': {'commit': True, 'channel': 'nightly', 'upstreamArtifacts': [{'paths': ['public/target.x86_64.apk', 'public/target.armeabi-v7a.apk', 'public/target.x86.apk', 'public/target.arm64-v8a.apk'], 'taskId': 'UO6exEhES7inQrP1iwl0gw', 'taskType': 'signing'}]}, 'metadata': {'owner': 'cron@noreply.mozilla.org', 'source': 'https://github.com/mozilla-mobile/reference-browser/blob/ceb89d3f24dea012de688fe1f23d81fe608af39b/taskcluster/ci/push-apk', 'description': 'Publish Reference Browser ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=reference-browser&revision=ceb89d3f24dea012de688fe1f23d81fe608af39b))', 'name': 'push-apk-nightly'}, 'tags': {'os': 'scriptworker', 'createdForUser': 'cron@noreply.mozilla.org', 'worker-implementation': 'scriptworker-pushapk', 'kind': 'push-apk', 'label': 'push-apk-nightly'}, 'extra': {'index': {'rank': 0}, 'treeherder': {'machine': {'platform': 'android'}, 'tier': 2, 'symbol': 'gp', 'jobKind': 'build', 'collection': {'nightly': True}}, 'treeherder-platform': 'android/nightly', 'parent': 'KWLwDCsLTuORTpQ0myB7xg'}}
```

This is because we're using the scriptworker provisioner, but `tags.worker-implementation` wasn't also set to "scriptworker".

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [x] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
