### PR TITLE
Fix for flaky openFXAQrCodeTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
@@ -73,7 +73,9 @@ class SettingsViewTest {
         }.openThreeDotMenu {
         }.openSettings {
         }.openFXAQrCode {
+            mDevice.waitForIdle()
             verifyFxAQrCode()
+            mDevice.pressBack()
         }
 
     }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
@@ -5,10 +5,13 @@
 package org.mozilla.reference.browser.ui.robots
 
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.Until
+import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTimeShort
 
 /**
@@ -25,10 +28,12 @@ class ExternalAppsRobot {
     }
 }
 
-private fun fXAQrCode() = onView(ViewMatchers.withText("Pairing"))
-
 private fun assertDefaultAppsLayout() {
     mDevice.wait(Until.findObject(By.text("Default apps")), waitingTimeShort)
 }
-private fun assertFXAQrCode() = fXAQrCode()
-        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertFXAQrCode() {
+    onView(withText(R.string.pair_preferences))
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    onView(withText(R.string.pair_instructions))
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+}


### PR DESCRIPTION
Fix for **flaky** `openFXAQrCodeTest` that in some cases **causes test instrumentation process to crash**
✔️ Successfully ran 30x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
