### PR TITLE
set the dynamic toolbar maximum height

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
@@ -191,6 +191,8 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, UserInteractionHan
             owner = this,
             view = view
         )
+
+        engineView.setDynamicToolbarMaxHeight(toolbar.getLayoutParams().height)
     }
 
     private fun fullScreenChanged(enabled: Boolean) {


### PR DESCRIPTION
With dynamic toolbar we need to call setDynamicToolbarMaxHeight to tell
it to Gecko, see https://bugzilla.mozilla.org/show_bug.cgi?id=1586144 for
corresponding changes in Gecko and see https://github.com/bokand/URLBarSizing
for detail backgrounds of this change.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
