### PR TITLE
Bug 1631839 - part 2: Remove "project.mobile" routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Make sure you use the same Google Account for both steps.
 
 Signed Nightly builds can be downloaded from:
 
-* [⬇️ ARM64/Aarch64 devices (64 bit; Android 5+)](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.reference-browser.v3.nightly.latest/artifacts/public/target.arm64-v8a.apk)
-* [⬇️ ARM devices (32 bit; Android 5+)](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.reference-browser.v3.nightly.latest/artifacts/public/target.armeabi-v7a.apk)
-* [⬇️ x86_64  devices (64 bit; Android 5+)](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.reference-browser.v3.nightly.latest/artifacts/public/target.x86_64.apk)
-* [⬇️ x86  devices (32 bit; Android 5+)](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.reference-browser.v3.nightly.latest/artifacts/public/target.x86.apk)
+* [⬇️ ARM64/Aarch64 devices (64 bit; Android 5+)](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mobile.v2.reference-browser.nightly.latest.arm64-v8a/artifacts/public/target.arm64-v8a.apk)
+* [⬇️ ARM devices (32 bit; Android 5+)](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mobile.v2.reference-browser.nightly.latest.armeabi-v7a/artifacts/public/target.armeabi-v7a.apk)
+* [⬇️ x86_64  devices (64 bit; Android 5+)](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mobile.v2.reference-browser.nightly.latest.x86_64/artifacts/public/target.x86_64.apk)
+* [⬇️ x86  devices (32 bit; Android 5+)](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mobile.v2.reference-browser.nightly.latest.x86/artifacts/public/target.x86.apk)
 
 > Please note that these builds do not auto-update, you will have to keep up to date manually.
 

--- a/taskcluster/rb_taskgraph/routes.py
+++ b/taskcluster/rb_taskgraph/routes.py
@@ -13,11 +13,6 @@ SIGNING_ROUTE_TEMPLATES = [
     "index.{trust-domain}.v2.{project}.{variant}.{build_date}.revision.{head_rev}.{abi}",
     "index.{trust-domain}.v2.{project}.{variant}.{build_date}.latest.{abi}",
     "index.{trust-domain}.v2.{project}.{variant}.revision.{head_rev}.{abi}",
-
-    # TODO Bug 1631839: Remove the following scopes once all consumers have migrated
-    "index.project.{trust-domain}.{project}.v3.{variant}.{build_date}.revision.{head_rev}",
-    "index.project.{trust-domain}.{project}.v3.{variant}.{build_date}.latest",
-    "index.project.{trust-domain}.{project}.v3.{variant}.latest",
 ]
 
 


### PR DESCRIPTION
Unlike Fenix (https://github.com/mozilla-mobile/fenix/pull/12821), there's no `project.mobile` routes in `.taskcluster.yml`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
