### PR TITLE
Prepare to use minidump_stackwalk toolchain artifact rather than tooltool package

### DIFF
--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -8,6 +8,7 @@ transforms:
 
 kind-dependencies:
     - signing
+    - toolchain
 only-for-build-types:
     - raptor
 only-for-abis:
@@ -39,6 +40,7 @@ job-defaults:
         tier: 2
     dependencies:
         geckoview-nightly: geckoview-nightly
+        linux64-minidump-stackwalk: toolchain-linux64-minidump-stackwalk
     worker:
         max-run-time: 3600
         env:
@@ -67,6 +69,9 @@ job-defaults:
             - '--binary=org.mozilla.reference.browser.raptor'
             - '--activity=org.mozilla.reference.browser.GeckoViewActivity'
             - '--download-symbols=ondemand'
+    fetches:
+        linux64-minidump-stackwalk:
+            - artifact: minidump_stackwalk.tar.xz
 
 jobs:
     speedometer:

--- a/taskcluster/ci/toolchain/kind.yml
+++ b/taskcluster/ci/toolchain/kind.yml
@@ -1,0 +1,11 @@
+---
+loader: taskgraph.loader.transform:loader
+transforms:
+    - taskgraph.transforms.index_search:transforms
+    - taskgraph.transforms.task:transforms
+
+jobs:
+    linux64-minidump-stackwalk:
+        description: "minidump_stackwalk toolchain"
+        index-search:
+            - gecko.cache.level-3.toolchains.v3.linux64-minidump-stackwalk.latest

--- a/taskcluster/rb_taskgraph/transforms/raptor.py
+++ b/taskcluster/rb_taskgraph/transforms/raptor.py
@@ -26,7 +26,7 @@ def add_variants(config, tasks):
     tests = list(tasks)
 
     for dep_task in config.kind_dependencies_tasks:
-        build_type = dep_task.attributes["build-type"]
+        build_type = dep_task.attributes.get("build-type", '')
         if build_type not in only_types:
             continue
 


### PR DESCRIPTION
Bug 1525218 is changing mozilla-central to use minidump_stackwalk toolchain artifacts instead of tooltool packages, and both fenix and reference-browser broke when that landed because the new mozharness code expected the toolchain artifacts that their taskgraph doesn't know about. This is about adding them.