### PR TITLE
Bug 1631834 - part 4: Use taskgraph by providing full path

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -254,7 +254,7 @@ tasks:
                                               cd /builds/worker/checkouts/src &&
                                               taskcluster/scripts/decision-install-sdk.sh &&
                                               ln -s /builds/worker/artifacts artifacts &&
-                                              taskgraph action-callback
+                                              ~/.local/bin/taskgraph/taskgraph action-callback
                                           else: >
                                               PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
                                               taskcluster/scripts/decision-install-sdk.sh &&


### PR DESCRIPTION
Follows https://github.com/mozilla-mobile/reference-browser/pull/1193 up. 

Fixes the same error 😭  https://firefox-ci-tc.services.mozilla.com/tasks/Z3_VmhguTYWLEXcqruPgWA/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FZ3_VmhguTYWLEXcqruPgWA%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L2905


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
