### PR TITLE
Bug 1595808 - Bump taskgraph to the latest revision

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: bbd657c72f8a5fb113f14ca0a8bd02d9cbd06189
+              revision: d302e95cc988706ba746bfecbf1dae31090d212f
           trustDomain: mobile
       in:
           $if: 'tasks_for in ["github-pull-request", "github-push", "action", "cron"]'


### PR DESCRIPTION
Same as mozilla-mobile/android-components#5043. If we don't take this patch, then any github-release will just build and ship whatever is on the top of the target branch.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
