### PR TITLE
Request desktop site in custom tabs test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/CustomTabsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/CustomTabsTest.kt
@@ -135,10 +135,10 @@ class CustomTabsTest {
 
         customTabScreen {
         }.openMainMenu {
-            requestDesktopSite()
+            switchRequestDesktopSiteToggle()
         }.openMainMenu {
             verifyRequestDesktopSiteIsTurnedOn()
-            requestDesktopSite()
+            switchRequestDesktopSiteToggle()
         }.openMainMenu {
             verifyRequestDesktopSiteIsTurnedOff()
         }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/CustomTabsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/CustomTabsTest.kt
@@ -122,4 +122,25 @@ class CustomTabsTest {
             verifyShareContentPanel()
         }
     }
+
+    @Test
+    fun customTabRequestDesktopSiteTest() {
+        val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        intentReceiverActivityTestRule.launchActivity(
+            createCustomTabIntent(
+                customTabPage.url.toString()
+            )
+        )
+
+        customTabScreen {
+        }.openMainMenu {
+            requestDesktopSite()
+        }.openMainMenu {
+            verifyRequestDesktopSiteIsTurnedOn()
+            requestDesktopSite()
+        }.openMainMenu {
+            verifyRequestDesktopSiteIsTurnedOff()
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
@@ -265,12 +265,12 @@ class ThreeDotMenuTest {
         }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
         }.openNavigationToolbar {
         }.openThreeDotMenu {
-        }.requestDesktopSite {
+        }.switchRequestDesktopSiteToggle {
         }.openThreeDotMenu {
             verifyRequestDesktopSiteIsTurnedOn()
         }.goBack {
         }.openThreeDotMenu {
-        }.requestDesktopSite {
+        }.switchRequestDesktopSiteToggle {
         }.openThreeDotMenu {
             verifyRequestDesktopSiteIsTurnedOff()
         }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/CustomTabRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/CustomTabRobot.kt
@@ -13,6 +13,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withSubstring
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
@@ -38,6 +39,8 @@ class CustomTabRobot {
     fun verifyRequestDesktopButton() = assertRequestDesktopButton()
     fun verifyFindInPageButton() = assertFindInPageButton()
     fun verifyOpenInBrowserButton() = assertOpenInBrowserButton()
+    fun verifyRequestDesktopSiteIsTurnedOff() = assertRequestDesktopSiteIsTurnedOff()
+    fun verifyRequestDesktopSiteIsTurnedOn() = assertRequestDesktopSiteIsTurnedOn()
     fun clickForwardButton() = forwardButton().click()
 
     fun clickGenericLink(expectedText: String) {
@@ -46,6 +49,13 @@ class CustomTabRobot {
         mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)
         val link = mDevice.findObject(By.textContains(expectedText))
         link.click()
+    }
+
+    fun requestDesktopSite() {
+        mDevice.findObject(UiSelector().textContains("Request desktop site"))
+            .waitForExists(waitingTime)
+        requestDesktopButton().click()
+        mDevice.waitForIdle()
     }
 
     class Transition {
@@ -125,3 +135,13 @@ private fun assertFindInPageButton() =
     findInPage().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 private fun assertOpenInBrowserButton() =
     openInBrowser().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertRequestDesktopSiteIsTurnedOff() {
+    assertFalse(
+        mDevice.findObject(UiSelector().textContains("Request desktop site")).isChecked
+    )
+}
+private fun assertRequestDesktopSiteIsTurnedOn() {
+    assertTrue(
+        mDevice.findObject(UiSelector().textContains("Request desktop site")).isChecked
+    )
+}

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/CustomTabRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/CustomTabRobot.kt
@@ -51,7 +51,7 @@ class CustomTabRobot {
         link.click()
     }
 
-    fun requestDesktopSite() {
+    fun switchRequestDesktopSiteToggle() {
         mDevice.findObject(UiSelector().textContains("Request desktop site"))
             .waitForExists(waitingTime)
         requestDesktopButton().click()

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
@@ -78,7 +78,9 @@ class ThreeDotMenuRobot {
             return ContentPanelRobot.Transition()
         }
 
-        fun requestDesktopSite(interact: NavigationToolbarRobot.() -> Unit): NavigationToolbarRobot.Transition {
+        fun switchRequestDesktopSiteToggle(
+            interact: NavigationToolbarRobot.() -> Unit
+        ): NavigationToolbarRobot.Transition {
             mDevice.findObject(UiSelector().textContains("Request desktop site"))
                 .waitForExists(waitingTime)
             requestDesktopSiteToggle().click()


### PR DESCRIPTION
• New `customTabRequestDesktopSiteTest` ✔️ Successfully ran 20x on Firebase
• Use a more suggestive name for switching the "Request desktop site" toggle, changed from `requestDesktopSite` to `switchRequestDesktopSiteToggle`

Use a more suggestive naming 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
