### PR TITLE
Add support for auto-publication workflow for android-component

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ You might be interested in building this project against local versions of some 
 This could be done either by using a [local maven repository](https://mozilla-mobile.github.io/android-components/contributing/testing-components-inside-app) (quite cumbersome), or via Gradle's [dependency substitutions](https://docs.gradle.org/current/userguide/customizing_dependency_resolution_behavior.html) (not at all cumbersome!).
 
 Currently, the substitution flow is streamlined for some of the core dependencies via configuration flags in `local.properties`. You can build against a local checkout of the following dependencies by specifying their local paths:
+- [android-components](https://github.com/mozilla-mobile/android-components), specifying its path via `autoPublish.android-components.dir=../android-components`
+  - This assumes that you have an `android-components` project at the same level in the directory hierarchy as the `reference-browser`.
+  - When enabled, a Reference Browser build will compile android-components locally and publish if it has been modified,
+    and published versions of android-components modules will be automatically used instead of whatever is declared in Dependencies.kt.
 - [application-services](https://github.com/mozilla/application-services), specifying its path via `substitutions.application-services.dir=../application-services`
   - This assumes that you have an `application-services` project at the same level in the directory hierarchy as the `reference-browser`.
 - [GeckoView](https://hg.mozilla.org/mozilla-central), specifying its path via `dependencySubstitutions.geckoviewTopsrcdir=/path/to/mozilla-central` (and, optionally, `dependencySubstitutions.geckoviewTopobjdir=/path/to/topobjdir`). See [Bug 1533465](https://bugzilla.mozilla.org/show_bug.cgi?id=1533465).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -318,3 +318,8 @@ if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcd
     ext.topsrcdir = gradle."localProperties.dependencySubstitutions.geckoviewTopsrcdir"
     apply from: "${topsrcdir}/substitute-local-geckoview.gradle"
 }
+
+if (gradle.hasProperty('localProperties.autoPublish.android-components.dir')) {
+    ext.acSrcDir = gradle."localProperties.autoPublish.android-components.dir"
+    apply from: "../${acSrcDir}/substitute-local-ac.gradle"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,16 +1,40 @@
 include ':app'
 
-Properties localProperties = null;
-String settingAppServicesPath = "substitutions.application-services.dir";
+def log(message) {
+    logger.lifecycle("[settings] ${message}")
+}
+
+def runCmd(cmd, workingDir, successMessage) {
+    def proc = cmd.execute(null, new File(workingDir))
+    def standardOutput = new ByteArrayOutputStream()
+    def standardError = new ByteArrayOutputStream()
+    proc.consumeProcessOutput(standardOutput, standardError)
+    proc.waitFor()
+
+    if (proc.exitValue() != 0) {
+        throw new GradleException("Process '${cmd}' finished with non-zero exit value ${proc.exitValue()}:\n\nstdout:\n${standardOutput.toString()}\n\nstderr:\n${standardError.toString()}")
+    } else {
+        log(successMessage)
+    }
+    return standardOutput
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Local Development overrides
+//////////////////////////////////////////////////////////////////////////
+
+Properties localProperties = null
+String settingAndroidComponentsPath = "autoPublish.android-components.dir"
+String settingAppServicesPath = "substitutions.application-services.dir"
 // FIXME: substitution configuration for android-components.
 // See https://github.com/mozilla-mobile/reference-browser/issues/365
 
 if (file('local.properties').canRead()) {
     localProperties = new Properties()
     localProperties.load(file('local.properties').newDataInputStream())
-    logger.lifecycle('Local configuration: loaded local.properties')
+    log('Loaded local.properties')
 } else {
-    logger.lifecycle('Local configuration: absent local.properties; proceeding as normal.')
+    log('Missing local.properties; see https://github.com/mozilla-mobile/fenix/blob/master/README.md#local-properties-helpers for instructions.')
 }
 
 if (localProperties != null) {
@@ -18,14 +42,34 @@ if (localProperties != null) {
         gradle.ext.set("localProperties.${prop.key}", prop.value)
     }
 
-    String appServicesLocalPath = localProperties.getProperty(settingAppServicesPath);
+    String appServicesLocalPath = localProperties.getProperty(settingAppServicesPath)
 
     if (appServicesLocalPath != null) {
-        logger.lifecycle("Local configuration: substituting application-services modules from path: $appServicesLocalPath")
-
+        log("Enabling composite build with application-services modules from: $appServicesLocalPath")
         includeBuild(appServicesLocalPath)
 
     } else {
-        logger.lifecycle("Local configuration: application-services substitution path missing. You may specify it via '$settingAppServicesPath' setting.")
+        log("Disabled composite builds with application-services. Enable them by settings '$settingAppServicesPath' in local.properties")
+    }
+
+    String androidComponentsLocalPath = localProperties.getProperty(settingAndroidComponentsPath)
+
+    if (androidComponentsLocalPath != null) {
+        log("Enabling automatic publication of android-components from: $androidComponentsLocalPath")
+        log("Determining if android-components are up-to-date...")
+        def compileAcCmd = ["${androidComponentsLocalPath}/gradlew", "compileReleaseKotlin"]
+        def compileOutput = runCmd(compileAcCmd, androidComponentsLocalPath, "Compiled android-components.")
+        // This is somewhat brittle: parse last line of gradle output, to fish out how many tasks were executed.
+        // One executed task means gradle didn't do any work other than executing the top-level 'compile' task.
+        def compileTasksExecuted = compileOutput.toString().split('\n').last().split(':')[1].split(' ')[1]
+        if (compileTasksExecuted.equals("1")) {
+            log("android-components are up-to-date, skipping publication.")
+        } else {
+            log("android-components changed, publishing locally...")
+            def publishAcCmd = ["${androidComponentsLocalPath}/gradlew", "publishToMavenLocal", "-Plocal=true"]
+            runCmd(publishAcCmd, androidComponentsLocalPath, "Published android-components.")
+        }
+    } else {
+        log("Disabled auto-publication of android-components. Enable it by settings '$settingAndroidComponentsPath' in local.properties")
     }
 }


### PR DESCRIPTION
Applying AC autoPublish workflow patch to reference-browser https://github.com/mozilla-mobile/fenix/issues/1022

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
