### PR TITLE
New Sanity Check requestDesktopSiteTest and fix flaky openThreeDotMenu transition

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
@@ -256,4 +256,23 @@ class ThreeDotMenuTest {
             verifyNotSignedInSyncTabsView()
         }
     }
+
+    @Test
+    fun requestDesktopSiteTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
+        }.openNavigationToolbar {
+        }.openThreeDotMenu {
+        }.requestDesktopSite {
+        }.openThreeDotMenu {
+            verifyRequestDesktopSiteIsTurnedOn()
+        }.goBack {
+        }.openThreeDotMenu {
+        }.requestDesktopSite {
+        }.openThreeDotMenu {
+            verifyRequestDesktopSiteIsTurnedOff()
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NavigationToolbarRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NavigationToolbarRobot.kt
@@ -15,9 +15,11 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.waitAndInteract
+import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.click
 
 /**
@@ -46,9 +48,11 @@ class NavigationToolbarRobot {
         }
 
         fun openThreeDotMenu(interact: ThreeDotMenuRobot.() -> Unit): ThreeDotMenuRobot.Transition {
-            mDevice.waitAndInteract(Until.findObject(By.desc("Menu"))) {
-                click()
-            }
+            mDevice.findObject(UiSelector()
+                .resourceId("org.mozilla.reference.browser.debug:id/mozac_browser_toolbar_menu"))
+                .waitForExists(waitingTime)
+            threeDotMenuButton().click()
+
             ThreeDotMenuRobot().interact()
             return ThreeDotMenuRobot.Transition()
         }
@@ -70,6 +74,7 @@ private fun openTabTray() = onView(withId(R.id.counter_box))
 private var numberOfOpenTabsTabCounter = onView(withId(R.id.counter_text))
 private fun urlBar() = onView(withId(R.id.mozac_browser_toolbar_url_view))
 private fun awesomeBar() = onView(withId(R.id.mozac_browser_toolbar_edit_url_view))
+private fun threeDotMenuButton() = onView(withId(R.id.mozac_browser_toolbar_menu))
 
 private fun assertNoTabAddressText() {
     mDevice.waitAndInteract(Until.findObject(By.text("Search or enter address"))) {}

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
@@ -15,6 +15,8 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
+import junit.framework.Assert.assertFalse
+import junit.framework.Assert.assertTrue
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.click
@@ -46,6 +48,9 @@ class ThreeDotMenuRobot {
     fun verifyStopButtonDoesntExist() = assertStopButtonDoesntExist()
     fun verifyAddToHomescreenButtonDoesntExist() = assertAddToHomescreenButtonDoesntExist()
 
+    fun verifyRequestDesktopSiteIsTurnedOff() = assertRequestDesktopSiteIsTurnedOff()
+    fun verifyRequestDesktopSiteIsTurnedOn() = assertRequestDesktopSiteIsTurnedOn()
+
     class Transition {
 
         fun goForward(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
@@ -76,7 +81,10 @@ class ThreeDotMenuRobot {
         }
 
         fun requestDesktopSite(interact: NavigationToolbarRobot.() -> Unit): NavigationToolbarRobot.Transition {
+            mDevice.findObject(UiSelector().textContains("Request desktop site"))
+                .waitForExists(waitingTime)
             requestDesktopSiteToggle().click()
+            mDevice.waitForIdle()
             NavigationToolbarRobot().interact()
             return NavigationToolbarRobot.Transition()
         }
@@ -112,6 +120,13 @@ class ThreeDotMenuRobot {
 
             SyncedTabsRobot().interact()
             return SyncedTabsRobot.Transition()
+        }
+
+        fun goBack(interact: NavigationToolbarRobot.() -> Unit): NavigationToolbarRobot.Transition {
+            mDevice.pressBack()
+
+            NavigationToolbarRobot().interact()
+            return NavigationToolbarRobot.Transition()
         }
     }
 }
@@ -164,3 +179,13 @@ private fun assertReportIssueButton() = reportIssueButton()
         .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 private fun assertSettingsButton() = settingsButton()
         .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertRequestDesktopSiteIsTurnedOff() {
+    assertFalse(
+        mDevice.findObject(UiSelector().textContains("Request desktop site")).isChecked
+    )
+}
+private fun assertRequestDesktopSiteIsTurnedOn() {
+    assertTrue(
+        mDevice.findObject(UiSelector().textContains("Request desktop site")).isChecked
+    )
+}


### PR DESCRIPTION
1. New Sanity Check `requestDesktopSiteTest`
✔️ Successfully ran 30x on Firebase

2. Fix flaky `openThreeDotMenu` transition

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
