### PR TITLE
For #1449 - Use the new AC custom behavior for both the top and bottom toolbars

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
@@ -11,11 +11,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.CallSuper
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.fragment.app.Fragment
 import androidx.preference.PreferenceManager
 import kotlinx.android.synthetic.main.fragment_browser.*
 import kotlinx.android.synthetic.main.fragment_browser.view.*
 import mozilla.components.browser.state.selector.selectedTab
+import mozilla.components.browser.toolbar.behavior.BrowserToolbarBehavior
 import mozilla.components.feature.app.links.AppLinksFeature
 import mozilla.components.feature.downloads.DownloadsFeature
 import mozilla.components.feature.downloads.manager.FetchDownloadManager
@@ -24,6 +26,7 @@ import mozilla.components.feature.prompts.PromptFeature
 import mozilla.components.feature.session.FullScreenFeature
 import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SwipeRefreshFeature
+import mozilla.components.feature.session.behavior.EngineViewBrowserToolbarBehavior
 import mozilla.components.feature.tabs.WindowFeature
 import mozilla.components.feature.sitepermissions.SitePermissionsFeature
 import mozilla.components.feature.webauthn.WebAuthnFeature
@@ -43,6 +46,8 @@ import org.mozilla.reference.browser.downloads.DownloadService
 import org.mozilla.reference.browser.ext.getPreferenceKey
 import org.mozilla.reference.browser.ext.requireComponents
 import org.mozilla.reference.browser.pip.PictureInPictureIntegration
+import mozilla.components.feature.session.behavior.ToolbarPosition as MozacEngineBehaviorToolbarPosition
+import mozilla.components.browser.toolbar.behavior.ToolbarPosition as MozacToolbarBehaviorToolbarPosition
 
 /**
  * Base fragment extended by [BrowserFragment] and [ExternalAppBrowserFragment].
@@ -103,6 +108,13 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
             owner = this,
             view = view)
 
+        (toolbar.layoutParams as? CoordinatorLayout.LayoutParams)?.apply {
+            behavior = BrowserToolbarBehavior(
+                view.context,
+                null,
+                MozacToolbarBehaviorToolbarPosition.BOTTOM
+            )
+        }
         toolbarIntegration.set(
             feature = ToolbarIntegration(
                 requireContext(),
@@ -223,6 +235,15 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
             view = view
         )
 
+        (swipeRefresh.layoutParams as? CoordinatorLayout.LayoutParams)?.apply {
+            behavior = EngineViewBrowserToolbarBehavior(
+                context,
+                null,
+                swipeRefresh,
+                toolbar.height,
+                MozacEngineBehaviorToolbarPosition.BOTTOM
+            )
+        }
         swipeRefreshFeature.set(
             feature = SwipeRefreshFeature(
                 requireComponents.core.store,

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -14,8 +14,7 @@
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefresh"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_behavior="mozilla.components.feature.session.behavior.EngineViewBottomBehavior">
+        android:layout_height="match_parent">
         <mozilla.components.concept.engine.EngineView
             android:id="@+id/engineView"
             android:layout_width="match_parent"
@@ -52,8 +51,6 @@
         android:layout_height="@dimen/browser_toolbar_height"
         android:layout_gravity="bottom"
         android:background="@color/toolbarBackgroundColor"
-        app:layout_behavior="mozilla.components.browser.toolbar.behavior.BrowserToolbarBottomBehavior"
-        app:layout_scrollFlags="scroll|enterAlways|snap|exitUntilCollapsed"
         mozac:browserToolbarTrackingProtectionAndSecurityIndicatorSeparatorColor="@color/photonWhite"
         mozac:browserToolbarSuggestionForegroundColor="@color/toolbarSuggestionForeground"
         mozac:browserToolbarSuggestionBackgroundColor="@color/toolbarSuggestionBackground" />


### PR DESCRIPTION
AC replaced BrowserToolbarBottomBehavior with BrowserToolbarBehavior that would
allow for easily offering the same great UX but with the toolbar placed at the
top if we'd want to.


https://user-images.githubusercontent.com/11428869/108070081-c3e0ca80-706c-11eb-8fd1-dc02e48a03b3.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
