### PR TITLE
Integrate activity for showing past crashes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -162,6 +162,10 @@
             android:theme="@style/AppTheme"
             android:parentActivityName=".BrowserActivity" />
 
+        <activity
+            android:name=".CrashListActivity"
+            android:exported="false" />
+
         <service android:name=".media.MediaService"
             android:exported="false" />
 

--- a/app/src/main/java/org/mozilla/reference/browser/AppRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/AppRequestInterceptor.kt
@@ -5,6 +5,8 @@
 package org.mozilla.reference.browser
 
 import android.content.Context
+import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import mozilla.components.browser.errorpages.ErrorPages
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.EngineSession
@@ -30,6 +32,14 @@ class AppRequestInterceptor(private val context: Context) : RequestInterceptor {
                 RequestInterceptor.InterceptionResponse.Content(page, encoding = "base64")
             }
 
+            "about:crashes" -> {
+                val intent = Intent(context, CrashListActivity::class.java)
+                intent.addFlags(FLAG_ACTIVITY_NEW_TASK)
+                context.startActivity(intent)
+
+                RequestInterceptor.InterceptionResponse.Url("about:blank")
+            }
+
             else -> {
                 context.components.services.accountsAuthFeature.interceptor.onLoadRequest(
                     engineSession, uri, hasUserGesture, isSameDomain
@@ -48,4 +58,6 @@ class AppRequestInterceptor(private val context: Context) : RequestInterceptor {
         val errorPage = ErrorPages.createErrorPage(context, errorType, uri)
         return RequestInterceptor.ErrorResponse.Content(errorPage)
     }
+
+    override fun interceptsAppInitiatedRequests() = true
 }

--- a/app/src/main/java/org/mozilla/reference/browser/CrashListActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/CrashListActivity.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser
+
+import android.content.Intent
+import android.net.Uri
+import mozilla.components.lib.crash.CrashReporter
+import mozilla.components.lib.crash.ui.AbstractCrashListActivity
+import org.mozilla.reference.browser.ext.components
+
+class CrashListActivity : AbstractCrashListActivity() {
+    override val crashReporter: CrashReporter by lazy { components.analytics.crashReporter }
+
+    override fun onCrashServiceSelected(url: String) {
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            data = Uri.parse(url)
+            `package` = packageName
+        }
+        startActivity(intent)
+        finish()
+    }
+}


### PR DESCRIPTION
I wasn't able to see any crash reports locally, so I'm guessing I've missed something from this integration PR: https://github.com/mozilla-mobile/fenix/pull/10561/files

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
