### PR TITLE
Fixes for A-C: Move EngineSession to BrowserState

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
@@ -6,6 +6,7 @@ package org.mozilla.reference.browser
 
 import android.app.Application
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.state.action.SystemAction
 import mozilla.components.concept.push.PushProcessor
 import mozilla.components.feature.addons.update.GlobalAddonDependencyProvider
 import mozilla.components.support.base.log.Log
@@ -84,7 +85,8 @@ open class BrowserApplication : Application() {
     override fun onTrimMemory(level: Int) {
         super.onTrimMemory(level)
         runOnlyInMainProcess {
-            components.core.sessionManager.onTrimMemory(level)
+            components.core.store.dispatch(SystemAction.LowMemoryAction(level))
+            components.core.icons.onTrimMemory(level)
         }
     }
 

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
@@ -88,7 +88,6 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
             feature = SessionFeature(
                 requireComponents.core.store,
                 requireComponents.useCases.sessionUseCases.goBack,
-                requireComponents.useCases.engineSessionUseCases,
                 engineView,
                 sessionId),
             owner = this,

--- a/app/src/main/java/org/mozilla/reference/browser/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/UseCases.kt
@@ -7,10 +7,8 @@ package org.mozilla.reference.browser.components
 import android.content.Context
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.browser.session.usecases.EngineSessionUseCases
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
-import mozilla.components.concept.engine.EngineSession
 import mozilla.components.feature.contextmenu.ContextMenuUseCases
 import mozilla.components.feature.downloads.DownloadsUseCases
 import mozilla.components.feature.pwa.WebAppShortcutManager
@@ -35,12 +33,7 @@ class UseCases(
     /**
      * Use cases that provide engine interactions for a given browser session.
      */
-    val sessionUseCases by lazy { SessionUseCases(sessionManager) }
-
-    /**
-     * Use cases for getting and creating [EngineSession] instances for tabs.
-     */
-    val engineSessionUseCases by lazy { EngineSessionUseCases(sessionManager) }
+    val sessionUseCases by lazy { SessionUseCases(store, sessionManager) }
 
     /**
      * Use cases that provide tab management.
@@ -50,7 +43,7 @@ class UseCases(
     /**
      * Use cases that provide search engine integration.
      */
-    val searchUseCases by lazy { SearchUseCases(context, searchEngineManager, sessionManager) }
+    val searchUseCases by lazy { SearchUseCases(context, store, searchEngineManager, sessionManager) }
 
     /**
      * Use cases that provide settings management.

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "57.0.20200826130107"
+    const val VERSION = "57.0.20200827130040"
 }


### PR DESCRIPTION
Preparing for breaking changes in A-C: https://github.com/mozilla-mobile/android-components/pull/8121

We continue our refactoring to browser store/state. This part moves the engine session to the `BrowserStore` entirely, and no longer keeps it in `SessionManager`. The goal is to get rid of `SessionManager` eventually.