### PR TITLE
Implement packageName TestHelper and use instead of hardcoded resource-id.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/TestHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/TestHelper.kt
@@ -4,10 +4,13 @@
 
 package org.mozilla.reference.browser.helpers
 
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 
 object TestHelper {
+
+    val packageName = InstrumentationRegistry.getInstrumentation().targetContext.packageName
 
     fun scrollToElementByText(text: String): UiScrollable {
         val appView = UiScrollable(UiSelector().scrollable(true))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
@@ -11,6 +11,7 @@ import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.mozilla.reference.browser.ext.waitAndInteract
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
+import org.mozilla.reference.browser.helpers.TestHelper.packageName
 
 /**
  * Implementation of Robot Pattern for browser action.
@@ -34,10 +35,10 @@ class BrowserRobot {
 
     private fun verifyUrl(expectedUrl: String) {
         mDevice.findObject(UiSelector()
-            .resourceId("org.mozilla.reference.browser.debug:id/toolbar"))
+            .resourceId("$packageName:id/toolbar"))
             .waitForExists(waitingTime)
         mDevice.findObject(UiSelector()
-            .resourceId("org.mozilla.reference.browser.debug:id/mozac_browser_toolbar_url_view"))
+            .resourceId("$packageName:id/mozac_browser_toolbar_url_view"))
             .waitForExists(waitingTime)
         mDevice.findObject(UiSelector().textContains(expectedUrl))
             .waitForExists(waitingTime)

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NavigationToolbarRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NavigationToolbarRobot.kt
@@ -20,6 +20,7 @@ import androidx.test.uiautomator.Until
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.waitAndInteract
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
+import org.mozilla.reference.browser.helpers.TestHelper.packageName
 import org.mozilla.reference.browser.helpers.click
 
 /**
@@ -49,7 +50,7 @@ class NavigationToolbarRobot {
 
         fun openThreeDotMenu(interact: ThreeDotMenuRobot.() -> Unit): ThreeDotMenuRobot.Transition {
             mDevice.findObject(UiSelector()
-                .resourceId("org.mozilla.reference.browser.debug:id/mozac_browser_toolbar_menu"))
+                .resourceId("$packageName:id/mozac_browser_toolbar_menu"))
                 .waitForExists(waitingTime)
             threeDotMenuButton().click()
 

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
@@ -21,6 +21,7 @@ import org.hamcrest.CoreMatchers.allOf
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.TestAssetHelper
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
+import org.mozilla.reference.browser.helpers.TestHelper.packageName
 import org.mozilla.reference.browser.helpers.click
 import org.mozilla.reference.browser.helpers.hasCousin
 
@@ -98,7 +99,7 @@ class SettingsViewRobot {
 }
 
 private fun waitForSettingsRecyclerViewToExist() {
-    mDevice.findObject(UiSelector().resourceId("org.mozilla.reference.browser.debug:id/recycler_view"))
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/recycler_view"))
         .waitForExists(
         waitingTime)
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SyncedTabsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SyncedTabsRobot.kt
@@ -11,6 +11,7 @@ import junit.framework.Assert.assertTrue
 import org.hamcrest.CoreMatchers.allOf
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.TestAssetHelper
+import org.mozilla.reference.browser.helpers.TestHelper.packageName
 
 /**
  * Implementation of Robot Pattern for Synced Tabs sub menu.
@@ -29,7 +30,7 @@ class SyncedTabsRobot {
     private fun assertNotSignedInSyncTabsView() {
         assertTrue(
             mDevice.findObject(UiSelector()
-                .resourceId("org.mozilla.reference.browser.debug:id/synced_tabs_status"))
+                .resourceId("$packageName:id/synced_tabs_status"))
             .waitForExists(TestAssetHelper.waitingTime))
 
         onView(


### PR DESCRIPTION
Implement `packageName` TestHelper and use instead of hardcoded resource-id.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
