### PR TITLE
[taskgraph] Don't try to guess the path to put secret at.

### DIFF
--- a/taskcluster/scripts/get-secret.py
+++ b/taskcluster/scripts/get-secret.py
@@ -11,7 +11,6 @@ import taskcluster
 
 
 def write_secret_to_file(path, data, key, base64decode=False, json_secret=False, append=False, prefix=''):
-    path = os.path.join(os.path.dirname(__file__), '../../../' + path)
     with open(path, 'a' if append else 'w') as f:
         value = data['secret'][key]
         if base64decode:


### PR DESCRIPTION
The pre-taskgraph `get-secrets.py` made assumptions about where to write the file based on the location of the script. The taskgraph automation assumes the script will write to the exact path given. Adjust the script to match.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [X] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
