### PR TITLE
Bug 1611397 - Fix Raptor Reference-Browser activity.

### DIFF
--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -67,7 +67,7 @@ job-defaults:
             - '--cfg=mozharness/configs/raptor/android_hw_config.py'
             - '--app=refbrow'
             - '--binary=org.mozilla.reference.browser.raptor'
-            - '--activity=org.mozilla.reference.browser.GeckoViewActivity'
+            - '--activity=org.mozilla.reference.browser.BrowserTestActivity'
             - '--download-symbols=ondemand'
     fetches:
         linux64-minidump-stackwalk:


### PR DESCRIPTION
This patch fixes the raptor reference-browser `--activity` to use the correct name `BrowserTestActivity`. Previously, it was erroneously using the GeckoView activity.