### PR TITLE
Use Android Components Nightly builds instead of snapshots.

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
@@ -39,7 +39,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 requireComponents.core.client)
             .addSessionProvider(
                 resources,
-                requireComponents.core.sessionManager,
+                requireComponents.core.store,
                 requireComponents.useCases.tabsUseCases.selectTab)
             .addHistoryProvider(
                 requireComponents.core.historyStorage,

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
         google()
 
         maven {
-            url "https://snapshots.maven.mozilla.org/maven2"
+            url "https://nightly.maven.mozilla.org/maven2"
 
             content {
                 // Always fetch components from the snapshots repository


### PR DESCRIPTION
Switching from snapshots to nightly builds. For now we are still using `+` as the requested version. The next step is to switch to a pinned version and have an automation task update it if tests pass.