### PR TITLE
Fix goForwardTest and disable openFXAQrCodeTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
@@ -67,6 +67,7 @@ class SettingsViewTest {
 
     // openFXAQrCodeTest tests that we get to the camera
     // Additional tests are needed to verify that the QR code reader works
+    @Ignore("Test instrumentation process is crashing, see: https://github.com/mozilla-mobile/reference-browser/issues/1502")
     @Test
     fun openFXAQrCodeTest() {
         navigationToolbar {

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
@@ -103,31 +103,25 @@ class ThreeDotMenuTest {
     }
 
     @Test
-    @Ignore("Cannot figure out why this test is failing when trying to open the three-dot menu.")
     fun goForwardTest() {
 
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val nextWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
 
-        // navigate to webpage and back to cache a browsing history
-        // (for page forward test)
-
         navigationToolbar {
         }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            verifyUrl(defaultWebPage.toString())
         }.openNavigationToolbar {
         }.enterUrlAndEnterToBrowser(nextWebPage.url) {
-            verifyPageContent(nextWebPage.content)
-        }.openNavigationToolbar {
+            verifyUrl(nextWebPage.toString())
             mDevice.pressBack()
-            mDevice.pressBack()
+            verifyUrl(defaultWebPage.toString())
         }
 
         navigationToolbar {
         }.openThreeDotMenu {
-            verifyThreeDotMenuExists()
         }.goForward {
-            verifyPageContent(nextWebPage.content)
+            verifyUrl(nextWebPage.toString())
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
@@ -55,6 +55,8 @@ class ThreeDotMenuRobot {
 
         fun goForward(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
             forwardButton().click()
+            mDevice.waitForIdle()
+
             BrowserRobot().interact()
             return BrowserRobot.Transition()
         }


### PR DESCRIPTION
Fix `goForwardTest `
✔️ Successfully ran 30x on Firebase

Disabled `openFXAQrCodeTest`
❗ It causes the test instrumentation process to crash
Filled #1502 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
