### PR TITLE
Rebuild toolchain if AndroidComponents.kt changes.

### DIFF
--- a/taskcluster/ci/toolchain/android.yml
+++ b/taskcluster/ci/toolchain/android.yml
@@ -39,8 +39,7 @@ linux64-android-gradle-dependencies:
             - taskcluster/scripts/toolchain/android-gradle-dependencies.sh
             - taskcluster/scripts/toolchain/android-gradle-dependencies/**
             - buildSrc/src/main/java/Dependencies.kt
-            # We don't follow 'buildSrc/src/main/java/AndroidComponents.kt' because we only cache
-            # dependencies outside of the ones hosted on maven.mozilla.org.
+            - buildSrc/src/main/java/AndroidComponents.kt
         toolchain-artifact: public/build/android-gradle-dependencies.tar.xz
         toolchain-alias: android-gradle-dependencies
     treeherder:


### PR DESCRIPTION
Initially we didn't want to do that since we do not need to cache dependencies from our own
maven repository. But Android Components can introduce other third-party transitive
dependencies from other repositories (like Android X) and those need to be cached.