### PR TITLE
Bug 1625126 - part 1: Cache external dependencies in a single task and let gradle tasks use it

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: f949fb56d96b9509b071ba55853f2d60e8dbbf57
+              revision: 1777b15a4fb990f2862ddcd9bdc8188c566abefb
           trustDomain: mobile
       in:
           $if: 'tasks_for in ["github-pull-request", "github-push", "action", "cron"]'

--- a/taskcluster/ci/build-bundle/kind.yml
+++ b/taskcluster/ci/build-bundle/kind.yml
@@ -23,6 +23,7 @@ job-defaults:
     fetches:
         toolchain:
             - android-sdk-linux
+            - android-gradle-dependencies
     run:
         using: gradlew
         use-caches: false

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -27,6 +27,7 @@ job-defaults:
     fetches:
         toolchain:
             - android-sdk-linux
+            - android-gradle-dependencies
     treeherder:
         kind: build
         symbol: B

--- a/taskcluster/ci/lint/kind.yml
+++ b/taskcluster/ci/lint/kind.yml
@@ -19,6 +19,7 @@ job-defaults:
     fetches:
         toolchain:
             - android-sdk-linux
+            - android-gradle-dependencies
     run:
         use-caches: false
     treeherder:

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -18,6 +18,7 @@ job-defaults:
     fetches:
         toolchain:
             - android-sdk-linux
+            - android-gradle-dependencies
     run:
         using: gradlew
         use-caches: false

--- a/taskcluster/ci/toolchain/android.yml
+++ b/taskcluster/ci/toolchain/android.yml
@@ -23,3 +23,27 @@ linux64-android-sdk-linux-repack:
         toolchain-alias: android-sdk-linux
     treeherder:
         symbol: TL(android-sdk-linux)
+
+
+linux64-android-gradle-dependencies:
+    description: "Android Gradle dependencies toolchain task"
+    fetches:
+        toolchain:
+            # Aliases aren't allowed for toolchains depending on toolchains.
+            - linux64-android-sdk-linux-repack
+    run:
+        script: android-gradle-dependencies.sh
+        sparse-profile: null
+        resources:
+            - taskcluster/scripts/toolchain/android-gradle-dependencies.sh
+            - buildSrc/src/main/java/Dependencies.kt
+            # We don't follow 'buildSrc/src/main/java/AndroidComponents.kt' because we only cache
+            # dependencies outside of the ones hosted on maven.mozilla.org.
+        toolchain-artifact: public/build/android-gradle-dependencies.tar.xz
+        toolchain-alias: android-gradle-dependencies
+    treeherder:
+        symbol: TL(gradle-dependencies)
+    worker:
+        env:
+            # TODO do no hardcode
+            ANDROID_SDK_ROOT: /builds/worker/fetches/android-sdk-linux

--- a/taskcluster/rb_taskgraph/job.py
+++ b/taskcluster/rb_taskgraph/job.py
@@ -75,10 +75,10 @@ def configure_gradlew(config, job, taskdesc):
     run = job["run"]
     worker = taskdesc["worker"] = job["worker"]
 
+    fetches_dir = path.join(run["workdir"], worker["env"]["MOZ_FETCHES_DIR"])
     worker.setdefault("env", {}).update({
-        "ANDROID_SDK_ROOT": path.join(
-            run["workdir"], worker["env"]["MOZ_FETCHES_DIR"], "android-sdk-linux"
-        )
+        "ANDROID_SDK_ROOT": path.join(fetches_dir, "android-sdk-linux"),
+        "GRADLE_USER_HOME": path.join(fetches_dir, "android-gradle-dependencies"),
     })
 
     run["command"] = _extract_gradlew_command(run)

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -ex
+
+function get_abs_path {
+    local file_path="$1"
+    echo "$( cd "$(dirname "$file_path")" >/dev/null 2>&1 ; pwd -P )"
+}
+
+CURRENT_DIR="$(get_abs_path $0)"
+PROJECT_DIR="$(get_abs_path $CURRENT_DIR/../../../..)"
+
+pushd $PROJECT_DIR
+
+# We build everything to be sure to fetch all dependencies
+./gradlew --no-daemon assemble assembleAndroidTest bundle test lint ktlint detekt
+
+# We only cache dependencies outside of the ones hosted on maven.mozilla.org.
+# caches/modules-2/files-2.1/ is where the pom, jar, and aar files are.
+tar cf - -C "$HOME/.gradle/" --exclude='*mozilla*' --transform='s,^,android-gradle-dependencies/,' 'caches/modules-2/files-2.1/' \
+  | xz > "$HOME/artifacts/android-gradle-dependencies.tar.xz"
+
+popd


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Before merging checklist
<!-- Before merging this PR, please address each item -->
- [ ] **Changelog**: This PR includes a [changelog](https://github.com/mozilla-mobile/reference-browser/wiki/Changelog) entry or does not need one.
