### PR TITLE
For #1388 - Use url encoded error pages

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/AppRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/AppRequestInterceptor.kt
@@ -61,8 +61,8 @@ class AppRequestInterceptor(private val context: Context) : RequestInterceptor {
         errorType: ErrorType,
         uri: String?
     ): RequestInterceptor.ErrorResponse? {
-        val errorPage = ErrorPages.createErrorPage(context, errorType, uri)
-        return RequestInterceptor.ErrorResponse.Content(errorPage)
+        val errorPage = ErrorPages.createUrlEncodedErrorPage(context, errorType, uri)
+        return RequestInterceptor.ErrorResponse(errorPage)
     }
 
     override fun interceptsAppInitiatedRequests() = true


### PR DESCRIPTION
Integrate the AC changes which dropped support for data url error pages.

After which the error pages should work as before:
<img src="https://user-images.githubusercontent.com/11428869/101043162-ada39200-3586-11eb-90fe-59f6204a913e.gif" width="33%" />
[video](https://drive.google.com/file/d/1erspfjDIrfVMurS3dsFRv-hkkginTu6_/view?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR  does not include any a11y user facing features.
