### PR TITLE
Forward activity results to attached fragments

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
@@ -18,6 +18,7 @@ import mozilla.components.browser.state.state.WebExtensionState
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.intent.ext.EXTRA_SESSION_ID
 import mozilla.components.lib.crash.Crash
+import mozilla.components.support.base.feature.ActivityResultHandler
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.utils.SafeIntent
@@ -82,6 +83,19 @@ open class BrowserActivity : AppCompatActivity() {
         removeSessionIfNeeded()
     }
 
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        Logger.info("Activity onActivityResult received with " +
+            "requestCode: $requestCode, resultCode: $resultCode, data: $data")
+
+        supportFragmentManager.fragments.forEach {
+            if (it is ActivityResultHandler && it.onActivityResult(requestCode, data, resultCode)) {
+                return
+            }
+        }
+
+        super.onActivityResult(requestCode, resultCode, data)
+    }
+
     /**
      * If needed remove the current session.
      *
@@ -120,13 +134,6 @@ open class BrowserActivity : AppCompatActivity() {
             EngineView::class.java.name -> components.core.engine.createView(context, attrs).asView()
             else -> super.onCreateView(parent, name, context, attrs)
         }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        Logger.info("Activity onActivityResult received with " +
-            "requestCode: $requestCode, resultCode: $resultCode, data: $data")
-
-        super.onActivityResult(requestCode, resultCode, data)
-    }
 
     private fun onNonFatalCrash(crash: Crash) {
         Snackbar.make(findViewById(android.R.id.content), R.string.crash_report_non_fatal_message, LENGTH_LONG)

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
@@ -26,6 +26,7 @@ import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SwipeRefreshFeature
 import mozilla.components.feature.tabs.WindowFeature
 import mozilla.components.feature.sitepermissions.SitePermissionsFeature
+import mozilla.components.support.base.feature.ActivityResultHandler
 import mozilla.components.support.base.feature.PermissionsFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
@@ -47,7 +48,7 @@ import org.mozilla.reference.browser.pip.PictureInPictureIntegration
  * UI code specific to the app or to custom tabs can be found in the subclasses.
  */
 @Suppress("TooManyFunctions")
-abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
+abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, ActivityResultHandler {
     private val sessionFeature = ViewBoundFeatureWrapper<SessionFeature>()
     private val toolbarIntegration = ViewBoundFeatureWrapper<ToolbarIntegration>()
     private val contextMenuIntegration = ViewBoundFeatureWrapper<ContextMenuIntegration>()
@@ -300,10 +301,10 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
         }
     }
 
-    final override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    override fun onActivityResult(requestCode: Int, data: Intent?, resultCode: Int): Boolean {
         Logger.info("Fragment onActivityResult received with " +
             "requestCode: $requestCode, resultCode: $resultCode, data: $data")
 
-        activityResultHandler.any { it.onActivityResult(requestCode, resultCode, data) }
+        return activityResultHandler.any { it.onActivityResult(requestCode, data, resultCode) }
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/browser/WebAuthnFeature.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/WebAuthnFeature.kt
@@ -42,7 +42,7 @@ class WebAuthnFeature(
         engine.unregisterActivityDelegate()
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+    override fun onActivityResult(requestCode: Int, data: Intent?, resultCode: Int): Boolean {
         logger.info("Received activity result with code: $requestCode\ndata: $data")
         if (this.requestCode == requestCode) {
             logger.info("Invoking callback!")

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "71.0.20210121190053"
+    const val VERSION = "72.0.20210122201459"
 }


### PR DESCRIPTION
From logging the activity result, we can see that we _are_ getting the activity result data back, but the result is not being forwarded to the fragment from the activity.

Here, we forward the activity results from the activity itself to the fragment.

Needs: https://github.com/mozilla-mobile/android-components/pull/9478

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
