### PR TITLE
Close #958: Set max dynamic height of toolbar on EngineView

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
@@ -230,7 +230,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
         } else {
             activity?.exitImmersiveModeIfNeeded()
             toolbar.visibility = View.VISIBLE
-            engineView.setDynamicToolbarMaxHeight(toolbar.measuredHeight)
+            engineView.setDynamicToolbarMaxHeight(resources.getDimensionPixelSize(R.dimen.browser_toolbar_height))
         }
     }
 

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
@@ -91,6 +91,8 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             owner = this,
             view = view
         )
+
+        engineView.setDynamicToolbarMaxHeight(resources.getDimensionPixelSize(R.dimen.browser_toolbar_height))
     }
 
     private fun showTabs() {

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -49,7 +49,7 @@
     <mozilla.components.browser.toolbar.BrowserToolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="@dimen/browser_toolbar_height"
         android:layout_gravity="bottom"
         android:background="@color/toolbarBackgroundColor"
         app:layout_behavior="mozilla.components.browser.toolbar.behavior.BrowserToolbarBottomBehavior"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <!-- Browser Toolbar -->
+    <dimen name="browser_toolbar_height">56dp</dimen>
+</resources>


### PR DESCRIPTION
We were not setting the max toolbar height on the engine view when we have the toolbar in regular browsing mode.