### PR TITLE
Bug 1631834 - part 5: Fix typo in path

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -254,7 +254,7 @@ tasks:
                                               cd /builds/worker/checkouts/src &&
                                               taskcluster/scripts/decision-install-sdk.sh &&
                                               ln -s /builds/worker/artifacts artifacts &&
-                                              ~/.local/bin/taskgraph/taskgraph action-callback
+                                              ~/.local/bin/taskgraph action-callback
                                           else: >
                                               PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
                                               taskcluster/scripts/decision-install-sdk.sh &&


### PR DESCRIPTION

![facepalm](https://user-images.githubusercontent.com/5907366/82885710-ca12a200-9f45-11ea-89aa-9c61978e6b0a.png)

Oh crap, I badly copied the path when I put https://github.com/mozilla-mobile/reference-browser/pull/1198 up. Android-components are fine. I just messed up r-b: https://firefox-ci-tc.services.mozilla.com/tasks/J8e0NHXVRM6QTG2Ybf4CWQ/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FJ8e0NHXVRM6QTG2Ybf4CWQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L2904

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
