### PR TITLE
Bug 1641880 - Disable raptor reference browser tests.

### DIFF
--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -34,7 +34,7 @@ job-defaults:
                     subject: '[{product_name}] Raptor job "{task_name}" failed'
                     to-addresses: [perftest-alerts@mozilla.com]
             default: {}
-    run-on-tasks-for: [github-push]
+    run-on-tasks-for: []
     treeherder:
         kind: test
         tier: 2


### PR DESCRIPTION
This patch is for disabling the speedometer raptor tests which are not being used or monitored.
