### PR TITLE
Remove bundle debug from CI

### DIFF
--- a/taskcluster/ci/build-bundle/kind.yml
+++ b/taskcluster/ci/build-bundle/kind.yml
@@ -47,7 +47,3 @@ jobs:
         include-shippable-secrets: true
         run:
             gradlew: ["-PcrashReportEnabled=true", "-Ptelemetry=true", "bundleNightly"]
-    debug:
-        run-on-tasks-for: [github-push, github-pull-request]
-        run:
-            gradlew: ["bundleDebug"]


### PR DESCRIPTION
Original discussion: https://mozilla.slack.com/archives/CKM7DLL67/p1590686422299300

Let's just use the nightly bundles. The debug ones are too big and not used.