### PR TITLE
New Sanity Check customAddonsCollectionTest and remove redundant verifyUseTelemetryToggle() from SettingsViewTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
@@ -27,6 +27,7 @@ class SettingsViewTest {
     val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(android.Manifest.permission.CAMERA)
 
     @get:Rule val browserActivityTestRule = BrowserActivityTestRule()
+
     // This test verifies settings view items are all in place
     @Test
     fun settingsItemsTest() {
@@ -94,7 +95,6 @@ class SettingsViewTest {
             verifyTPEnableinPrivateBrowsing()
             verifyDataChoicesHeading()
             verifyUseTelemetryToggle()
-            verifyUseTelemetryToggle()
             verifyTelemetrySummary()
         }
     }
@@ -128,6 +128,22 @@ class SettingsViewTest {
             scrollToElementByText("About Reference Browser")
         }.openAboutReferenceBrowser {
             verifyAboutBrowser()
+        }
+    }
+
+    @Test
+    /* Can't check further because after creating the custom add-on collection
+    the currently running process is terminated see:
+    /blob/master/app/src/main/java/org/mozilla/reference/browser/settings/SettingsFragment.kt#L217
+    Confirming the custom add-on collection creation or trying to continue testing afterwards
+    will cause the test instrumentation process to crash */
+    fun customAddonsCollectionTest() {
+        navigationToolbar {
+        }.openThreeDotMenu {
+        }.openSettings {
+            verifyCustomAddonCollectionButton()
+            clickCustomAddonCollectionButton()
+            verifyCustomAddonCollectionPanelExist()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
@@ -10,6 +10,8 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -48,6 +50,9 @@ class SettingsViewRobot {
     fun verifyMozillaHeading() = assertMozillaHeading()
     fun verifyAboutReferenceBrowserButton() = assertAboutReferenceBrowserButton()
     fun verifySettingsRecyclerViewToExist() = waitForSettingsRecyclerViewToExist()
+
+    fun clickCustomAddonCollectionButton() = customAddonCollectionButton().click()
+    fun verifyCustomAddonCollectionPanelExist() = assertCustomAddonCollectionPanel()
 
     // toggleRemoteDebugging does not yet verify that the debug service is started
     // server runs on port 6000
@@ -159,3 +164,14 @@ private fun assertMozillaHeading() = mozillaHeading()
         .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 private fun assertAboutReferenceBrowserButton() = aboutReferenceBrowserButton()
         .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertCustomAddonCollectionPanel() {
+    mDevice.waitForIdle()
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/parentPanel"))
+        .waitForExists(waitingTime)
+    onView(
+        allOf(
+            withText(R.string.preferences_customize_amo_collection),
+            isDescendantOfA(withId(R.id.title_template))
+        )
+    ).check(matches(isCompletelyDisplayed()))
+}


### PR DESCRIPTION
• New Sanity Check `customAddonsCollectionTest`
✔️ Successfully ran 30x on Firebase

• Remove redundant `verifyUseTelemetryToggle()` from `SettingsViewTest` (was used 2x)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
