### PR TITLE
For #1104 - Implement new layout for tabs tray

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
@@ -11,6 +11,7 @@ import android.util.AttributeSet
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.snackbar.Snackbar.LENGTH_LONG
 import mozilla.components.browser.session.Session
@@ -23,6 +24,7 @@ import mozilla.components.lib.crash.Crash
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.utils.SafeIntent
 import mozilla.components.support.webextensions.WebExtensionPopupFeature
+import mozilla.components.browser.tabstray.TabsAdapter
 import org.mozilla.reference.browser.addons.WebExtensionActionPopupActivity
 import org.mozilla.reference.browser.browser.BrowserFragment
 import org.mozilla.reference.browser.browser.CrashIntegration
@@ -121,7 +123,9 @@ open class BrowserActivity : AppCompatActivity() {
         when (name) {
             EngineView::class.java.name -> components.core.engine.createView(context, attrs).asView()
             TabsTray::class.java.name -> {
-                BrowserTabsTray(context, attrs).also { tray ->
+                val layout = LinearLayoutManager(context)
+                val adapter = TabsAdapter(layoutId = R.layout.browser_tabstray_item)
+                BrowserTabsTray(context, attrs, tabsAdapter = adapter, layout = layout).also { tray ->
                     TabsTouchHelper(tray.tabsAdapter).attachToRecyclerView(tray)
                 }
             }

--- a/app/src/main/res/layout/browser_tabstray_item.xml
+++ b/app/src/main/res/layout/browser_tabstray_item.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="72dp">
+
+    <ImageView
+        android:id="@+id/mozac_browser_tabstray_icon"
+        android:layout_width="100dp"
+        android:layout_height="56dp"
+        android:visibility="gone"
+        android:importantForAccessibility="no"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/mozac_browser_tabstray_card"
+        android:layout_width="100dp"
+        android:layout_height="56dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginStart="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:cardBackgroundColor="@color/photonWhite">
+
+        <mozilla.components.browser.tabstray.thumbnail.TabThumbnailView
+            android:id="@+id/mozac_browser_tabstray_thumbnail"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:contentDescription="@string/mozac_browser_tabstray_open_tab" />
+
+    </androidx.cardview.widget.CardView>
+
+    <TextView
+        android:id="@+id/mozac_browser_tabstray_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:ellipsize="end"
+        android:lines="1"
+        android:textSize="16sp"
+        android:paddingTop="16dp"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintEnd_toStartOf="@id/mozac_browser_tabstray_close"
+        app:layout_constraintStart_toEndOf="@id/mozac_browser_tabstray_card"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/mozac_browser_tabstray_url"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_alignParentTop="true"
+        android:ellipsize="end"
+        android:lines="1"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintEnd_toStartOf="@id/mozac_browser_tabstray_close"
+        app:layout_constraintStart_toEndOf="@id/mozac_browser_tabstray_card"
+        app:layout_constraintTop_toBottomOf="@id/mozac_browser_tabstray_title" />
+
+    <androidx.appcompat.widget.AppCompatImageButton
+        android:id="@+id/mozac_browser_tabstray_close"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:contentDescription="@string/mozac_browser_tabstray_close_tab"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        app:srcCompat="@drawable/mozac_ic_close" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_tabstray.xml
+++ b/app/src/main/res/layout/fragment_tabstray.xml
@@ -4,6 +4,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:mozac="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -14,9 +15,9 @@
         app:layout_constraintBottom_toTopOf="@+id/tabsPanel"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-    </mozilla.components.concept.tabstray.TabsTray>
+        app:layout_constraintTop_toTopOf="parent"
+        mozac:tabsTrayItemBackgroundColor="@android:color/transparent"
+        mozac:tabsTrayItemTextColor="#ffffff" />
 
     <org.mozilla.reference.browser.tabs.TabsPanel
         android:id="@+id/tabsPanel"


### PR DESCRIPTION
Fixes #1104.

Moving to a look more consistent with @topotropic's new design for the tab tray:

![image](https://user-images.githubusercontent.com/46655/78584332-abbddf00-77fd-11ea-996d-8ee46bdf7a66.png)
