### PR TITLE
update_android_components.sh: Correctly install 'hub' command.

### DIFF
--- a/automation/taskcluster/update_android_components.sh
+++ b/automation/taskcluster/update_android_components.sh
@@ -6,8 +6,9 @@
 set -ex
 
 # Install dependencies (TODO: Move to Docker image)
-apt-get install -y brew
-brew install hub
+wget https://github.com/github/hub/releases/download/v2.14.1/hub-linux-amd64-2.14.1.tgz
+tar -xzvf hub-linux-amd64-2.14.1.tgz
+PATH=$PATH:`pwd`hub-linux-amd64-2.14.1/bin
 
 BRANCH="ac-update"
 USER="MickeyMoz"


### PR DESCRIPTION
Locally I was testing on MacOS and there I could use `brew`. In our Ubuntu-based `Docker` images this of course doesn't make any sense. The [docs](https://github.com/github/hub) suggest to use `snap` to install `hub`. But installing ~200 MB of packages to get another package manager seems hardly worth it. So for now we are downloading a prebuild binary from the `hub` releases page.