### PR TITLE
Bug 1631834 - part 3: Install taskgraph in action task too

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -250,6 +250,7 @@ tasks:
                                       in:
                                           $if: 'tasks_for == "action"'
                                           then: >
+                                              PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
                                               cd /builds/worker/checkouts/src &&
                                               taskcluster/scripts/decision-install-sdk.sh &&
                                               ln -s /builds/worker/artifacts artifacts &&


### PR DESCRIPTION
Follows #1187 up

Fixes 

```
[task 2020-05-22T12:29:49.064Z] + taskgraph action-callback
[task 2020-05-22T12:29:49.064Z] bash: taskgraph: command not found
[taskcluster 2020-05-22 12:29:49.296Z] === Task Finished ===
```

https://firefox-ci-tc.services.mozilla.com/tasks/VGffgwHUTSOmc6fv8bde2Q/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FVGffgwHUTSOmc6fv8bde2Q%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L2916


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
