### PR TITLE
Bug 1595040 - Remove speedometer power tests running on reference browser.

### DIFF
--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -73,10 +73,3 @@ jobs:
         test-name: raptor-speedometer
         treeherder:
             symbol: 'Rap(sp)'
-
-    speedometer-power:
-        test-name: raptor-speedometer
-        description: 'raptor speedometer power'
-        treeherder:
-            symbol: 'Rap-P(sp)'
-        args: ['--power-test', '--page-cycles 5', '--host HOST_IP']


### PR DESCRIPTION
This patch disables raptor speedometer power tests running on reference browser.

I don't think this change requires a Changelog entry but if it does I'm happy to add it.
