### PR TITLE
A-C 44.0.20200528190114: Pass store to download manager and service

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
@@ -124,6 +124,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
                 fragmentManager = childFragmentManager,
                 downloadManager = FetchDownloadManager(
                     requireContext().applicationContext,
+                    requireComponents.core.store,
                     DownloadService::class
                 ),
                 onNeedToRequestPermissions = { permissions ->

--- a/app/src/main/java/org/mozilla/reference/browser/components/Core.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Core.kt
@@ -21,6 +21,7 @@ import mozilla.components.feature.addons.AddonManager
 import mozilla.components.feature.addons.amo.AddonCollectionProvider
 import mozilla.components.feature.addons.update.AddonUpdater
 import mozilla.components.feature.addons.update.DefaultAddonUpdater
+import mozilla.components.feature.downloads.DownloadMiddleware
 import mozilla.components.feature.downloads.DownloadsUseCases
 import mozilla.components.feature.media.RecordingDevicesNotificationFeature
 import mozilla.components.feature.media.middleware.MediaMiddleware
@@ -35,6 +36,7 @@ import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.R.string.pref_key_remote_debugging
 import org.mozilla.reference.browser.R.string.pref_key_tracking_protection_normal
 import org.mozilla.reference.browser.R.string.pref_key_tracking_protection_private
+import org.mozilla.reference.browser.downloads.DownloadService
 import org.mozilla.reference.browser.media.MediaService
 import java.util.concurrent.TimeUnit
 
@@ -75,6 +77,7 @@ class Core(private val context: Context) {
         BrowserStore(
             middleware = listOf(
                 MediaMiddleware(context, MediaService::class.java),
+                DownloadMiddleware(context, DownloadService::class.java),
                 ReaderViewMiddleware()
             )
         )

--- a/app/src/main/java/org/mozilla/reference/browser/downloads/DownloadService.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/downloads/DownloadService.kt
@@ -4,9 +4,11 @@
 
 package org.mozilla.reference.browser.downloads
 
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.downloads.AbstractFetchDownloadService
 import org.mozilla.reference.browser.ext.components
 
 class DownloadService : AbstractFetchDownloadService() {
     override val httpClient by lazy { components.core.client }
+    override val store: BrowserStore by lazy { components.core.store }
 }

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "44.0.20200528130107"
+    const val VERSION = "44.0.20200528190114"
 }


### PR DESCRIPTION
Preparing for breaking API change in downloads. Needs to land after https://github.com/mozilla-mobile/android-components/issues/7103.