### PR TITLE
No issue: fix errors from test-ui execution (pyyaml/max-test-shards)

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -257,6 +257,7 @@ tasks:
                                               ~/.local/bin/taskgraph action-callback
                                           else: >
                                               PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
+                                              PIP_IGNORE_INSTALLED=0 pip install --user pyyaml &&
                                               taskcluster/scripts/decision-install-sdk.sh &&
                                               ln -s /builds/worker/artifacts artifacts &&
                                               ~/.local/bin/taskgraph decision

--- a/automation/taskcluster/androidTest/flank-aarch64.yml
+++ b/automation/taskcluster/androidTest/flank-aarch64.yml
@@ -41,7 +41,7 @@ flank:
   project: GOOGLE_PROJECT
   # test shards - the amount of groups to split the test suite into
   # set to -1 to use one shard per test.
-  max-test-shards: -1 
+  max-test-shards: 2
   # repeat tests - the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
   repeat-tests: 1

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -62,7 +62,7 @@ jobs:
             # TODO Generate APKs in a build task instead
             gradlew: ['clean', 'assembleDebug', 'assembleAndroidTest']
             post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'aarch64', '-1']
+                - ['automation/taskcluster/androidTest/ui-test.sh', 'aarch64', '2']
             secrets:
                 - name: project/mobile/reference-browser/firebase
                   key: firebaseToken


### PR DESCRIPTION
https://firefox-ci-tc.services.mozilla.com/tasks/VfDEzvbwQ7aHxbBxtSGUfQ failed with two errors:

- max-test-shards expected an integer in the script (default set: -1), 4 tests, let's just use 2 shards for Flank)
- pyyaml missing (copying the pip install from .taskcluster in fenix 🤷) https://github.com/mozilla-mobile/fenix/blob/ca9f99540ad22be0d322cffb5cfbbc3e0ba52ba1/.taskcluster.yml#L274