### PR TITLE
Remove service-experiments.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -251,7 +251,6 @@ dependencies {
     implementation Deps.mozilla_service_firefox_accounts
     implementation Deps.mozilla_service_glean
     implementation Deps.mozilla_service_location
-    implementation Deps.mozilla_service_experiments
 
     implementation Deps.mozilla_support_images
     implementation Deps.mozilla_support_utils

--- a/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
@@ -70,7 +70,6 @@ open class BrowserApplication : Application() {
             onUpdatePermissionRequest = components.core.addonUpdater::onUpdatePermissionRequest
         )
         components.analytics.initializeGlean()
-        components.analytics.initializeExperiments()
 
         components.push.feature?.let {
             Logger.info("AutoPushFeature is configured, initializing it...")

--- a/app/src/main/java/org/mozilla/reference/browser/components/Analytics.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Analytics.kt
@@ -12,7 +12,6 @@ import mozilla.components.lib.crash.service.CrashReporterService
 import mozilla.components.lib.crash.service.GleanCrashReporterService
 import mozilla.components.lib.crash.service.MozillaSocorroService
 import mozilla.components.lib.crash.service.SentryService
-import mozilla.components.service.experiments.Experiments
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.net.ConceptFetchHttpUploader
@@ -75,13 +74,6 @@ class Analytics(private val context: Context) {
         Glean.initialize(context, enableUpload, Configuration(
             httpClient = ConceptFetchHttpUploader(lazy { context.components.core.client })
         ))
-    }
-
-    internal fun initializeExperiments() {
-        Experiments.initialize(
-            context,
-            mozilla.components.service.experiments.Configuration(context.components.core.client)
-        )
     }
 }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -99,7 +99,6 @@ object Deps {
     const val mozilla_service_firefox_accounts = "org.mozilla.components:service-firefox-accounts:${Versions.mozilla_android_components}"
     const val mozilla_service_glean = "org.mozilla.components:service-glean:${Versions.mozilla_android_components}"
     const val mozilla_service_location = "org.mozilla.components:service-location:${Versions.mozilla_android_components}"
-    const val mozilla_service_experiments = "org.mozilla.components:service-experiments:${Versions.mozilla_android_components}"
 
     const val mozilla_support_images = "org.mozilla.components:support-images:${Versions.mozilla_android_components}"
     const val mozilla_support_utils = "org.mozilla.components:support-utils:${Versions.mozilla_android_components}"


### PR DESCRIPTION
Since Nimbus is the new shiny experimentation framework, we want to get rid of `service-fretboard` and `service-experiments`. Reference Browser still uses `service-experiments` and this patch removes it.