### PR TITLE
Bug 1622339 - Move android-sdk installation into a toolchain task

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: 5c4df61138f328708073cc7223d614a6040a8bab
+              revision: f949fb56d96b9509b071ba55853f2d60e8dbbf57
           trustDomain: mobile
       in:
           $if: 'tasks_for in ["github-pull-request", "github-push", "action", "cron"]'
@@ -220,7 +220,7 @@ tasks:
                                         taskgraph action-callback
                                     else: >
                                         PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
-                                        taskcluster/scripts/install-sdk.sh &&
+                                        taskcluster/scripts/decision-install-sdk.sh &&
                                         ln -s /builds/worker/artifacts artifacts &&
                                         ~/.local/bin/taskgraph decision
                                         --pushlog-id='0'

--- a/taskcluster/ci/build-bundle/kind.yml
+++ b/taskcluster/ci/build-bundle/kind.yml
@@ -10,8 +10,22 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
+kind-dependencies:
+    - toolchain
+
+
 job-defaults:
+    aab-artifact-template:
+        type: file
+        name: public/target.aab
+        path: '/builds/worker/checkouts/src/app/build/outputs/bundle/{variant}/app-{variant}.aab'
     description: Build AAB (Android App Bundle) from source code.
+    fetches:
+        toolchain:
+            - android-sdk-linux
+    run:
+        using: gradlew
+        use-caches: false
     treeherder:
         kind: build
         symbol: AAB
@@ -21,13 +35,7 @@ job-defaults:
         docker-image: {in-tree: base}
         max-run-time: 7200
         chain-of-trust: true
-    run:
-        using: gradlew
-        use-caches: false
-    aab-artifact-template:
-        type: file
-        name: public/target.aab
-        path: '/builds/worker/checkouts/src/app/build/outputs/bundle/{variant}/app-{variant}.aab'
+
 
 jobs:
     nightly:

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -10,20 +10,11 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
+kind-dependencies:
+    - toolchain
+
+
 job-defaults:
-    description: Build Reference Browser from source code.
-    treeherder:
-        kind: build
-        symbol: B
-        tier: 2
-    worker-type: b-android
-    worker:
-        docker-image: {in-tree: base}
-        max-run-time: 7200
-        chain-of-trust: true
-    run:
-        using: gradlew
-        use-caches: false
     # Builds generate multiple APKs with different ABIs. For each APK described
     # by `gradlew printVariants`, an artifact will be generated. `variant` and
     # the per-apk config from `printVariants` can be used as subsistutions in
@@ -32,6 +23,22 @@ job-defaults:
         type: file
         name: public/target.{abi}.apk
         path: '/builds/worker/checkouts/src/app/build/outputs/apk/{gradle_build_type}/{fileName}'
+    description: Build Reference Browser from source code.
+    fetches:
+        toolchain:
+            - android-sdk-linux
+    treeherder:
+        kind: build
+        symbol: B
+        tier: 2
+    run:
+        using: gradlew
+        use-caches: false
+    worker-type: b-android
+    worker:
+        docker-image: {in-tree: base}
+        max-run-time: 7200
+        chain-of-trust: true
 
 jobs:
     nightly:

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -3,9 +3,11 @@ trust-domain: mobile
 treeherder:
     group-names:
         'bump': 'Bump dependencies'
+        'Fetch': 'Fetch and store content'
         'I': 'Docker Image Builds'
         'Rap': 'Raptor tests'
         'Rap-P': 'Raptor power tests'
+        'TL': 'Toolchain builds for Linux 64-bits'
 
 task-priority: lowest
 

--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - taskgraph.transforms.fetch:transforms
+    - taskgraph.transforms.job:transforms
+    - taskgraph.transforms.task:transforms
+
+job-defaults:
+    docker-image: {in-tree: base}
+
+jobs:
+    android-sdk-3859397:
+        description: Android SDK
+        fetch:
+            type: static-url
+            url: https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip
+            artifact-name: sdk-tools-linux.zip
+            sha256: 444e22ce8ca0f67353bda4b85175ed3731cae3ffa695ca18119cbacef1c1bea0
+            size: 136964098
+        artifact-prefix: mobile/android-sdk
+        fetch-alias: android-sdk

--- a/taskcluster/ci/geckoview/kind.yml
+++ b/taskcluster/ci/geckoview/kind.yml
@@ -1,11 +1,14 @@
 ---
 loader: taskgraph.loader.transform:loader
 transforms:
-    - taskgraph.transforms.index_search:transforms
+    - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
 jobs:
     nightly:
         description: "upstream nightly job"
-        index-search:
-            - gecko.v2.mozilla-central.nightly.latest.mobile.android-x86_64-opt
+        run:
+            using: index-search
+            index-search:
+                - gecko.v2.mozilla-central.nightly.latest.mobile.android-x86_64-opt
+        worker-type: always-optimized

