### PR TITLE
Bug 1618531 - Rename APK signing format

### DIFF
--- a/taskcluster/rb_taskgraph/transforms/signing_apks.py
+++ b/taskcluster/rb_taskgraph/transforms/signing_apks.py
@@ -23,7 +23,7 @@ def build_signing_task(config, tasks):
                 "taskId": {"task-reference": "<build>"},
                 "taskType": "build",
                 "paths": dep.attributes["apks"].values(),
-                "formats": ["autograph_apk_reference_browser"],
+                "formats": ["autograph_apk"],
             }
         ]
         del task["primary-dependency"]

--- a/taskcluster/rb_taskgraph/transforms/signing_bundle.py
+++ b/taskcluster/rb_taskgraph/transforms/signing_bundle.py
@@ -23,7 +23,7 @@ def build_signing_task(config, tasks):
             "taskId": {"task-reference": "<build-bundle>"},
             "taskType": "build",
             "paths": [dep.attributes["aab"]],
-            "formats": ["autograph_apk_reference_browser"],
+            "formats": ["autograph_apk"],
         }]
         del task["primary-dependency"]
         yield task


### PR DESCRIPTION
Fixes https://firefox-ci-tc.services.mozilla.com/tasks/KFXZv85-RcqFAw19GT_ZvA/runs/1/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FKFXZv85-RcqFAw19GT_ZvA%2Fruns%2F1%2Fartifacts%2Fpublic%2Flogs%2Flive_backing.log#L27 

The signing format remains the same, it was just renamed as part of https://github.com/mozilla-releng/scriptworker-scripts/pull/158. The full rationale is in [bug 1618531 comment 0](https://bugzilla.mozilla.org/show_bug.cgi?id=1618531#c0)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
