### PR TITLE
Fix building local android-components on Windows

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,10 @@ def runCmd(cmd, workingDir, successMessage) {
     return standardOutput
 }
 
+def gradlew = './gradlew'
+if (System.properties['os.name'].toLowerCase().contains('windows')) {
+    gradlew += ".bat"
+}
 //////////////////////////////////////////////////////////////////////////
 // Local Development overrides
 //////////////////////////////////////////////////////////////////////////
@@ -57,7 +61,7 @@ if (localProperties != null) {
     if (androidComponentsLocalPath != null) {
         log("Enabling automatic publication of android-components from: $androidComponentsLocalPath")
         log("Determining if android-components are up-to-date...")
-        def compileAcCmd = ["${androidComponentsLocalPath}/gradlew", "compileReleaseKotlin"]
+        def compileAcCmd = [gradlew, "compileReleaseKotlin"]
         def compileOutput = runCmd(compileAcCmd, androidComponentsLocalPath, "Compiled android-components.")
         // This is somewhat brittle: parse last line of gradle output, to fish out how many tasks were executed.
         // One executed task means gradle didn't do any work other than executing the top-level 'compile' task.
@@ -66,7 +70,7 @@ if (localProperties != null) {
             log("android-components are up-to-date, skipping publication.")
         } else {
             log("android-components changed, publishing locally...")
-            def publishAcCmd = ["${androidComponentsLocalPath}/gradlew", "publishToMavenLocal", "-Plocal=true"]
+            def publishAcCmd = ["${androidComponentsLocalPath}/${gradlew}", "publishToMavenLocal", "-Plocal=true"]
             runCmd(publishAcCmd, androidComponentsLocalPath, "Published android-components.")
         }
     } else {


### PR DESCRIPTION
Squashed commit of:
98cc869
0411233
bb292d5

from https://github.com/mozilla-mobile/fenix

Fix Issue #7366: Reference local android-components gradlew correctly

In `settings.gradle` when Fenix determines whether there is an
overriding local android-components it calls `gradlew` from the
`autoPublish.android-components.dir` directory. It sets the current
working directory (cwd) to `autoPublish.android-components.dir` and then
invokes `<autoPublish.android-components.dir>/gradlew`. The proper
behavior is to invoke `./gradlew` because the cwd is already set properly.

Allow builds with a local android-components to work on Windows

No issue: make fenix build again

Regression from when we made auto-publish flow work on Windows.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
