### PR TITLE
No issue: Pin Flank Snapshot and update Flank

### DIFF
--- a/taskcluster/docker/ui-tests/Dockerfile
+++ b/taskcluster/docker/ui-tests/Dockerfile
@@ -1,7 +1,9 @@
 # %ARG DOCKER_IMAGE_PARENT
 FROM $DOCKER_IMAGE_PARENT
-MAINTAINER Richard Pappalardo <rpappalax@gmail.com>
 
+LABEL authors="Richard Pappalardo <rpappalax@gmail.com>, Aaron Train <atrain@mozilla.com>"
+LABEL maintainer="Richard Pappalardo <rpappalax@gmail.com>"
+ 
 #----------------------------------------------------------------------------------------------------------------------
 #-- Test tools --------------------------------------------------------------------------------------------------------
 #----------------------------------------------------------------------------------------------------------------------
@@ -10,6 +12,7 @@ USER worker:worker
 
 ENV GOOGLE_SDK_DOWNLOAD ./gcloud.tar.gz
 ENV GOOGLE_SDK_VERSION 233
+ENV FLANK_VERSION flank_snapshot
 
 ENV TEST_TOOLS /builds/worker/test-tools
 ENV PATH ${PATH}:${TEST_TOOLS}:${TEST_TOOLS}/google-cloud-sdk/bin
@@ -23,7 +26,7 @@ RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
     && ${TEST_TOOLS}/google-cloud-sdk/install.sh --quiet \
     && ${TEST_TOOLS}/google-cloud-sdk/bin/gcloud --quiet components update
 
-RUN URL_FLANK_BIN=$(curl -s "https://api.github.com/repos/Flank/flank/releases/latest" | grep "browser_download_url*" | sed -r "s/\"//g" | cut -d ":" -f3) \
+RUN URL_FLANK_BIN=$(curl -s "https://api.github.com/repos/Flank/flank/releases" | grep "browser_download_url*" | grep "${FLANK_VERSION}" | sed -r "s/\"//g" | cut -d ":" -f3) \
     && wget "https:${URL_FLANK_BIN}" -O ${TEST_TOOLS}/flank.jar \
     && chmod +x ${TEST_TOOLS}/flank.jar
 


### PR DESCRIPTION
r-b uses Flank v8.1.0. Latest (snapshot) Flank uses server side sharding for faster run-time and much better reporting.