### PR TITLE
Import basic Addon support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -198,6 +198,7 @@ dependencies {
     implementation Deps.mozilla_browser_icons
 
     implementation Deps.mozilla_feature_accounts
+    implementation Deps.mozilla_feature_addons
     implementation Deps.mozilla_feature_app_links
     implementation Deps.mozilla_feature_awesomebar
     implementation Deps.mozilla_feature_contextmenu
@@ -222,6 +223,7 @@ dependencies {
 
     implementation Deps.mozilla_ui_autocomplete
     implementation Deps.mozilla_ui_colors
+    implementation Deps.mozilla_ui_icons
 
     implementation Deps.mozilla_service_firefox_accounts
     implementation Deps.mozilla_service_glean
@@ -231,6 +233,7 @@ dependencies {
     implementation Deps.mozilla_support_ktx
     implementation Deps.mozilla_support_rustlog
     implementation Deps.mozilla_support_rusthttp
+    implementation Deps.mozilla_support_webextensions
 
     implementation Deps.mozilla_lib_crash
     implementation Deps.mozilla_lib_push_firebase
@@ -241,6 +244,7 @@ dependencies {
     implementation Deps.kotlin_coroutines
 
     implementation Deps.androidx_appcompat
+    implementation Deps.androidx_core_ktx
     implementation Deps.androidx_constraintlayout
     implementation Deps.androidx_preference_ktx
     implementation Deps.androidx_work_runtime_ktx

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,6 +54,37 @@
             android:autoRemoveFromRecents="false"
             android:label="@string/app_name" />
 
+        <activity
+            android:theme="@style/Theme.AppCompat.Light"
+            android:name=".addons.AddonsActivity"
+            android:label="@string/mozac_feature_addons_addons"
+            android:exported="false"
+            android:parentActivityName=".BrowserActivity" />
+
+        <activity
+            android:theme="@style/Theme.AppCompat.Light"
+            android:name=".addons.AddonDetailsActivity"
+            android:exported="false"
+            android:label="@string/mozac_feature_addons_addons" />
+
+        <activity android:name=".addons.InstalledAddonDetailsActivity"
+            android:label="@string/mozac_feature_addons_addons"
+            android:parentActivityName=".addons.AddonsActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Light" />
+
+        <activity
+            android:name=".addons.PermissionsDetailsActivity"
+            android:label="@string/mozac_feature_addons_addons"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Light" />
+
+        <activity
+            android:name=".addons.AddonSettingsActivity"
+            android:label="@string/mozac_feature_addons_addons"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Light" />
+
         <activity android:name=".IntentReceiverActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/org/mozilla/reference/browser/addons/AddonDetailsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/AddonDetailsActivity.kt
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.addons
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.text.method.LinkMovementMethod
+import android.view.View
+import android.widget.RatingBar
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.text.HtmlCompat
+import mozilla.components.feature.addons.Addon
+import org.mozilla.reference.browser.R
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+/**
+ * An activity to show the details of an add-on.
+ */
+class AddonDetailsActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_add_on_details)
+        val addon = requireNotNull(intent.getParcelableExtra<Addon>("add_on"))
+        bind(addon)
+    }
+
+    private fun bind(addon: Addon) {
+
+        title = addon.translatableName.translate()
+
+        bindDetails(addon)
+
+        bindAuthors(addon)
+
+        bindVersion(addon)
+
+        bindLastUpdated(addon)
+
+        bindWebsite(addon)
+
+        bindRating(addon)
+    }
+
+    private fun bindRating(addon: Addon) {
+        addon.rating?.let {
+            val ratingView = findViewById<RatingBar>(R.id.rating_view)
+            val userCountView = findViewById<TextView>(R.id.users_count)
+
+            val ratingContentDescription = getString(R.string.mozac_feature_addons_rating_content_description)
+            ratingView.contentDescription = String.format(ratingContentDescription, it.average)
+            ratingView.rating = it.average
+
+            userCountView.text = getFormattedAmount(it.reviews)
+        }
+    }
+
+    private fun bindWebsite(addon: Addon) {
+        findViewById<View>(R.id.home_page_text).setOnClickListener {
+            val intent =
+                Intent(Intent.ACTION_VIEW).setData(Uri.parse(addon.siteUrl))
+            startActivity(intent)
+        }
+    }
+
+    private fun bindLastUpdated(addon: Addon) {
+        val lastUpdatedView = findViewById<TextView>(R.id.last_updated_text)
+        lastUpdatedView.text = formatDate(addon.updatedAt)
+    }
+
+    private fun bindVersion(addon: Addon) {
+        val versionView = findViewById<TextView>(R.id.version_text)
+        versionView.text = addon.version
+    }
+
+    private fun bindAuthors(addon: Addon) {
+        val authorsView = findViewById<TextView>(R.id.author_text)
+
+        val authorText = addon.authors.joinToString { author ->
+            author.name + " \n"
+        }
+
+        authorsView.text = authorText
+    }
+
+    private fun bindDetails(addon: Addon) {
+        val detailsView = findViewById<TextView>(R.id.details)
+        val detailsText = addon.translatableDescription.translate()
+
+        val parsedText = detailsText.replace("\n", "<br/>")
+        val text = HtmlCompat.fromHtml(parsedText, HtmlCompat.FROM_HTML_MODE_COMPACT)
+
+        detailsView.text = text
+        detailsView.movementMethod = LinkMovementMethod.getInstance()
+    }
+
+    private fun formatDate(text: String): String {
+        val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.getDefault())
+        return DateFormat.getDateInstance().format(formatter.parse(text)!!)
+    }
+}