--- a/taskcluster/ci/lint/kind.yml
+++ b/taskcluster/ci/lint/kind.yml
@@ -9,19 +9,27 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
+kind-dependencies:
+    - toolchain
+
+
 job-defaults:
     attributes:
         code-review: true
-    worker-type: b-android
-    worker:
-        docker-image: {in-tree: base}
-        max-run-time: 7200
+    fetches:
+        toolchain:
+            - android-sdk-linux
     run:
         use-caches: false
     treeherder:
         kind: test
         platform: 'lint/opt'
         tier: 1
+    worker-type: b-android
+    worker:
+        docker-image: {in-tree: base}
+        max-run-time: 7200
+
 
 jobs:
     compare-locales:

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -9,8 +9,18 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
+kind-dependencies:
+    - toolchain
+
+
 job-defaults:
     description: Test Reference Browser
+    fetches:
+        toolchain:
+            - android-sdk-linux
+    run:
+        using: gradlew
+        use-caches: false
     treeherder:
         kind: test
         symbol: T
@@ -20,9 +30,7 @@ job-defaults:
         docker-image: {in-tree: base}
         max-run-time: 7200
         chain-of-trust: true
-    run:
-        using: gradlew
-        use-caches: false
+
 
 jobs:
     nightly:

--- a/taskcluster/ci/toolchain/android.yml
+++ b/taskcluster/ci/toolchain/android.yml
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+job-defaults:
+    worker-type: b-android
+    worker:
+        docker-image: {in-tree: base}
+        max-run-time: 1800
+
+
+linux64-android-sdk-linux-repack:
+    attributes:
+        artifact_prefix: mobile/android-sdk
+    description: "Android SDK (Linux) repack toolchain build"
+    fetches:
+        fetch:
+            - android-sdk
+    run:
+        script: repack-android-sdk-linux.sh
+        resources: []
+        toolchain-artifact: mobile/android-sdk/android-sdk-linux.tar.xz
+        toolchain-alias: android-sdk-linux
+    treeherder:
+        symbol: TL(android-sdk-linux)

--- a/taskcluster/ci/toolchain/kind.yml
+++ b/taskcluster/ci/toolchain/kind.yml
@@ -1,11 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
 loader: taskgraph.loader.transform:loader
+
+kind-dependencies:
+    - fetch
+
 transforms:
-    - taskgraph.transforms.index_search:transforms
+    - taskgraph.transforms.job:transforms
+    - taskgraph.transforms.cached_tasks:transforms
     - taskgraph.transforms.task:transforms
 
-jobs:
-    linux64-minidump-stackwalk:
-        description: "minidump_stackwalk toolchain"
-        index-search:
-            - gecko.cache.level-3.toolchains.v3.linux64-minidump-stackwalk.latest
+
+job-defaults:
+    treeherder:
+        kind: build
+        platform: toolchains/opt
+        tier: 1
+    run-on-projects: []
+    run:
+        using: toolchain-script
+
+
+jobs-from:
+    - android.yml
+    - minidump-stackwalk.yml

--- a/taskcluster/ci/toolchain/minidump-stackwalk.yml
+++ b/taskcluster/ci/toolchain/minidump-stackwalk.yml
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+job-defaults:
+    description: "minidump-stackwalk toolchain"
+    run:
+        using: index-search
+    worker-type: always-optimized
+
+
+linux64-minidump-stackwalk:
+    run:
+        index-search:
+            - gecko.cache.level-3.toolchains.v3.linux64-minidump-stackwalk.latest
+    treeherder:
+        symbol: TL(stackwalk)

--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -19,14 +19,9 @@ WORKDIR /builds/worker/
 #-- Configuration -----------------------------------------------------------------------------------------------------
 #----------------------------------------------------------------------------------------------------------------------
 
-ENV ANDROID_SDK_SHA256='444e22ce8ca0f67353bda4b85175ed3731cae3ffa695ca18119cbacef1c1bea0' \
-    ANDROID_SDK_VERSION='3859397' \
-    ANDROID_SDK_ROOT='/builds/worker/android-sdk-linux' \
-    CURL='curl --location --retry 5' \
-    GRADLE_OPTS='-Xmx4096m -Dorg.gradle.daemon=false' \
+ENV GRADLE_OPTS='-Xmx4096m -Dorg.gradle.daemon=false' \
     LANG='en_US.UTF-8' \
-    TERM='dumb' \
-    SDK_ZIP_LOCATION="$HOME/sdk-tools-linux.zip"
+    TERM='dumb'
 
 #----------------------------------------------------------------------------------------------------------------------
 #-- System ------------------------------------------------------------------------------------------------------------
