### PR TITLE
update_android_components.sh: Watch different component.

### DIFF
--- a/automation/taskcluster/update_android_components.sh
+++ b/automation/taskcluster/update_android_components.sh
@@ -13,7 +13,7 @@ export REPO="reference-browser"
 git config --global user.email "$EMAIL"
 git config --global user.name "$GITHUB_USER"
 
-COMPONENT_TO_WATCH='browser-engine-gecko-nightly'
+COMPONENT_TO_WATCH='browser-engine-gecko'
 MAVEN_URL="https://nightly.maven.mozilla.org/maven2/org/mozilla/components/$COMPONENT_TO_WATCH"
 
 # Fetch latest version


### PR DESCRIPTION
`browser-engine-gecko-nightly` doesn't exist anymore. Let's watch `browser-engine-gecko` instead.

Like Fenix: https://github.com/mozilla-mobile/fenix/pull/19165