### PR TITLE
Remove unused tab tray icon from template

### DIFF
--- a/app/src/main/res/layout/browser_tabstray_item.xml
+++ b/app/src/main/res/layout/browser_tabstray_item.xml
@@ -8,15 +8,6 @@
     android:layout_width="match_parent"
     android:layout_height="72dp">
 
-    <ImageView
-        android:id="@+id/mozac_browser_tabstray_icon"
-        android:layout_width="100dp"
-        android:layout_height="56dp"
-        android:visibility="gone"
-        android:importantForAccessibility="no"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
     <androidx.cardview.widget.CardView
         android:id="@+id/mozac_browser_tabstray_card"
         android:layout_width="100dp"


### PR DESCRIPTION
We used "gone" to hide this because AC required it, but since https://github.com/mozilla-mobile/android-components/pull/6611 , we no longer need this.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