--- a/app/src/main/java/org/mozilla/reference/browser/addons/AddonSettingsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/AddonSettingsActivity.kt
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.addons
+
+import android.content.Context
+import android.os.Bundle
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import kotlinx.android.synthetic.main.fragment_add_on_settings.*
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineView
+import mozilla.components.feature.addons.Addon
+import org.mozilla.reference.browser.R
+import org.mozilla.reference.browser.ext.components
+
+/**
+ * An activity to show the settings of an add-on.
+ */
+class AddonSettingsActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_add_on_settings)
+
+        val addon = requireNotNull(intent.getParcelableExtra<Addon>("add_on"))
+        title = addon.translatableName.translate()
+
+        supportFragmentManager
+            .beginTransaction()
+            .replace(R.id.addonSettingsContainer, AddonSettingsFragment.create(addon))
+            .commit()
+    }
+
+    override fun onCreateView(parent: View?, name: String, context: Context, attrs: AttributeSet): View? =
+        when (name) {
+            EngineView::class.java.name -> components.core.engine.createView(context, attrs).asView()
+            else -> super.onCreateView(parent, name, context, attrs)
+        }
+
+    /**
+     * A fragment to show the settings of an add-on with [EngineView].
+     */
+    class AddonSettingsFragment : Fragment() {
+        private lateinit var addon: Addon
+        private lateinit var engineSession: EngineSession
+
+        override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+            addon = requireNotNull(arguments?.getParcelable("add_on"))
+            engineSession = requireContext().components.core.engine.createSession()
+
+            return inflater.inflate(R.layout.fragment_add_on_settings, container, false)
+        }
+
+        override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+            super.onViewCreated(view, savedInstanceState)
+
+            addonSettingsEngineView.render(engineSession)
+            engineSession.loadUrl(addon.installedState!!.optionsPageUrl)
+        }
+
+        override fun onDestroyView() {
+            engineSession.close()
+            super.onDestroyView()
+        }
+
+        companion object {
+            /**
+             * Create an [AddonSettingsFragment] with add_on as a required parameter.
+             */
+            fun create(addon: Addon) = AddonSettingsFragment().apply {
+                arguments = Bundle().apply {
+                    putParcelable("add_on", addon)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/reference/browser/addons/AddonsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/AddonsActivity.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.addons
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import org.mozilla.reference.browser.R
+
+/**
+ * An activity to manage add-ons.
+ */
+class AddonsActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        if (savedInstanceState == null) {
+            supportFragmentManager.beginTransaction().apply {
+                replace(R.id.container, AddonsFragment())
+                commit()
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/reference/browser/addons/AddonsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/AddonsFragment.kt
@@ -1,0 +1,320 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.addons
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.RatingBar
+import android.widget.TextView
+import android.widget.Toast
+import androidx.annotation.StringRes
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.AddonManagerException
+import org.mozilla.reference.browser.R
+import org.mozilla.reference.browser.ext.components
+import org.mozilla.reference.browser.addons.AddonsFragment.CustomViewHolder.AddonViewHolder
+import org.mozilla.reference.browser.addons.AddonsFragment.CustomViewHolder.SectionViewHolder
+import org.mozilla.reference.browser.addons.PermissionsDialogFragment.PromptsStyling
+
+/**
+ * Fragment use for managing add-ons.
+ */
+class AddonsFragment : Fragment(), View.OnClickListener {
+    private lateinit var recyclerView: RecyclerView
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_add_ons, container, false)
+    }
+
+    override fun onViewCreated(rootView: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(rootView, savedInstanceState)
+        bindRecyclerView(rootView)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        findPreviousDialogFragment()?.let { dialog ->
+            dialog.onPositiveButtonClicked = onPositiveButtonClicked
+        }
+    }
+
+    private fun bindRecyclerView(rootView: View) {
+        recyclerView = rootView.findViewById(R.id.add_ons_list)
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        scope.launch {
+            try {
+                val addons = requireContext().components.core.addonManager.getAddons()
+
+                scope.launch(Dispatchers.Main) {
+                    val adapter = AddonsAdapter(
+                        this@AddonsFragment,
+                        addons
+                    )
+                    recyclerView.adapter = adapter
+                }
+            } catch (e: AddonManagerException) {
+                scope.launch(Dispatchers.Main) {
+                    Toast.makeText(activity, "Failed to query Add-ons!", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    /**
+     * An adapter for displaying add-on items.
+     */
+    inner class AddonsAdapter(
+        private val clickListener: View.OnClickListener,
+        addons: List<Addon>
+    ) : RecyclerView.Adapter<CustomViewHolder>() {
+        private val items: List<Any>
+
+        init {
+            items = createListWithSections(addons)
+        }
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CustomViewHolder {
+            return if (viewType == VIEW_HOLDER_TYPE_ADDON) {
+                createAddonViewHolder(parent)
+            } else {
+                createSectionViewHolder(parent)
+            }
+        }
+
+        private fun createSectionViewHolder(parent: ViewGroup): CustomViewHolder {
+            val context = parent.context
+            val inflater = LayoutInflater.from(context)
+            val view = inflater.inflate(R.layout.addons_section_item, parent, false)
+            val titleView = view.findViewById<TextView>(R.id.title)
+
+            return SectionViewHolder(view, titleView)
+        }
+
+        private fun createAddonViewHolder(parent: ViewGroup): AddonViewHolder {
+            val context = parent.context
+            val inflater = LayoutInflater.from(context)
+            val view = inflater.inflate(R.layout.add_ons_item, parent, false)
+            val iconView = view.findViewById<ImageView>(R.id.add_on_icon)
+            val titleView = view.findViewById<TextView>(R.id.add_on_name)
+            val summaryView = view.findViewById<TextView>(R.id.add_on_description)
+            val ratingView = view.findViewById<RatingBar>(R.id.rating)
+            val userCountView = view.findViewById<TextView>(R.id.users_count)
+            val addButton = view.findViewById<ImageView>(R.id.add_button)
+            return AddonViewHolder(
+                view,
+                iconView,
+                titleView,
+                summaryView,
+                ratingView,
+                userCountView,
+                addButton
+            )
+        }
+
+        override fun getItemCount() = items.size
+
+        override fun getItemViewType(position: Int): Int {
+            val isSection = items[position] !is Addon
+            return if (isSection) VIEW_HOLDER_TYPE_SECTION else VIEW_HOLDER_TYPE_ADDON
+        }
+
+        override fun onBindViewHolder(holder: CustomViewHolder, position: Int) {
+            val item = items[position]
+
+            when (holder) {
+                is SectionViewHolder -> bindSection(holder, item as Section)
+                is AddonViewHolder -> bindAddon(holder, item as Addon)
+            }
+        }
+
+        private fun bindSection(holder: SectionViewHolder, section: Section) {
+            holder.titleView.setText(section.title)
+        }
+
+        private fun bindAddon(holder: AddonViewHolder, addon: Addon) {
+            val context = holder.itemView.context
+            addon.rating?.let {
+                val userCount = context.getString(R.string.mozac_feature_addons_user_rating_count)
+                val ratingContentDescription =
+                    context.getString(R.string.mozac_feature_addons_rating_content_description)
+                holder.ratingView.contentDescription =
+                    String.format(ratingContentDescription, it.average)
+                holder.ratingView.rating = it.average
+                holder.userCountView.text = String.format(userCount, getFormattedAmount(it.reviews))
+            }
+
+            holder.titleView.text = addon.translatableName.translate()
+            holder.summaryView.text = addon.translatableSummary.translate()
+            holder.itemView.tag = addon
+            holder.itemView.setOnClickListener(clickListener)
+            holder.addButton.isVisible = !addon.isInstalled()
+            val listener = if (!addon.isInstalled()) {
+                clickListener
+            } else {
+                null
+            }
+            holder.addButton.setOnClickListener(listener)
+
+            scope.launch {
+                val iconBitmap =
+                    context.components.core.addonCollectionProvider.getAddonIconBitmap(addon)
+
+                iconBitmap?.let {
+                    MainScope().launch {
+                        holder.iconView.setImageBitmap(it)
+                    }
+                }
+            }
+        }
+
+        private fun createListWithSections(addons: List<Addon>): List<Any> {
+            // We want to have the installed add-ons first in the list.
+            val sortedAddons = addons.sortedBy { !it.isInstalled() }
+
+            val itemsWithSections = ArrayList<Any>()
+            val shouldAddInstalledSection = sortedAddons.first().isInstalled()
+            var isRecommendedSectionAdded = false
+
+            if (shouldAddInstalledSection) {
+                itemsWithSections.add(Section(R.string.mozac_feature_addons_installed_section))
+            }
+
+            sortedAddons.forEach { addon ->
+                if (!isRecommendedSectionAdded && !addon.isInstalled()) {
+                    itemsWithSections.add(Section(R.string.mozac_feature_addons_recommended_section))
+                    isRecommendedSectionAdded = true
+                }
+
+                itemsWithSections.add(addon)
+            }
+            return itemsWithSections
+        }
+    }
+
+    /**
+     * A base view holder.
+     */
+    sealed class CustomViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        /**
+         * A view holder for displaying section items.
+         */
+        class SectionViewHolder(
+            view: View,
+            val titleView: TextView
+        ) : CustomViewHolder(view)
+
+        /**
+         * A view holder for displaying add-on items.
+         */
+        class AddonViewHolder(
+            view: View,
+            val iconView: ImageView,
+            val titleView: TextView,
+            val summaryView: TextView,
+            val ratingView: RatingBar,
+            val userCountView: TextView,
+            val addButton: ImageView
+        ) : CustomViewHolder(view)
+    }
+
+    override fun onClick(view: View) {
+        val context = view.context
+        when (view.id) {
+            R.id.add_button -> {
+                val addon = (((view.parent) as View).tag as Addon)
+                showPermissionDialog(addon)
+            }
+            R.id.add_on_item -> {
+                val addon = view.tag as Addon
+                if (addon.isInstalled()) {
+                    val intent = Intent(context, InstalledAddonDetailsActivity::class.java)
+                    intent.putExtra("add_on", addon)
+                    context.startActivity(intent)
+                } else {
+                    val intent = Intent(context, AddonDetailsActivity::class.java)
+                    intent.putExtra("add_on", addon)
+                    this.startActivity(intent)
+                }
+            }
+            else -> {
+            }
+        }
+    }
+
+    private fun isAlreadyADialogCreated(): Boolean {
+        return findPreviousDialogFragment() != null
+    }
+
+    private fun findPreviousDialogFragment(): PermissionsDialogFragment? {
+        return fragmentManager?.findFragmentByTag(PERMISSIONS_DIALOG_FRAGMENT_TAG) as? PermissionsDialogFragment
+    }
+
+    private fun showPermissionDialog(addon: Addon) {
+        val dialog = PermissionsDialogFragment.newInstance(
+            addon = addon,
+            title = addon.translatableName.translate(),
+            permissions = addon.translatePermissions(),
+            promptsStyling = PromptsStyling(
+                gravity = Gravity.BOTTOM,
+                shouldWidthMatchParent = true
+            ),
+            onPositiveButtonClicked = onPositiveButtonClicked
+        )
+
+        if (!isAlreadyADialogCreated() && fragmentManager != null) {
+            dialog.show(requireFragmentManager(), PERMISSIONS_DIALOG_FRAGMENT_TAG)
+        }
+    }
+
+    private val onPositiveButtonClicked: ((Addon) -> Unit) = { addon ->
+        requireContext().components.core.addonManager.installAddon(
+            addon,
+            onSuccess = {
+                Toast.makeText(
+                    requireContext(),
+                    "Successfully installed: ${it.translatableName.translate()}",
+                    Toast.LENGTH_SHORT
+                ).show()
+
+                this@AddonsFragment.view?.let { view ->
+                    bindRecyclerView(view)
+                }
+            },
+            onError = { _, _ ->
+                Toast.makeText(
+                    requireContext(),
+                    "Failed to install: ${addon.translatableName.translate()}",
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        )
+    }
+
+    companion object {
+        private const val PERMISSIONS_DIALOG_FRAGMENT_TAG = "ADDONS_PERMISSIONS_DIALOG_FRAGMENT"
+        private const val VIEW_HOLDER_TYPE_SECTION = 0
+        private const val VIEW_HOLDER_TYPE_ADDON = 1
+    }
+
+    private inner class Section(@StringRes val title: Int)
+}

--- a/app/src/main/java/org/mozilla/reference/browser/addons/Extensions.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/Extensions.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.addons
+
+import java.text.NumberFormat
+import java.util.Locale
+
+/**
+ * Try to find the default language on the map otherwise defaults to "en-US".
+ */
+internal fun Map<String, String>.translate(): String {
+    val lang = Locale.getDefault().isO3Language
+    return get(lang) ?: get("en-US") ?: asIterable().firstOrNull()?.value ?: ""
+}
+
+internal fun getFormattedAmount(amount: Int): String {
+    return NumberFormat.getNumberInstance(Locale.getDefault()).format(amount)
+}

--- a/app/src/main/java/org/mozilla/reference/browser/addons/InstalledAddonDetailsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/InstalledAddonDetailsActivity.kt
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.addons
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.Switch
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import mozilla.components.feature.addons.Addon
+import org.mozilla.reference.browser.R
+import org.mozilla.reference.browser.ext.components
+
+/**
+ * An activity to show the details of a installed add-on.
+ */
+class InstalledAddonDetailsActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_installed_add_on_details)
+        val addon = requireNotNull(intent.getParcelableExtra<Addon>("add_on"))
+        bind(addon)
+    }
+
+    private fun bind(addon: Addon) {
+        title = addon.translatableName.translate()
+
+        bindEnableSwitch(addon)
+
+        bindSettings(addon)
+
+        bindDetails(addon)
+
+        bindPermissions(addon)
+
+        bindRemoveButton(addon)
+    }
+
+    private fun bindVersion(addon: Addon) {
+        val versionView = findViewById<TextView>(R.id.version_text)
+        versionView.text = addon.version
+    }
+
+    private fun bindEnableSwitch(addon: Addon) {
+        val switch = findViewById<Switch>(R.id.enable_switch)
+        switch.setState(addon.isEnabled())
+        switch.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                this.components.core.addonManager.disableAddon(
+                    addon,
+                    onSuccess = {
+                        Toast.makeText(
+                            this,
+                            "Successfully disabled ${addon.translatableName.translate()}",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    },
+                    onError = {
+                        Toast.makeText(
+                            this,
+                            "Failed to disable ${addon.translatableName.translate()}",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                )
+            } else {
+                this.components.core.addonManager.enableAddon(
+                    addon,
+                    onSuccess = {
+                        Toast.makeText(
+                            this,
+                            "Successfully enabled ${addon.translatableName.translate()}",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    },
+                    onError = {
+                        Toast.makeText(
+                            this,
+                            "Failed to enable ${addon.translatableName.translate()}",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                )
+            }
+        }
+    }
+
+    private fun bindSettings(addOn: Addon) {
+        val view = findViewById<View>(R.id.settings)
+        view.isEnabled = addOn.installedState?.optionsPageUrl != null
+        view.setOnClickListener {
+            val intent = Intent(this, AddonSettingsActivity::class.java)
+            intent.putExtra("add_on", addOn)
+            this.startActivity(intent)
+        }
+    }
+
+    private fun bindDetails(addon: Addon) {
+        findViewById<View>(R.id.details).setOnClickListener {
+            val intent = Intent(this, AddonDetailsActivity::class.java)
+            intent.putExtra("add_on", addon)
+            this.startActivity(intent)
+        }
+    }
+
+    private fun bindPermissions(addon: Addon) {
+        findViewById<View>(R.id.permissions).setOnClickListener {
+            val intent = Intent(this, PermissionsDetailsActivity::class.java)
+            intent.putExtra("add_on", addon)
+            this.startActivity(intent)
+        }
+    }
+
+    private fun bindRemoveButton(addon: Addon) {
+        findViewById<View>(R.id.remove_add_on).setOnClickListener {
+            this.components.core.addonManager.uninstallAddon(
+                addon,
+                onSuccess = {
+                    Toast.makeText(
+                        this,
+                        "Successfully uninstalled ${addon.translatableName.translate()}",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                    finish()
+                },
+                onError = { _, _ ->
+                    Toast.makeText(
+                        this,
+                        "Failed to uninstall ${addon.translatableName.translate()}",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            )
+        }
+    }
+
+    private fun Switch.setState(checked: Boolean) {
+        val text = if (checked) {
+            R.string.mozac_feature_addons_settings_on
+        } else {
+            R.string.mozac_feature_addons_settings_off
+        }
+        setText(text)
+        isChecked = checked
+    }
+}

--- a/app/src/main/java/org/mozilla/reference/browser/addons/PermissionsDetailsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/PermissionsDetailsActivity.kt
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.addons
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.feature.addons.Addon
+import org.mozilla.reference.browser.R
+
+private const val LEARN_MORE_URL =
+    "https://support.mozilla.org/kb/permission-request-messages-firefox-extensions"
+
+/**
+ * An activity to show the permissions of an add-on.
+ */
+class PermissionsDetailsActivity : AppCompatActivity(), View.OnClickListener {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_add_on_permissions)
+        val addon = requireNotNull(intent.getParcelableExtra<Addon>("add_on"))
+        title = addon.translatableName.translate()
+
+        bindPermissions(addon)
+
+        bindLearnMore()
+    }
+
+    private fun bindPermissions(addon: Addon) {
+        val recyclerView = findViewById<RecyclerView>(R.id.add_ons_permissions)
+        recyclerView.layoutManager = LinearLayoutManager(this)
+        val sortedPermissions = addon.translatePermissions().map { stringId ->
+            getString(stringId)
+        }.sorted()
+        recyclerView.adapter = PermissionsAdapter(sortedPermissions)
+    }
+
+    private fun bindLearnMore() {
+        findViewById<View>(R.id.learn_more_label).setOnClickListener(this)
+    }
+
+    /**
+     * An adapter for displaying the permissions of an add-on.
+     */
+    class PermissionsAdapter(
+        private val permissions: List<String>
+    ) :
+        RecyclerView.Adapter<PermissionViewHolder>() {
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PermissionViewHolder {
+            val context = parent.context
+            val inflater = LayoutInflater.from(context)
+            val view = inflater.inflate(R.layout.add_ons_permission_item, parent, false)
+            val titleView = view.findViewById<TextView>(R.id.permission)
+            return PermissionViewHolder(
+                view,
+                titleView
+            )
+        }
+
+        override fun getItemCount() = permissions.size
+
+        override fun onBindViewHolder(holder: PermissionViewHolder, position: Int) {
+            val permission = permissions[position]
+            holder.textView.text = permission
+        }
+    }
+
+    /**
+     * A view holder for displaying the permissions of an add-on.
+     */
+    class PermissionViewHolder(
+        val view: View,
+        val textView: TextView
+    ) : RecyclerView.ViewHolder(view)
+
+    override fun onClick(v: View?) {
+        val intent =
+            Intent(Intent.ACTION_VIEW).setData(Uri.parse(LEARN_MORE_URL))
+        startActivity(intent)
+    }
+}

--- a/app/src/main/java/org/mozilla/reference/browser/addons/PermissionsDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/PermissionsDialogFragment.kt
@@ -1,0 +1,232 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.addons
+
+import android.annotation.SuppressLint
+import android.app.Dialog
+import android.content.DialogInterface
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.GradientDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.Window
+import android.widget.TextView
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.LinearLayout.LayoutParams
+import androidx.annotation.ColorRes
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.core.content.ContextCompat
+import mozilla.components.feature.addons.Addon
+import org.mozilla.reference.browser.R
+
+internal const val KEY_ADDON = "KEY_ADDON"
+internal const val KEY_TITLE = "KEY_TITLE"
+private const val KEY_DIALOG_GRAVITY = "KEY_DIALOG_GRAVITY"
+private const val KEY_DIALOG_WIDTH_MATCH_PARENT = "KEY_DIALOG_WIDTH_MATCH_PARENT"
+private const val KEY_PERMISSIONS = "KEY_PERMISSIONS"
+private const val KEY_POSITIVE_BUTTON_BACKGROUND_COLOR = "KEY_POSITIVE_BUTTON_BACKGROUND_COLOR"
+private const val KEY_POSITIVE_BUTTON_TEXT_COLOR = "KEY_POSITIVE_BUTTON_TEXT_COLOR"
+private const val KEY_POSITIVE_BUTTON_RADIUS = "KEY_POSITIVE_BUTTON_RADIUS"
+private const val DEFAULT_VALUE = Int.MAX_VALUE
+
+internal class PermissionsDialogFragment : AppCompatDialogFragment() {
+
+    internal var onPositiveButtonClicked: ((Addon) -> Unit)? = null
+    internal var onNegativeButtonClicked: (() -> Unit)? = null
+
+    private val safeArguments get() = requireNotNull(arguments)
+
+    internal val addon get() = safeArguments.getParcelable<Addon>(KEY_ADDON)
+
+    internal val positiveButtonRadius
+        get() =
+            safeArguments.getFloat(KEY_POSITIVE_BUTTON_RADIUS, DEFAULT_VALUE.toFloat())
+
+    internal val permissions: IntArray
+        get() =
+            safeArguments.getIntArray(KEY_PERMISSIONS) ?: intArrayOf()
+
+    internal val title: String
+        get() =
+            safeArguments.getString(KEY_TITLE, "")
+
+    internal val dialogGravity: Int
+        get() =
+            safeArguments.getInt(KEY_DIALOG_GRAVITY, DEFAULT_VALUE)
+    internal val dialogShouldWidthMatchParent: Boolean
+        get() =
+            safeArguments.getBoolean(KEY_DIALOG_WIDTH_MATCH_PARENT)
+
+    internal val positiveButtonBackgroundColor
+        get() =
+            safeArguments.getInt(KEY_POSITIVE_BUTTON_BACKGROUND_COLOR, DEFAULT_VALUE)
+
+    internal val positiveButtonTextColor
+        get() =
+            safeArguments.getInt(KEY_POSITIVE_BUTTON_TEXT_COLOR, DEFAULT_VALUE)
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val sheetDialog = Dialog(requireContext())
+        sheetDialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
+        sheetDialog.setCanceledOnTouchOutside(true)
+
+        val rootView = createContainer()
+
+        sheetDialog.setContainerView(rootView)
+
+        sheetDialog.window?.apply {
+
+            if (dialogGravity != DEFAULT_VALUE) {
+                setGravity(dialogGravity)
+            }
+
+            if (dialogShouldWidthMatchParent) {
+                setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+                // This must be called after addContentView, or it won't fully fill to the edge.
+                setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+            }
+        }
+
+        return sheetDialog
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        onNegativeButtonClicked?.invoke()
+    }
+
+    private fun Dialog.setContainerView(rootView: View) {
+        if (dialogShouldWidthMatchParent) {
+            setContentView(rootView)
+        } else {
+            addContentView(
+                rootView,
+                LayoutParams(
+                    LayoutParams.MATCH_PARENT,
+                    LayoutParams.MATCH_PARENT
+                )
+            )
+        }
+    }
+
+    @SuppressLint("InflateParams")
+    private fun createContainer(): View {
+        val rootView = LayoutInflater.from(requireContext()).inflate(
+            R.layout.fragment_dialog_addon_permissions,
+            null,
+            false
+        )
+        rootView.findViewById<TextView>(R.id.title).text =
+            requireContext().getString(R.string.mozac_feature_addons_permissions_dialog_title, title)
+        rootView.findViewById<TextView>(R.id.permissions).text = buildPermissionsText()
+
+        val positiveButton = rootView.findViewById<Button>(R.id.allow_button)
+        val negativeButton = rootView.findViewById<Button>(R.id.deny_button)
+
+        positiveButton.setOnClickListener {
+            onPositiveButtonClicked?.invoke(addon!!)
+            dismiss()
+        }
+
+        if (positiveButtonBackgroundColor != DEFAULT_VALUE) {
+            val backgroundTintList =
+                ContextCompat.getColorStateList(requireContext(), positiveButtonBackgroundColor)
+            positiveButton.backgroundTintList = backgroundTintList
+        }
+
+        if (positiveButtonTextColor != DEFAULT_VALUE) {
+            val color = ContextCompat.getColor(requireContext(), positiveButtonTextColor)
+            positiveButton.setTextColor(color)
+        }
+
+        if (positiveButtonRadius != DEFAULT_VALUE.toFloat()) {
+            val shape = GradientDrawable()
+            shape.shape = GradientDrawable.RECTANGLE
+            shape.setColor(
+                ContextCompat.getColor(
+                    requireContext(),
+                    positiveButtonBackgroundColor
+                )
+            )
+            shape.cornerRadius = positiveButtonRadius
+            positiveButton.background = shape
+        }
+
+        negativeButton.setOnClickListener {
+            onNegativeButtonClicked?.invoke()
+            dismiss()
+        }
+
+        return rootView
+    }
+
+    private fun buildPermissionsText(): String {
+        var permissionsText = getString(R.string.mozac_feature_addons_permissions_dialog_subtitle) + "\n\n"
+
+        permissions.forEachIndexed { index, item ->
+            val brakeLine = if (index + 1 != permissions.size) "\n\n" else ""
+            val permissionText = requireContext().getString(item)
+            permissionsText += "• $permissionText $brakeLine"
+        }
+        return permissionsText
+    }
+
+    @Suppress("LongParameterList")
+    companion object {
+        fun newInstance(
+            addon: Addon,
+            title: String,
+            permissions: List<Int>,
+            promptsStyling: PromptsStyling? = null,
+            onPositiveButtonClicked: ((Addon) -> Unit)? = null,
+            onNegativeButtonClicked: (() -> Unit)? = null
+        ): PermissionsDialogFragment {
+
+            val fragment = PermissionsDialogFragment()
+            val arguments = fragment.arguments ?: Bundle()
+
+            arguments.apply {
+                putParcelable(KEY_ADDON, addon)
+                putString(KEY_TITLE, title)
+                putIntArray(KEY_PERMISSIONS, permissions.toIntArray())
+
+                promptsStyling?.gravity?.apply {
+                    putInt(KEY_DIALOG_GRAVITY, this)
+                }
+                promptsStyling?.shouldWidthMatchParent?.apply {
+                    putBoolean(KEY_DIALOG_WIDTH_MATCH_PARENT, this)
+                }
+                promptsStyling?.positiveButtonBackgroundColor?.apply {
+                    putInt(KEY_POSITIVE_BUTTON_BACKGROUND_COLOR, this)
+                }
+
+                promptsStyling?.positiveButtonTextColor?.apply {
+                    putInt(KEY_POSITIVE_BUTTON_TEXT_COLOR, this)
+                }
+                println(permissions)
+            }
+            fragment.onPositiveButtonClicked = onPositiveButtonClicked
+            fragment.onNegativeButtonClicked = onNegativeButtonClicked
+            fragment.arguments = arguments
+            return fragment
+        }
+    }
+
+    /**
+     * Styling for the permissions dialog.
+     */
+    data class PromptsStyling(
+        val gravity: Int,
+        val shouldWidthMatchParent: Boolean = false,
+        @ColorRes
+        val positiveButtonBackgroundColor: Int? = null,
+        @ColorRes
+        val positiveButtonTextColor: Int? = null,
+        val positiveButtonRadius: Float? = null
+    )
+}

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
@@ -11,9 +11,11 @@ import kotlinx.android.synthetic.main.fragment_browser.view.*
 import mozilla.components.feature.awesomebar.AwesomeBarFeature
 import mozilla.components.feature.session.ThumbnailsFeature
 import mozilla.components.feature.tabs.toolbar.TabsToolbarFeature
+import mozilla.components.feature.toolbar.WebExtensionToolbarFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.reference.browser.R
+import org.mozilla.reference.browser.ext.components
 import org.mozilla.reference.browser.ext.requireComponents
 import org.mozilla.reference.browser.tabs.TabsTrayFragment
 
@@ -23,6 +25,7 @@ import org.mozilla.reference.browser.tabs.TabsTrayFragment
 class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     private val thumbnailsFeature = ViewBoundFeatureWrapper<ThumbnailsFeature>()
     private val readerViewFeature = ViewBoundFeatureWrapper<ReaderViewIntegration>()
+    private val webExtToolbarFeature = ViewBoundFeatureWrapper<WebExtensionToolbarFeature>()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -63,6 +66,15 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 view.toolbar,
                 view.readerViewBar,
                 view.readerViewAppearanceButton
+            ),
+            owner = this,
+            view = view
+        )
+
+        webExtToolbarFeature.set(
+            feature = WebExtensionToolbarFeature(
+                view.toolbar,
+                requireContext().components.core.store
             ),
             owner = this,
             view = view

--- a/app/src/main/java/org/mozilla/reference/browser/browser/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/ToolbarIntegration.kt
@@ -26,6 +26,7 @@ import mozilla.components.feature.toolbar.ToolbarFeature
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import org.mozilla.reference.browser.R
+import org.mozilla.reference.browser.addons.AddonsActivity
 import org.mozilla.reference.browser.ext.components
 import org.mozilla.reference.browser.ext.share
 import org.mozilla.reference.browser.settings.SettingsActivity
@@ -98,6 +99,12 @@ class ToolbarIntegration(
                 FindInPageIntegration.launch?.invoke()
             }.apply {
                 visible = { sessionManager.selectedSession != null }
+            },
+
+            SimpleBrowserMenuItem("Add-ons") {
+                val intent = Intent(context, AddonsActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                context.startActivity(intent)
             },
 
             SimpleBrowserMenuItem("Report issue") {

--- a/app/src/main/java/org/mozilla/reference/browser/components/Core.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Core.kt
@@ -16,6 +16,10 @@ import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.fetch.Client
+import mozilla.components.feature.addons.AddonManager
+import mozilla.components.feature.addons.amo.AddonCollectionProvider
+import mozilla.components.feature.addons.update.AddonUpdater
+import mozilla.components.feature.addons.update.DefaultAddonUpdater
 import mozilla.components.feature.downloads.DownloadsUseCases
 import mozilla.components.feature.media.MediaFeature
 import mozilla.components.feature.media.RecordingDevicesNotificationFeature
@@ -31,6 +35,8 @@ import org.mozilla.reference.browser.R.string.pref_key_remote_debugging
 import org.mozilla.reference.browser.R.string.pref_key_tracking_protection_normal
 import org.mozilla.reference.browser.R.string.pref_key_tracking_protection_private
 import java.util.concurrent.TimeUnit
+
+private const val DAY_IN_MINUTES = 24 * 60L
 
 /**
  * Component group for all core browser functionality.
@@ -117,6 +123,20 @@ class Core(private val context: Context) {
      * Icons component for loading, caching and processing website icons.
      */
     val icons by lazy { BrowserIcons(context, client) }
+
+    // Addons
+    val addonManager by lazy {
+        val addonUpdater = DefaultAddonUpdater(context, AddonUpdater.Frequency(1, TimeUnit.DAYS))
+        AddonManager(store, engine, addonCollectionProvider, addonUpdater)
+    }
+
+    val addonCollectionProvider by lazy {
+        AddonCollectionProvider(
+            context = context,
+            client = client,
+            maxCacheAgeInMinutes = DAY_IN_MINUTES
+        )
+    }
 
     /**
      * Constructs a [TrackingProtectionPolicy] based on current preferences.

--- a/app/src/main/res/drawable/addon_textview_selector.xml
+++ b/app/src/main/res/drawable/addon_textview_selector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~  License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="true" android:color="@android:color/black" />
+    <item android:state_checked="false" android:color="@color/photonGrey40" />
+</selector>

--- a/app/src/main/res/drawable/mozac_ic_permissions.xml
+++ b/app/src/main/res/drawable/mozac_ic_permissions.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="16dp"
+        android:height="16dp"
+        android:autoMirrored="true"
+        android:viewportWidth="24"
+        android:viewportHeight="24">
+    <path
+            android:fillColor="#FF000000"
+            android:pathData="M2,1h20c1.1,0 2,0.9 2,2v18c0,1.1 -0.9,2 -2,2H2c-1.1,0 -2,-0.9 -2,-2V3c0,-1.1 0.9,-2 2,-2z" />
+    <path
+            android:fillColor="#FFF"
+            android:pathData="M12,3h9c0.6,0 1,0.4 1,1v16c0,0.6 -0.4,1 -1,1h-9L12,3zM5.5,12.5l2.7,-3.7c0.2,-0.3 0.6,-0.3 0.8,-0.1l0.7,0.5c0.2,0.2 0.2,0.5 0,0.7L5.8,15c-0.2,0.2 -0.5,0.3 -0.8,0.1l-2.2,-2.2c-0.2,-0.2 -0.2,-0.5 0,-0.7l0.8,-0.8c0.2,-0.2 0.5,-0.2 0.7,0l1.2,1.1z" />
+    <path
+            android:fillColor="#FF000000"
+            android:pathData="M15,9l-1,1 2,2 -2,2 1,1 2,-2 2,2 1,-1 -2,-2 2,-2 -1,-1 -2,2.01L15,9z" />
+</vector>
+

--- a/app/src/main/res/layout/activity_add_on_details.xml
+++ b/app/src/main/res/layout/activity_add_on_details.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:layout_marginBottom="6dp">
+
+    <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+            android:paddingEnd="?android:attr/listPreferredItemPaddingEnd">
+
+        <TextView
+                android:id="@+id/details"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="20dp"
+                tools:text="@tools:sample/lorem/random" />
+
+        <TextView
+                android:id="@+id/author_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/details"
+                android:text="@string/mozac_feature_addons_authors" />
+
+        <TextView
+                android:id="@+id/author_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/details"
+                android:layout_alignParentEnd="true"
+                tools:text="@tools:sample/full_names" />
+
+        <View
+                android:id="@+id/author_divider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_below="@+id/author_label"
+                android:layout_marginTop="10dp"
+                android:layout_marginBottom="10dp"
+                android:background="@color/photonGrey40"
+                android:importantForAccessibility="no" />
+
+        <TextView
+                android:id="@+id/version_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/author_divider"
+                android:text="@string/mozac_feature_addons_version" />
+
+        <TextView
+                android:id="@+id/version_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/author_divider"
+                android:layout_alignParentEnd="true"
+                tools:text="1.2.3" />
+
+        <View
+                android:id="@+id/version_divider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_below="@+id/version_label"
+                android:layout_marginTop="10dp"
+                android:layout_marginBottom="10dp"
+                android:background="@color/photonGrey40"
+                android:importantForAccessibility="no" />
+
+        <TextView
+                android:id="@+id/last_updated_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/version_divider"
+                android:text="@string/mozac_feature_addons_last_updated" />
+
+        <TextView
+                android:id="@+id/last_updated_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/version_divider"
+                android:layout_alignParentEnd="true"
+                tools:text="Oct 16, 2019" />
+
+        <View
+                android:id="@+id/last_updated_divider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_below="@+id/last_updated_label"
+                android:layout_marginTop="10dp"
+                android:layout_marginBottom="10dp"
+                android:background="@color/photonGrey40"
+                android:importantForAccessibility="no" />
+
+        <TextView
+                android:id="@+id/home_page_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/last_updated_divider"
+                android:text="@string/mozac_feature_addons_home_page" />
+
+        <ImageView
+                android:id="@+id/home_page_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/last_updated_divider"
+                android:layout_alignParentEnd="true"
+                android:contentDescription="@string/mozac_feature_addons_home_page"
+                android:src="@drawable/mozac_ic_link"
+                android:tint="@android:color/black" />
+
+        <View
+                android:id="@+id/home_page_divider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_below="@+id/home_page_label"
+                android:layout_marginTop="10dp"
+                android:layout_marginBottom="10dp"
+                android:background="@color/photonGrey40"
+                android:importantForAccessibility="no" />
+
+        <TextView
+                android:id="@+id/rating_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/home_page_divider"
+                android:text="@string/mozac_feature_addons_rating" />
+
+        <RatingBar
+                android:id="@+id/rating_view"
+                style="@style/Widget.AppCompat.RatingBar.Small"
+                android:layout_width="wrap_content"
+                android:layout_height="20dp"
+                android:layout_below="@+id/home_page_divider"
+                android:layout_toStartOf="@+id/users_count"
+                android:isIndicator="true"
+                android:numStars="5" />
+
+        <TextView
+                android:id="@+id/users_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/home_page_divider"
+                android:layout_alignParentEnd="true"
+                android:layout_marginStart="6dp"
+                tools:text="591,642" />
+
+    </RelativeLayout>
+</ScrollView>

--- a/app/src/main/res/layout/activity_add_on_permissions.xml
+++ b/app/src/main/res/layout/activity_add_on_permissions.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        tools:context=".addons.PermissionsDetailsActivity">
+
+    <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/add_ons_permissions"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    <TextView
+            android:id="@+id/learn_more_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/add_ons_permissions"
+            android:drawableEnd="@drawable/mozac_ic_link"
+            android:padding="16dp"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:background="?attr/selectableItemBackground"
+            android:text="@string/mozac_feature_addons_learn_more"
+            app:drawableTint="@android:color/black"
+            android:textColor="@android:color/black" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_add_on_settings.xml
+++ b/app/src/main/res/layout/activity_add_on_settings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/addonSettingsContainer"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:ignore="MergeRootFrame" />

--- a/app/src/main/res/layout/activity_installed_add_on_details.xml
+++ b/app/src/main/res/layout/activity_installed_add_on_details.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="6dp">
+
+    <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+            android:paddingEnd="?android:attr/listPreferredItemPaddingEnd">
+
+        <Switch
+                android:id="@+id/enable_switch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical|end"
+                android:background="?android:attr/selectableItemBackground"
+                android:checked="true"
+                android:clickable="true"
+                android:focusable="true"
+                android:text="@string/mozac_feature_addons_settings_off"
+                android:padding="16dp"
+                android:textSize="18sp"/>
+
+        <TextView
+                android:id="@+id/settings"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/enable_switch"
+                android:background="?android:attr/selectableItemBackground"
+                android:drawablePadding="10dp"
+                android:padding="16dp"
+                android:text="@string/mozac_feature_addons_settings"
+                android:textColor="@drawable/addon_textview_selector"
+                android:textSize="18sp"
+                app:drawableStartCompat="@drawable/mozac_ic_preferences"
+                app:drawableTint="@android:color/black" />
+
+        <TextView
+                android:id="@+id/details"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/settings"
+                android:background="?android:attr/selectableItemBackground"
+                android:drawablePadding="6dp"
+                android:padding="16dp"
+                android:text="@string/mozac_feature_addons_details"
+                android:textColor="@drawable/addon_textview_selector"
+                android:textSize="18sp"
+                app:drawableStartCompat="@drawable/mozac_ic_information"
+                app:drawableTint="@android:color/black" />
+
+        <TextView
+                android:id="@+id/permissions"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/details"
+                android:background="?android:attr/selectableItemBackground"
+                android:drawablePadding="6dp"
+                android:padding="16dp"
+                android:text="@string/mozac_feature_addons_permissions"
+                android:textColor="@drawable/addon_textview_selector"
+                android:textSize="18sp"
+                app:drawableStartCompat="@drawable/mozac_ic_permissions" />
+
+        <Button
+                android:id="@+id/remove_add_on"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/permissions"
+                android:layout_marginTop="16dp"
+                android:textColor="@color/photonRed50"
+                android:text="@string/mozac_feature_addons_remove" />
+    </RelativeLayout>
+</ScrollView>

--- a/app/src/main/res/layout/add_ons_item.xml
+++ b/app/src/main/res/layout/add_ons_item.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/add_on_item"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?android:attr/selectableItemBackground"
+        android:orientation="horizontal"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+    <androidx.cardview.widget.CardView
+            android:id="@+id/icon_container"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_alignParentStart="true"
+            android:layout_marginTop="16dp"
+            android:elevation="0dp"
+            app:cardCornerRadius="30dp">
+
+        <ImageView
+                android:id="@+id/add_on_icon"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_gravity="center"
+                android:src="@drawable/mozac_ic_extensions"
+                android:importantForAccessibility="no"
+                android:scaleType="fitCenter" />
+
+    </androidx.cardview.widget.CardView>
+
+    <LinearLayout
+            android:id="@+id/details_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:padding="8dp"
+            android:layout_toStartOf="@+id/add_button"
+            android:layout_toEndOf="@+id/icon_container"
+            android:orientation="vertical">
+
+        <TextView
+                android:id="@+id/add_on_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textStyle="bold"
+                android:layout_marginBottom="6dp"
+                tools:text="uBlock Origin" />
+
+        <TextView
+                android:id="@+id/add_on_description"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="12sp"
+                tools:text="An efficient blocker: easy on memory and CPU footprint, and yet can load and enforce thousands more filters than other popular blockers out there." />
+
+        <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:orientation="horizontal">
+
+            <RatingBar
+                    android:id="@+id/rating"
+                    style="@style/Widget.AppCompat.RatingBar.Small"
+                    android:layout_width="wrap_content"
+                    android:layout_height="20dp"
+                    android:isIndicator="true"
+                    android:numStars="5" />
+
+            <TextView
+                    android:id="@+id/users_count"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="6dp"
+                    android:textSize="12sp"
+                    tools:text="Users: 591,642" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <ImageView
+            android:id="@+id/add_button"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:contentDescription="@string/mozac_feature_addons_install_addon_content_description"
+            android:tint="@android:color/black"
+            android:src="@drawable/mozac_ic_new" />
+</RelativeLayout>

--- a/app/src/main/res/layout/add_ons_permission_item.xml
+++ b/app/src/main/res/layout/add_ons_permission_item.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/add_on_item"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?android:attr/selectableItemBackground"
+        android:orientation="vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+    <TextView
+            android:id="@+id/permission"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:textColor="@android:color/black"
+            tools:text="Access your data for all websites" />
+
+    <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/photonGrey40"
+            android:importantForAccessibility="no" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/addons_section_item.xml
+++ b/app/src/main/res/layout/addons_section_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?android:attr/selectableItemBackground"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        tools:text="@string/addon_settings_recommended_header"
+        android:textStyle="bold" />

--- a/app/src/main/res/layout/fragment_add_on_settings.xml
+++ b/app/src/main/res/layout/fragment_add_on_settings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <mozilla.components.concept.engine.EngineView
+        android:id="@+id/addonSettingsEngineView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_add_ons.xml
+++ b/app/src/main/res/layout/fragment_add_ons.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/add_ons_list"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".BrowserActivity"/>

--- a/app/src/main/res/layout/fragment_dialog_addon_permissions.xml
+++ b/app/src/main/res/layout/fragment_dialog_addon_permissions.xml
@@ -1,0 +1,79 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?android:windowBackground"
+        android:orientation="vertical"
+        tools:ignore="Overdraw">
+
+    <ImageView
+            android:id="@+id/icon"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_alignParentTop="true"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:importantForAccessibility="no"
+            android:scaleType="center"
+            android:src="@drawable/mozac_ic_extensions"
+            android:tint="?android:attr/textColorPrimary" />
+
+    <TextView
+            android:id="@+id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignBaseline="@id/icon"
+            android:layout_alignParentTop="true"
+            android:layout_marginStart="3dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="11dp"
+            android:layout_toEndOf="@id/icon"
+            android:paddingStart="5dp"
+            android:paddingTop="4dp"
+            android:paddingEnd="5dp"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textSize="16sp"
+            tools:text="Add Ublock Origin?"
+            tools:textColor="#000000" />
+
+    <TextView
+            android:id="@+id/permissions"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/title"
+            android:layout_alignStart="@id/title"
+            android:layout_marginTop="16dp"
+            android:paddingStart="5dp"
+            android:paddingTop="4dp"
+            android:paddingEnd="5dp"
+            android:textColor="?android:attr/textColorPrimary"
+            tools:text="It requires your permission to: \n\n 	• Access your data for all websites. \n\n 	• Acess browser tabs. \n\n 	• Access browser activity during navigation." />
+
+    <Button
+            android:id="@+id/deny_button"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/permissions"
+            android:layout_marginTop="16dp"
+            android:layout_toStartOf="@id/allow_button"
+            android:text="@string/addon_permissions_dialog_cancel"
+            android:textAllCaps="false" />
+
+    <Button
+            android:id="@+id/allow_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/permissions"
+            android:layout_alignParentEnd="true"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:text="@string/addon_permissions_dialog_add"
+            android:textAllCaps="false" />
+
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -165,4 +165,8 @@
     <!-- %s is the device name -->
     <string name="fxa_tab_received_from_notification_name">Tab from %s</string>
 
+    <!-- Addons -->
+    <string name="addon_permissions_dialog_add">Add</string>
+    <string name="addon_permissions_dialog_cancel">Cancel</string>
+
 </resources>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,6 +27,10 @@ private object Versions {
     const val tools_test_rules = "1.1.0"
     const val tools_test_runner = "1.1.0"
     const val uiautomator = "2.2.0"
+
+    object AndroidX {
+        const val core = "1.1.0"
+    }
 }
 
 // Synchronized dependencies used by (some) modules
@@ -57,6 +61,7 @@ object Deps {
     const val mozilla_browser_icons = "org.mozilla.components:browser-icons:${Versions.mozilla_android_components}"
 
     const val mozilla_feature_accounts = "org.mozilla.components:feature-accounts:${Versions.mozilla_android_components}"
+    const val mozilla_feature_addons = "org.mozilla.components:feature-addons:${Versions.mozilla_android_components}"
     const val mozilla_feature_app_links = "org.mozilla.components:feature-app-links:${Versions.mozilla_android_components}"
     const val mozilla_feature_awesomebar = "org.mozilla.components:feature-awesomebar:${Versions.mozilla_android_components}"
     const val mozilla_feature_contextmenu = "org.mozilla.components:feature-contextmenu:${Versions.mozilla_android_components}"
@@ -82,6 +87,7 @@ object Deps {
 
     const val mozilla_ui_autocomplete = "org.mozilla.components:ui-autocomplete:${Versions.mozilla_android_components}"
     const val mozilla_ui_colors = "org.mozilla.components:ui-colors:${Versions.mozilla_android_components}"
+    const val mozilla_ui_icons = "org.mozilla.components:ui-icons:${Versions.mozilla_android_components}"
 
     const val mozilla_service_firefox_accounts = "org.mozilla.components:service-firefox-accounts:${Versions.mozilla_android_components}"
     const val mozilla_service_glean = "org.mozilla.components:service-glean:${Versions.mozilla_android_components}"
@@ -91,6 +97,7 @@ object Deps {
     const val mozilla_support_ktx= "org.mozilla.components:support-ktx:${Versions.mozilla_android_components}"
     const val mozilla_support_rustlog = "org.mozilla.components:support-rustlog:${Versions.mozilla_android_components}"
     const val mozilla_support_rusthttp = "org.mozilla.components:support-rusthttp:${Versions.mozilla_android_components}"
+    const val mozilla_support_webextensions = "org.mozilla.components:support-webextensions:${Versions.mozilla_android_components}"
 
     const val mozilla_lib_crash = "org.mozilla.components:lib-crash:${Versions.mozilla_android_components}"
     const val mozilla_lib_push_firebase = "org.mozilla.components:lib-push-firebase:${Versions.mozilla_android_components}"
@@ -98,6 +105,7 @@ object Deps {
     const val thirdparty_sentry = "io.sentry:sentry-android:${Versions.thirdparty_sentry}"
 
     const val androidx_appcompat = "androidx.appcompat:appcompat:${Versions.androidx_appcompat}"
+    const val androidx_core_ktx = "androidx.core:core-ktx:${Versions.AndroidX.core}"
     const val androidx_constraintlayout = "androidx.constraintlayout:constraintlayout:${Versions.androidx_constraintlayout}"
     const val androidx_preference_ktx = "androidx.preference:preference-ktx:${Versions.androidx_preference}"
     const val androidx_work_runtime_ktx = "androidx.work:work-runtime-ktx:${Versions.workmanager}"


### PR DESCRIPTION
Imported the Addon support implementation from Sample Browser to Reference Browser so I could play around with it. :)

Not sure how we feel about adding it here since it might be too early/unstable.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
