### PR TITLE
Resolves issue where taskcluster routes for signed apks aren't populated

### DIFF
--- a/taskcluster/rb_taskgraph/routes.py
+++ b/taskcluster/rb_taskgraph/routes.py
@@ -19,7 +19,7 @@ SIGNING_ROUTE_TEMPLATES = [
 def add_signing_indexes(config, task):
     routes = task.setdefault("routes", [])
 
-    if config.params["level"] != 3:
+    if config.params["level"] != "3":
         return task
 
     subs = config.params.copy()


### PR DESCRIPTION
`config.params["level"]` is a string, not a number :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [x] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
