### PR TITLE
New Sanity Check Addons Tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/AddonsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/AddonsTest.kt
@@ -1,0 +1,86 @@
+package org.mozilla.reference.browser.ui
+
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.reference.browser.helpers.AndroidAssetDispatcher
+import org.mozilla.reference.browser.helpers.BrowserActivityTestRule
+import org.mozilla.reference.browser.ui.robots.navigationToolbar
+
+class AddonsTest {
+
+    private lateinit var mockWebServer: MockWebServer
+
+    @get:Rule
+    val activityTestRule = BrowserActivityTestRule()
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer().apply {
+            setDispatcher(AndroidAssetDispatcher())
+            start()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun addonsListingPageTest() {
+        navigationToolbar {
+        }.openThreeDotMenu {
+        }.openAddonsManager {
+            verifyAddonsRecommendedView()
+        }
+    }
+
+    @Test
+    fun cancelAddonInstallTest() {
+        val addonName = "uBlock Origin"
+
+        navigationToolbar {
+        }.openThreeDotMenu {
+        }.openAddonsManager {
+            clickInstallAddonButton(addonName)
+            verifyInstallAddonPrompt(addonName)
+            clickCancelInstallButton()
+            verifyAddonsRecommendedView()
+        }
+    }
+
+    @Test
+    fun installAddonTest() {
+        val addonName = "uBlock Origin"
+
+        navigationToolbar {
+        }.openThreeDotMenu {
+        }.openAddonsManager {
+            clickInstallAddonButton(addonName)
+            verifyInstallAddonPrompt(addonName)
+            clickAllowInstallAddonButton()
+            waitForAddonDownloadComplete()
+            verifyAddonDownloadCompletedPrompt(addonName)
+        }
+    }
+
+    @Test
+    fun verifyAddonElementsTest() {
+        val addonName = "uBlock Origin"
+
+        navigationToolbar {
+        }.openThreeDotMenu {
+        }.openAddonsManager {
+            verifyAddonsRecommendedView()
+            clickInstallAddonButton(addonName)
+            clickAllowInstallAddonButton()
+            waitForAddonDownloadComplete()
+        }.dismissAddonDownloadCompletedPrompt {
+            openAddon(addonName)
+            verifyAddonElementsView(addonName)
+        }
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
@@ -222,22 +222,6 @@ class ThreeDotMenuTest {
     }
 
     @Test
-    fun openAddOnsManagerTest() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
-            mDevice.waitForIdle()
-        }.openNavigationToolbar {
-        }.openThreeDotMenu {
-            verifyAddOnsButtonExists()
-        }.openAddonsManager {
-            mDevice.waitForIdle()
-            verifyAddonsView()
-        }
-    }
-
-    @Test
     // Verifies the Synced tabs menu opens from a tab's 3 dot menu and displays the correct view if the user isn't signed in
     fun openSyncedTabsTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddonsManagerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddonsManagerRobot.kt
@@ -5,33 +5,59 @@
 package org.mozilla.reference.browser.ui.robots
 
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.UiSelector
 import junit.framework.Assert.assertTrue
 import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.containsString
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
+import org.mozilla.reference.browser.helpers.TestHelper.packageName
 
 /**
  * Implementation of Robot Pattern for the addons manager.
  */
 class AddonsManagerRobot {
 
-    fun verifyAddonsView() = assertAddonsView()
+    fun verifyAddonsRecommendedView() = assertAddonsRecommendedView()
+    fun verifyAddonsEnabledView() = assertAddonsEnabledView()
+    fun verifyInstallAddonPrompt(addonName: String) = assertAddonPrompt(addonName)
+    fun verifyAddonDownloadCompletedPrompt(addonName: String) = assertAddonDownloadCompletedPrompt(addonName)
+    fun verifyAddonElementsView(addonName: String) = assertAddonElementsView(addonName)
+    fun clickInstallAddonButton(addonName: String) = selectInstallAddonButton(addonName)
+    fun clickCancelInstallButton() = cancelInstallButton()
+    fun clickAllowInstallAddonButton() = allowInstallAddonButton()
+    fun waitForAddonDownloadComplete() = waitForDownloadProgressUntilGone()
+    fun openAddon(addonName: String) {
+        mDevice.waitForIdle()
+        verifyAddonsEnabledView()
+        onView(
+            allOf(
+                withId(R.id.add_on_name),
+                withText(addonName)))
+            .check(matches(isCompletelyDisplayed()))
+            .perform(click())
+    }
 
     class Transition {
-        fun addonsManager(interact: AddonsManagerRobot.() -> Unit): AddonsManagerRobot.Transition {
+        fun dismissAddonDownloadCompletedPrompt(interact: AddonsManagerRobot.() -> Unit): AddonsManagerRobot.Transition {
+            mDevice.pressBack()
             AddonsManagerRobot().interact()
             return AddonsManagerRobot.Transition()
         }
     }
 
-    private fun assertAddonsView() {
+    private fun assertAddonsRecommendedView() {
         assertTrue(mDevice.findObject(UiSelector().text("Recommended")).waitForExists(waitingTime))
         // Check uBlock is displayed in the "Recommended" section
         onView(
@@ -40,7 +66,118 @@ class AddonsManagerRobot {
                     hasDescendant(withText("uBlock Origin")),
                     hasDescendant(withText("Finally, an efficient wide-spectrum content blocker. Easy on CPU and memory.")),
                     hasDescendant(withId(R.id.rating)),
-                    hasDescendant(withId(R.id.users_count))
+                    hasDescendant(withId(R.id.users_count)),
+                    hasDescendant(withId(R.id.add_button))
+            )
+        ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    }
+
+    private fun assertAddonsEnabledView() {
+        assertTrue(mDevice.findObject(UiSelector().text("Enabled")).waitForExists(waitingTime))
+        // Check uBlock is displayed in the "Enabled" section
+        onView(
+            allOf(
+                withId(R.id.add_on_item),
+                hasDescendant(withText("uBlock Origin")),
+                hasDescendant(withText("Finally, an efficient wide-spectrum content blocker. Easy on CPU and memory.")),
+                hasDescendant(withId(R.id.rating)),
+                hasDescendant(withId(R.id.users_count)),
+                hasDescendant(withId(R.id.add_button))
+            )
+        ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    }
+
+    private fun installAddonButton(addonName: String) =
+        onView(
+            allOf(
+                withContentDescription(R.string.mozac_feature_addons_install_addon_content_description),
+                isDescendantOfA(withId(R.id.add_on_item)),
+                hasSibling(hasDescendant(withText(addonName)))
+            )
+        )
+
+    private fun selectInstallAddonButton(addonName: String) {
+        mDevice.waitForIdle()
+        mDevice.findObject(UiSelector().textContains(addonName))
+            .waitForExists(waitingTime)
+
+        installAddonButton(addonName)
+            .check(matches(isCompletelyDisplayed()))
+            .perform(click())
+    }
+
+    private fun assertAddonPrompt(addonName: String) {
+        mDevice.waitForIdle()
+        mDevice.findObject(UiSelector()
+            .resourceId("$packageName:id/title"))
+            .waitForExists(waitingTime)
+
+        assertTrue(mDevice.findObject(UiSelector().textContains("Add $addonName?"))
+            .waitForExists(waitingTime))
+
+        onView(
+            allOf(
+                withId(R.id.permissions),
+                withText(containsString("It requires your permission to:"))
+            )
+        ).check(matches(isCompletelyDisplayed()))
+
+        onView(
+            allOf(
+                withId(R.id.allow_button),
+                withText(R.string.mozac_feature_addons_permissions_dialog_add)))
+            .check(matches(isCompletelyDisplayed()))
+
+        onView(
+            allOf(
+                withId(R.id.deny_button),
+                withText(R.string.mozac_feature_addons_permissions_dialog_cancel)))
+            .check(matches(isCompletelyDisplayed()))
+    }
+
+    private fun cancelInstallButton() {
+        onView(
+            allOf(
+                withId(R.id.deny_button),
+                withText(R.string.mozac_feature_addons_permissions_dialog_cancel)))
+            .check(matches(isCompletelyDisplayed()))
+            .perform(click())
+    }
+
+    private fun allowInstallAddonButton() {
+        onView(
+            allOf(
+                withId(R.id.allow_button),
+                withText(R.string.mozac_feature_addons_permissions_dialog_add)))
+            .check(matches(isCompletelyDisplayed()))
+            .perform(click())
+    }
+
+    private fun assertAddonDownloadCompletedPrompt(addonName: String) {
+        mDevice.waitForIdle()
+        assertTrue(mDevice.findObject(UiSelector()
+            .textContains("$addonName has been added to Reference Browser"))
+            .waitForExists(waitingTime))
+    }
+
+    private fun waitForDownloadProgressUntilGone() {
+        mDevice.waitForIdle()
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/addonProgressOverlay"))
+            .waitUntilGone(waitingTime)
+    }
+
+    private fun assertAddonElementsView(addonName: String) {
+        mDevice.waitForIdle()
+        mDevice.findObject(UiSelector().textContains(addonName)).waitForExists(waitingTime)
+
+        onView(
+            allOf(
+                withId(R.id.remove_add_on),
+                hasSibling(withId(R.id.enable_switch)),
+                hasSibling(withId(R.id.settings)),
+                hasSibling(withId(R.id.details)),
+                hasSibling(withId(R.id.permissions)),
+                hasSibling(withId(R.id.allow_in_private_browsing_switch))
             )
         ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
     }


### PR DESCRIPTION
New Sanity Check Add-ons Tests:
`addonsListingPageTest` ✔️ Successfully ran 30x on Firebase
`cancelAddonInstallTest` ✔️ Successfully ran 30x on Firebase
`installAddonTest` ✔️ Successfully ran 30x on Firebase
`verifyAddonElementsTest` ✔️ Successfully ran 30x on Firebase

Removed the `openAddOnsManagerTest` from the `ThreeDotMenuTest` as it will be covered in the new `AddonsTest` class

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
