### PR TITLE
Bug 1638073 - Update geckoview index to use new shippable index

### DIFF
--- a/taskcluster/ci/geckoview/kind.yml
+++ b/taskcluster/ci/geckoview/kind.yml
@@ -10,5 +10,5 @@ jobs:
         run:
             using: index-search
             index-search:
-                - gecko.v2.mozilla-central.nightly.latest.mobile.android-x86_64-opt
+                - gecko.v2.mozilla-central.shippable.latest.mobile.android-x86_64-opt
         worker-type: always-optimized


### PR DESCRIPTION
This can't merge in until after the stack on https://bugzilla.mozilla.org/show_bug.cgi?id=1614970 lands, I'll comment here when that happens.

Impacts of the delay is that you'll use a slightly out of date geckoview for 24-48 hours until this lands.
