### PR TITLE
Add missing page view menu items to threeDotMenuItemsTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
@@ -80,14 +80,11 @@ class ThreeDotMenuTest {
 
     @Test
     fun threeDotMenuItemsTest() {
-
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
         navigationToolbar {
-
         // pull up URL to ensure this is not a first-user 3 dot menu
-
         }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
+            mDevice.waitForIdle()
         }.openNavigationToolbar {
         }.openThreeDotMenu {
             verifyThreeDotMenuExists()
@@ -96,7 +93,10 @@ class ThreeDotMenuTest {
             verifyStopButtonExists()
             verifyShareButtonExists()
             verifyRequestDesktopSiteToggleExists()
+            verifyAddToHomescreenButtonExists()
             verifyFindInPageButtonExists()
+            verifyAddOnsButtonExists()
+            verifySyncedTabsButtonExists()
             verifyReportIssueExists()
             verifyOpenSettingsExists()
         }


### PR DESCRIPTION
Adding missing page view menu items to `threeDotMenuItemsTest`
✔️ Successfully ran 30x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
