### PR TITLE
Add the WebCompat feature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -213,6 +213,7 @@ dependencies {
     implementation Deps.mozilla_feature_pwa
     implementation Deps.mozilla_feature_qr
     implementation Deps.mozilla_feature_readerview
+    implementation Deps.mozilla_feature_webcompat
 
     implementation Deps.mozilla_ui_autocomplete
     implementation Deps.mozilla_ui_colors

--- a/app/src/main/java/org/mozilla/reference/browser/EngineProvider.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/EngineProvider.kt
@@ -11,6 +11,7 @@ import mozilla.components.browser.engine.gecko.glean.GeckoAdapter
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.fetch.Client
+import mozilla.components.feature.webcompat.WebCompatFeature
 import mozilla.components.lib.crash.handler.CrashHandlerService
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
@@ -40,7 +41,10 @@ object EngineProvider {
 
     fun createEngine(context: Context, defaultSettings: DefaultSettings): Engine {
         val runtime = getOrCreateRuntime(context)
-        return GeckoEngine(context, defaultSettings, runtime)
+
+        return GeckoEngine(context, defaultSettings, runtime).also {
+            WebCompatFeature.install(it)
+        }
     }
 
     fun createClient(context: Context): Client {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -73,6 +73,7 @@ object Deps {
     const val mozilla_feature_pwa = "org.mozilla.components:feature-pwa:${Versions.mozilla_android_components}"
     const val mozilla_feature_qr = "org.mozilla.components:feature-qr:${Versions.mozilla_android_components}"
     const val mozilla_feature_readerview = "org.mozilla.components:feature-readerview:${Versions.mozilla_android_components}"
+    const val mozilla_feature_webcompat= "org.mozilla.components:feature-webcompat:${Versions.mozilla_android_components}"
 
     const val mozilla_ui_autocomplete = "org.mozilla.components:ui-autocomplete:${Versions.mozilla_android_components}"
     const val mozilla_ui_colors = "org.mozilla.components:ui-colors:${Versions.mozilla_android_components}"


### PR DESCRIPTION
We ship the WebCompat feature to Fenix (see https://github.com/mozilla-mobile/fenix/pull/5432) and soon to the sample browser. Let's add it to the Reference Browser as well. :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
