### PR TITLE
Add support for experimental WebAuthnFeature

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
@@ -19,6 +19,7 @@ import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.intent.ext.EXTRA_SESSION_ID
 import mozilla.components.lib.crash.Crash
 import mozilla.components.support.base.feature.UserInteractionHandler
+import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.utils.SafeIntent
 import mozilla.components.support.webextensions.WebExtensionPopupFeature
 import org.mozilla.reference.browser.addons.WebExtensionActionPopupActivity
@@ -119,6 +120,13 @@ open class BrowserActivity : AppCompatActivity() {
             EngineView::class.java.name -> components.core.engine.createView(context, attrs).asView()
             else -> super.onCreateView(parent, name, context, attrs)
         }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        Logger.info("Activity onActivityResult received with " +
+            "requestCode: $requestCode, resultCode: $resultCode, data: $data")
+
+        super.onActivityResult(requestCode, resultCode, data)
+    }
 
     private fun onNonFatalCrash(crash: Crash) {
         Snackbar.make(findViewById(android.R.id.content), R.string.crash_report_non_fatal_message, LENGTH_LONG)

--- a/app/src/main/java/org/mozilla/reference/browser/browser/WebAuthnFeature.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/WebAuthnFeature.kt
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.browser
+
+import android.app.Activity
+import android.content.Intent
+import android.content.IntentSender
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.activity.ActivityDelegate
+import mozilla.components.support.base.feature.ActivityResultHandler
+import mozilla.components.support.base.feature.LifecycleAwareFeature
+import mozilla.components.support.base.log.logger.Logger
+
+/**
+ * This implementation of the WebAuthnFeature is only for testing in a signed build.
+ */
+class WebAuthnFeature(
+    private val engine: Engine,
+    private val activity: Activity
+) : LifecycleAwareFeature, ActivityResultHandler {
+    val logger = Logger("WebAuthnFeature")
+    var requestCode = ACTIVITY_REQUEST_CODE
+    var resultCallback: ((Intent?) -> Unit)? = null
+    private val delegate = object : ActivityDelegate {
+        override fun startIntentSenderForResult(intent: IntentSender, onResult: (Intent?) -> Unit) {
+            val code = requestCode++
+            logger.info("Received activity delegate request with code: $code intent: $intent")
+            activity.startIntentSenderForResult(intent, code, null, 0, 0, 0)
+            resultCallback = onResult
+        }
+    }
+
+    override fun start() {
+        logger.info("Feature started.")
+        engine.registerActivityDelegate(delegate)
+    }
+
+    override fun stop() {
+        logger.info("Feature stopped.")
+        engine.unregisterActivityDelegate()
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        logger.info("Received activity result with code: $requestCode\ndata: $data")
+        if (this.requestCode == requestCode) {
+            logger.info("Invoking callback!")
+            resultCallback?.invoke(data)
+            return true
+        }
+
+        return false
+    }
+
+    companion object {
+        const val ACTIVITY_REQUEST_CODE = 10
+    }
+}


### PR DESCRIPTION
Adding an experimental WebAuthnFeature to Reference Browser. This will help us iterate faster against a private API that we cannot see the source for.

This is similar to the [Fenix implementation](https://github.com/mozilla-mobile/fenix/blob/master/app/src/main/java/org/mozilla/fenix/browser/WebAuthnFeature.kt).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
