### PR TITLE
Improved auto-publication workflow support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,22 +61,32 @@ Before you attempt to make a contribution please read the [Community Participati
 
 # Local Development
 
-## Dependency substitutions
+You might be interested in building this project against local versions of some of the dependencies. Depending on which dependencies you're building against, there are couple of paths.
 
-You might be interested in building this project against local versions of some of the dependencies.
-This could be done either by using a [local maven repository](https://mozilla-mobile.github.io/android-components/contributing/testing-components-inside-app) (quite cumbersome), or via Gradle's [dependency substitutions](https://docs.gradle.org/current/userguide/customizing_dependency_resolution_behavior.html) (not at all cumbersome!).
+## Auto-publication workflow
 
-Currently, the substitution flow is streamlined for some of the core dependencies via configuration flags in `local.properties`. You can build against a local checkout of the following dependencies by specifying their local paths:
-- [android-components](https://github.com/mozilla-mobile/android-components), specifying its path via `autoPublish.android-components.dir=../android-components`
-  - This assumes that you have an `android-components` project at the same level in the directory hierarchy as the `reference-browser`.
-  - When enabled, a Reference Browser build will compile android-components locally and publish if it has been modified,
-    and published versions of android-components modules will be automatically used instead of whatever is declared in Dependencies.kt.
-- [application-services](https://github.com/mozilla/application-services), specifying its path via `substitutions.application-services.dir=../application-services`
-  - This assumes that you have an `application-services` project at the same level in the directory hierarchy as the `reference-browser`.
-- [GeckoView](https://hg.mozilla.org/mozilla-central), specifying its path via `dependencySubstitutions.geckoviewTopsrcdir=/path/to/mozilla-central` (and, optionally, `dependencySubstitutions.geckoviewTopobjdir=/path/to/topobjdir`). See [Bug 1533465](https://bugzilla.mozilla.org/show_bug.cgi?id=1533465).
-  - This assumes that you have built, packaged, and published your local GeckoView -- but don't worry, the dependency substitution script has the latest instructions for doing that.
+This is the most streamlined workflow which fully automates dependency publication. It currently supports [android-components](https://github.com/mozilla-mobile/android-components/) and [application-services](https://github.com/mozilla/application-services) dependencies.
 
-Do not forget to run a Gradle sync in Android Studio after changing `local.properties`. If you specified any substitutions, they will be reflected in the modules list, and you'll be able to modify them from a single Android Studio window.
+In a `local.properties` file in root of the `reference-browser` checkout, specify relative paths to a repository you need (or both):
+```
+# Local workflow
+autoPublish.android-components.dir=../android-components
+autoPublish.application-services.dir=../application-services
+```
+
+That's it! Next build of `reference-browser` will be against your local versions of these repositories. Simply make changes in `android-components` or `application-services`, press Play in `reference-browser` and those changes will be picked-up.
+
+See a [demo of this workflow](https://www.youtube.com/watch?v=qZKlBzVvQGc) in action. Video mentions `Fenix`, but it works in exactly the same with with `reference-browser`.
+
+## Dependency substitutions for [GeckoView](https://hg.mozilla.org/mozilla-central)
+
+GeckoView currently can be configured via a dependency substitution.
+
+In a `local.properties` file in root of the `reference-browser` checkout, specify GeckoView's path via `dependencySubstitutions.geckoviewTopsrcdir=/path/to/mozilla-central` (and, optionally, `dependencySubstitutions.geckoviewTopobjdir=/path/to/topobjdir`). See [Bug 1533465](https://bugzilla.mozilla.org/show_bug.cgi?id=1533465).
+
+This assumes that you have built, packaged, and published your local GeckoView -- but don't worry, the dependency substitution script has the latest instructions for doing that.
+
+Do not forget to run a Gradle sync in Android Studio after changing `local.properties`. If you specified any substitutions (e.g. GeckoView), they will be reflected in the modules list, and you'll be able to modify them from a single Android Studio window. For auto-publication workflow, use seperate Android Studio windows.
 
 # License
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -323,3 +323,8 @@ if (gradle.hasProperty('localProperties.autoPublish.android-components.dir')) {
     ext.acSrcDir = gradle."localProperties.autoPublish.android-components.dir"
     apply from: "../${acSrcDir}/substitute-local-ac.gradle"
 }
+
+if (gradle.hasProperty('localProperties.autoPublish.application-services.dir')) {
+    ext.appServicesSrcDir = gradle."localProperties.autoPublish.application-services.dir"
+    apply from: "../${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,34 +4,27 @@ def log(message) {
     logger.lifecycle("[settings] ${message}")
 }
 
-def runCmd(cmd, workingDir, successMessage) {
+def runCmd(cmd, workingDir, successMessage, captureStdout=true) {
     def proc = cmd.execute(null, new File(workingDir))
-    def standardOutput = new ByteArrayOutputStream()
-    def standardError = new ByteArrayOutputStream()
-    proc.consumeProcessOutput(standardOutput, standardError)
+    def standardOutput = captureStdout ? new ByteArrayOutputStream() : System.out
+    proc.consumeProcessOutput(standardOutput, System.err)
     proc.waitFor()
 
     if (proc.exitValue() != 0) {
-        throw new GradleException("Process '${cmd}' finished with non-zero exit value ${proc.exitValue()}:\n\nstdout:\n${standardOutput.toString()}\n\nstderr:\n${standardError.toString()}")
+        throw new GradleException("Process '${cmd}' finished with non-zero exit value ${proc.exitValue()}");
     } else {
         log(successMessage)
     }
-    return standardOutput
+    return captureStdout ? standardOutput : null
 }
 
-def gradlew = './gradlew'
-if (System.properties['os.name'].toLowerCase().contains('windows')) {
-    gradlew += ".bat"
-}
 //////////////////////////////////////////////////////////////////////////
 // Local Development overrides
 //////////////////////////////////////////////////////////////////////////
 
 Properties localProperties = null
+String settingAppServicesPath = "autoPublish.application-services.dir"
 String settingAndroidComponentsPath = "autoPublish.android-components.dir"
-String settingAppServicesPath = "substitutions.application-services.dir"
-// FIXME: substitution configuration for android-components.
-// See https://github.com/mozilla-mobile/reference-browser/issues/365
 
 if (file('local.properties').canRead()) {
     localProperties = new Properties()
@@ -49,30 +42,19 @@ if (localProperties != null) {
     String appServicesLocalPath = localProperties.getProperty(settingAppServicesPath)
 
     if (appServicesLocalPath != null) {
-        log("Enabling composite build with application-services modules from: $appServicesLocalPath")
-        includeBuild(appServicesLocalPath)
-
+        log("Enabling automatic publication of application-services from: $appServicesLocalPath")
+        def publishAppServicesCmd = ["./automation/publish_to_maven_local_if_modified.py"]
+        runCmd(publishAppServicesCmd, appServicesLocalPath, "Published application-services for local development.", false)
     } else {
-        log("Disabled composite builds with application-services. Enable them by settings '$settingAppServicesPath' in local.properties")
+        log("Disabled auto-publication of application-services. Enable it by settings '$settingAppServicesPath' in local.properties")
     }
 
     String androidComponentsLocalPath = localProperties.getProperty(settingAndroidComponentsPath)
 
     if (androidComponentsLocalPath != null) {
         log("Enabling automatic publication of android-components from: $androidComponentsLocalPath")
-        log("Determining if android-components are up-to-date...")
-        def compileAcCmd = [gradlew, "compileReleaseKotlin"]
-        def compileOutput = runCmd(compileAcCmd, androidComponentsLocalPath, "Compiled android-components.")
-        // This is somewhat brittle: parse last line of gradle output, to fish out how many tasks were executed.
-        // One executed task means gradle didn't do any work other than executing the top-level 'compile' task.
-        def compileTasksExecuted = compileOutput.toString().split('\n').last().split(':')[1].split(' ')[1]
-        if (compileTasksExecuted.equals("1")) {
-            log("android-components are up-to-date, skipping publication.")
-        } else {
-            log("android-components changed, publishing locally...")
-            def publishAcCmd = ["${androidComponentsLocalPath}/${gradlew}", "publishToMavenLocal", "-Plocal=true"]
-            runCmd(publishAcCmd, androidComponentsLocalPath, "Published android-components.")
-        }
+        def publishAcCmd = ["./automation/publish_to_maven_local_if_modified.py"]
+        runCmd(publishAcCmd, androidComponentsLocalPath, "Published android-components for local development.", false)
     } else {
         log("Disabled auto-publication of android-components. Enable it by settings '$settingAndroidComponentsPath' in local.properties")
     }


### PR DESCRIPTION
Similar change in Fenix, see it for details: https://github.com/mozilla-mobile/fenix/pull/10100

Depends on https://github.com/mozilla-mobile/android-components/pull/6732

This PR enables autoPublication workflow for application-services, and improves it for android-components.
 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
