### PR TITLE
Closes #614: Fix Custom Tab shows blank screen on restore

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/CustomTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/CustomTabsIntegration.kt
@@ -18,6 +18,7 @@ import mozilla.components.feature.customtabs.CustomTabsToolbarFeature
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
+import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.reference.browser.BrowserActivity
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.share
@@ -32,11 +33,16 @@ class CustomTabsIntegration(
     activity: Activity?
 ) : LifecycleAwareFeature, BackHandler {
 
+    private val session = sessionManager.findSessionById(sessionId)
+    private val logger = Logger("CustomTabsIntegration")
+
     init {
+        if (session == null) {
+            logger.warn("The session for this ID, no longer exists. Finishing activity.")
+            activity?.finish()
+        }
         toolbar.urlBoxView = null
     }
-
-    private val session = sessionManager.findSessionById(sessionId)
 
     private val menuToolbar by lazy {
         val forward = BrowserMenuItemToolbar.Button(


### PR DESCRIPTION
When we get a session ID, it's for sessions that need to be specifically observed on via an external app, i.e. Custom Tabs and TWAs. 

Since we don't store these sessions to disk, they can be lost in memory if the activity is kept open before backgrounding the app, and the base activity is recreated.

In those cases, we can try to gracefully finish the activity so that we show an empty state. For the future, we can consider if/how we want to restore these session better.

@NotWoods what do you think?

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
