### PR TITLE
Uses scriptworker-k8s scriptworkers

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: 8724fdf41562f6eea82d1b905072d4a7c1f5ebbf
+              revision: bbd657c72f8a5fb113f14ca0a8bd02d9cbd06189
           trustDomain: mobile
       in:
           $if: 'tasks_for in ["github-pull-request", "github-push", "action", "cron"]'

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -29,26 +29,23 @@ workers:
             os: linux
             worker-type: 'images'
         dep-signing:
-            provisioner: scriptworker-prov-v1
+            provisioner: scriptworker-k8s
             implementation: scriptworker-signing
             os: scriptworker
-            worker-type: mobile-signing-dep-v1
+            worker-type: mobile-t-signing
         signing:
-            provisioner: scriptworker-prov-v1
+            provisioner: scriptworker-k8s
             implementation: scriptworker-signing
             os: scriptworker
             worker-type:
                 by-level:
-                    "3": mobile-signing-v1
-                    default: mobile-signing-dep-v1
+                    "3": mobile-3-signing
+                    default: mobile-t-signing
         push-apk:
-            provisioner: scriptworker-prov-v1
+            provisioner: scriptworker-k8s
             implementation: scriptworker-pushapk
             os: scriptworker
-            worker-type:
-                by-level:
-                    "3": mobile-pushapk-v1
-                    default: mobile-pushapk-dep-v1
+            worker-type: 'mobile-{level}-pushapk'
         t-bitbar.*:
             provisioner: proj-autophone
             implementation: generic-worker


### PR DESCRIPTION
This is a another change for [the Taskcluster instance migration](https://github.com/mozilla-mobile/reference-browser/pull/939).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [x] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
