### PR TITLE
Bug 1599148  - remove index on debug builds

### DIFF
--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -16,7 +16,10 @@ transforms:
 job-template:
     description: Sign Reference Browser
     index:
-        type: signing
+        by-build-type:
+            (nightly|raptor):
+                type: signing
+            default: {}
     treeherder:
         kind: build
         symbol: S

--- a/taskcluster/rb_taskgraph/transforms/signing.py
+++ b/taskcluster/rb_taskgraph/transforms/signing.py
@@ -27,13 +27,16 @@ def define_signing_flags(config, tasks):
         if "run_on_tasks_for" in task["attributes"]:
             task["run-on-tasks-for"] = task["attributes"]["run_on_tasks_for"]
 
-        for key in ("worker-type", "worker.signing-type"):
+        for key in ("index", "worker-type", "worker.signing-type"):
             resolve_keyed_by(
                 task,
                 key,
                 item_name=task["name"],
                 variant=task["attributes"]["build-type"],
-                level=config.params["level"],
+                **{
+                    "build-type": task["attributes"]["build-type"],
+                    "level": config.params["level"],
+                }
             )
         task["treeherder"] = inherit_treeherder_from_dep(task, dep)
         yield task


### PR DESCRIPTION
taskgraph-diff on push:

```py
[
    "change",
    [
        "signing-debug",
        "task",
        "routes",
        0
    ],
    [
        "index.project.mobile.reference-browser.v3.debug.2019.10.22.revision.1dff5b4d392d5f1aafb40c343e45ac3669905f5a",
        "tc-treeherder.v2.reference-browser.1dff5b4d392d5f1aafb40c343e45ac3669905f5a.0"
    ]
]
[
    "change",
    [
        "signing-debug",
        "task",
        "routes",
        1
    ],
    [
        "index.project.mobile.reference-browser.v3.debug.2019.10.22.latest",
        "checks"
    ]
]
[
    "remove",
    "signing-debug.task.routes",
    [
        [
            4,
            "checks"
        ],
        [
            3,
            "tc-treeherder.v2.reference-browser.1dff5b4d392d5f1aafb40c343e45ac3669905f5a.0"
        ],
        [
            2,
            "index.project.mobile.reference-browser.v3.debug.latest"
        ]
    ]
]
```


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
