### PR TITLE
Clear speculative session on engine settings change

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/Components.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/Components.kt
@@ -23,9 +23,9 @@ class Components(private val context: Context) {
     val useCases by lazy {
         UseCases(
             context,
+            core.engine,
             core.sessionManager,
             core.store,
-            core.engine.settings,
             search.searchEngineManager,
             core.client,
             core.thumbnailStorage

--- a/app/src/main/java/org/mozilla/reference/browser/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/UseCases.kt
@@ -10,8 +10,8 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.thumbnails.ThumbnailsUseCases
 import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
-import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.contextmenu.ContextMenuUseCases
 import mozilla.components.feature.downloads.DownloadsUseCases
 import mozilla.components.feature.pwa.WebAppUseCases
@@ -26,9 +26,9 @@ import mozilla.components.feature.tabs.TabsUseCases
  */
 class UseCases(
     private val context: Context,
+    private val engine: Engine,
     private val sessionManager: SessionManager,
     private val store: BrowserStore,
-    private val engineSettings: Settings,
     private val searchEngineManager: SearchEngineManager,
     private val client: Client,
     private val thumbnailStorage: ThumbnailStorage
@@ -51,7 +51,7 @@ class UseCases(
     /**
      * Use cases that provide settings management.
      */
-    val settingsUseCases by lazy { SettingsUseCases(engineSettings, sessionManager) }
+    val settingsUseCases by lazy { SettingsUseCases(engine, sessionManager) }
 
     /**
      * Use cases that provide shortcut and progressive web app management.

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "45.0.20200608130044"
+    const val VERSION = "45.0.20200609161836"
 }


### PR DESCRIPTION
Preparing for a breaking change in A-C: https://github.com/mozilla-mobile/android-components/pull/7296

We're passing the engine, instead of just `engine.settings` so we can also clear the speculative session when engine settings change.