### PR TITLE
BrowserApplication: Use session id instead of Session instance when invoking use case.

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
@@ -65,7 +65,7 @@ open class BrowserApplication : Application() {
             },
             onSelectTabOverride = { _, sessionId ->
                 val selected = components.core.sessionManager.findSessionById(sessionId)
-                selected?.let { components.useCases.tabsUseCases.selectTab(it) }
+                selected?.let { components.useCases.tabsUseCases.selectTab(it.id) }
             },
             onUpdatePermissionRequest = components.core.addonUpdater::onUpdatePermissionRequest
         )


### PR DESCRIPTION
A fix for https://github.com/mozilla-mobile/reference-browser/pull/1447