### PR TITLE
Update the internal request code after receiving a result

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/WebAuthnFeature.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/WebAuthnFeature.kt
@@ -25,7 +25,7 @@ class WebAuthnFeature(
     var resultCallback: ((Intent?) -> Unit)? = null
     private val delegate = object : ActivityDelegate {
         override fun startIntentSenderForResult(intent: IntentSender, onResult: (Intent?) -> Unit) {
-            val code = requestCode++
+            val code = requestCode
             logger.info("Received activity delegate request with code: $code intent: $intent")
             activity.startIntentSenderForResult(intent, code, null, 0, 0, 0)
             resultCallback = onResult
@@ -43,13 +43,18 @@ class WebAuthnFeature(
     }
 
     override fun onActivityResult(requestCode: Int, data: Intent?, resultCode: Int): Boolean {
-        logger.info("Received activity result with code: $requestCode\ndata: $data")
+        logger.info("Received activity result with " +
+            "code: $requestCode " +
+            "data: $data " +
+            "and original request code: ${this.requestCode}")
         if (this.requestCode == requestCode) {
             logger.info("Invoking callback!")
             resultCallback?.invoke(data)
+            this.requestCode++
             return true
         }
 
+        this.requestCode++
         return false
     }
 


### PR DESCRIPTION
Good news: We're getting the activity result delivered to the feature now, so that's a lot more progress than before!

Bad news: Made a small error where we were updating the request code too early.

This feature most definitely needs to hold on to the callback and request code in a better way. How would we hold a reference to the callback in BrowserStore if we went down that path? 🤔 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