@@ -53,13 +48,6 @@ RUN pip install --upgrade pip
 RUN pip install taskcluster
 
 RUN locale-gen "$LANG"
-
-RUN $CURL --output "$SDK_ZIP_LOCATION" "https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_VERSION}.zip" \
-    && echo "$ANDROID_SDK_SHA256  $SDK_ZIP_LOCATION" | sha256sum --check \
-    && unzip -d "$ANDROID_SDK_ROOT" "$SDK_ZIP_LOCATION" \
-    && rm "$SDK_ZIP_LOCATION" \
-    && yes | "${ANDROID_SDK_ROOT}/tools/bin/sdkmanager" --licenses \
-    && chown -R worker:worker "$ANDROID_SDK_ROOT"
 
 
 # %include-run-task

--- a/taskcluster/docker/bump/Dockerfile
+++ b/taskcluster/docker/bump/Dockerfile
@@ -5,7 +5,8 @@ MAINTAINER Johan Lorenzo <jlorenzo+tc@mozilla.com>
 
 USER worker:worker
 
-ENV HUB_ARCHIVE='hub.tgz' \
+ENV CURL='curl --location --retry 5' \
+  HUB_ARCHIVE='hub.tgz' \
   HUB_ROOT='/builds/worker/hub' \
   HUB_SHA256='734733c9d807715a4ec26ccce0f9987bd19f1c3f84dd35e56451711766930ef0' \
   HUB_VERSION='2.14.1'

--- a/taskcluster/rb_taskgraph/job.py
+++ b/taskcluster/rb_taskgraph/job.py
@@ -75,9 +75,11 @@ def configure_gradlew(config, job, taskdesc):
     run = job["run"]
     worker = taskdesc["worker"] = job["worker"]
 
-    worker.setdefault("env", {}).update(
-        {"ANDROID_SDK_ROOT": path.join(run["workdir"], "android-sdk-linux")}
-    )
+    worker.setdefault("env", {}).update({
+        "ANDROID_SDK_ROOT": path.join(
+            run["workdir"], worker["env"]["MOZ_FETCHES_DIR"], "android-sdk-linux"
+        )
+    })
 
     run["command"] = _extract_gradlew_command(run)
     _inject_secrets_scopes(run, taskdesc)

--- a/taskcluster/scripts/decision-install-sdk.sh
+++ b/taskcluster/scripts/decision-install-sdk.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -ex
+
+export CURL='curl --location --retry 5'
+
+ANDROID_SDK_VERSION='3859397'
+ANDROID_SDK_SHA256='444e22ce8ca0f67353bda4b85175ed3731cae3ffa695ca18119cbacef1c1bea0'
+SDK_ZIP_LOCATION="$HOME/sdk-tools-linux.zip"
+
+$CURL --output "$SDK_ZIP_LOCATION" "https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_VERSION}.zip"
+echo "$ANDROID_SDK_SHA256  $SDK_ZIP_LOCATION" | sha256sum --check
+unzip -d "$ANDROID_SDK_ROOT" "$SDK_ZIP_LOCATION"
+rm "$SDK_ZIP_LOCATION"
+yes | "${ANDROID_SDK_ROOT}/tools/bin/sdkmanager" --licenses

--- a/taskcluster/scripts/install-sdk.sh
+++ b/taskcluster/scripts/install-sdk.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set +x
-
-ANDROID_SDK_VERSION=3859397
-
-curl -o "$HOME/sdk-tools-linux.zip" "https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_VERSION}.zip"
-unzip -d "$ANDROID_SDK_ROOT" "$HOME/sdk-tools-linux.zip"
-yes | "${ANDROID_SDK_ROOT}/tools/bin/sdkmanager" --licenses

--- a/taskcluster/scripts/toolchain/repack-android-sdk-linux.sh
+++ b/taskcluster/scripts/toolchain/repack-android-sdk-linux.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export ANDROID_SDK_ROOT=$MOZ_FETCHES_DIR
+
+yes | "${ANDROID_SDK_ROOT}/tools/bin/sdkmanager" --licenses
+
+# It's nice to have the build logs include the state of the world upon completion.
+"${ANDROID_SDK_ROOT}/tools/bin/sdkmanager" --list
+
+tar cf - -C "$ANDROID_SDK_ROOT" . --transform 's,^\./,android-sdk-linux/,' | xz > "$UPLOAD_DIR/android-sdk-linux.tar.xz"


### PR DESCRIPTION
This is a rebase of @tomprince's initial work at https://github.com/mozilla-mobile/reference-browser/compare/master...tp-tc:toolchain. We've had great additions in taskgraph since then. Thus, it made the patch much easier 🙂 

Depends on https://phabricator.services.mozilla.com/D68037

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
