### PR TITLE
New open custom tab in browser UI test and assertion addition to the verifyUrl function

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ContextMenusTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ContextMenusTest.kt
@@ -92,7 +92,7 @@ class ContextMenusTest {
         }.clickToolbar {
             verifyLinkFromClipboard(genericURL.url.toString())
         }.clickLinkFromClipboard(genericURL.url.toString()) {
-            verifyUrl(genericURL.toString())
+            verifyUrl(genericURL.url.toString())
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/CustomTabsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/CustomTabsTest.kt
@@ -143,4 +143,21 @@ class CustomTabsTest {
             verifyRequestDesktopSiteIsTurnedOff()
         }
     }
+
+    @Test
+    fun customTabOpenInBrowserTest() {
+        val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        intentReceiverActivityTestRule.launchActivity(
+            createCustomTabIntent(
+                customTabPage.url.toString()
+            )
+        )
+
+        customTabScreen {
+        }.openMainMenu {
+        }.clickOpenInBrowserButton {
+            verifyUrl(customTabPage.url.toString())
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
@@ -110,16 +110,16 @@ class ThreeDotMenuTest {
 
         navigationToolbar {
         }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
-            verifyUrl(defaultWebPage.toString())
+            verifyUrl(defaultWebPage.url.toString())
         }.openNavigationToolbar {
         }.enterUrlAndEnterToBrowser(nextWebPage.url) {
-            verifyUrl(nextWebPage.toString())
+            verifyUrl(nextWebPage.url.toString())
         }.goBack {
-            verifyUrl(defaultWebPage.toString())
+            verifyUrl(defaultWebPage.url.toString())
         }.openNavigationToolbar {
         }.openThreeDotMenu {
         }.goForward {
-            verifyUrl(nextWebPage.toString())
+            verifyUrl(nextWebPage.url.toString())
         }
     }
 
@@ -134,16 +134,16 @@ class ThreeDotMenuTest {
             openPrivateBrowsing()
         }.openNewTab {
         }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
-            verifyUrl(defaultWebPage.toString())
+            verifyUrl(defaultWebPage.url.toString())
         }.openNavigationToolbar {
         }.enterUrlAndEnterToBrowser(nextWebPage.url) {
-            verifyUrl(nextWebPage.toString())
+            verifyUrl(nextWebPage.url.toString())
         }.goBack {
-            verifyUrl(defaultWebPage.toString())
+            verifyUrl(defaultWebPage.url.toString())
         }.openNavigationToolbar {
         }.openThreeDotMenu {
         }.goForward {
-            verifyUrl(nextWebPage.toString())
+            verifyUrl(nextWebPage.url.toString())
         }
     }
 
@@ -284,7 +284,7 @@ class ThreeDotMenuTest {
             verifyAddToHomeScreenPopup()
             clickAddAutomaticallyToHomeScreenButton()
         }.openHomeScreenShortcut(defaultWebPage.title) {
-            verifyUrl(defaultWebPage.toString())
+            verifyUrl(defaultWebPage.url.toString())
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
@@ -4,12 +4,21 @@
 
 package org.mozilla.reference.browser.ui.robots
 
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withSubstring
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import junit.framework.Assert.assertTrue
+import org.hamcrest.CoreMatchers.allOf
+import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.waitAndInteract
 import org.mozilla.reference.browser.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
@@ -44,6 +53,13 @@ class BrowserRobot {
             .waitForExists(waitingTime)
         mDevice.findObject(UiSelector().textContains(expectedUrl))
             .waitForExists(waitingTime)
+        onView(
+            allOf(
+                withSubstring(expectedUrl),
+                withId(R.id.mozac_browser_toolbar_url_view),
+                isDescendantOfA(withId(R.id.mozac_browser_toolbar_origin_view))
+            )
+        ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
     }
 
     fun verifyAboutBrowser() {

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/CustomTabRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/CustomTabRobot.kt
@@ -79,6 +79,13 @@ class CustomTabRobot {
             ContentPanelRobot().interact()
             return ContentPanelRobot.Transition()
         }
+
+        fun clickOpenInBrowserButton(interact: BrowserRobot.() -> Unit): Transition {
+            openInBrowserButton().click()
+
+            BrowserRobot().interact()
+            return Transition()
+        }
     }
 }
 
@@ -99,7 +106,7 @@ private fun stopButton() = onView(withContentDescription("Stop"))
 private fun shareButton() = onView(withText("Share"))
 private fun requestDesktopButton() = onView(withSubstring("Request desktop site"))
 private fun findInPage() = onView(withText("Find in Page"))
-private fun openInBrowser() = onView(withText("Open in Browser"))
+private fun openInBrowserButton() = onView(withText("Open in Browser"))
 
 private fun assertCloseButton() =
     closeButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
@@ -134,7 +141,7 @@ private fun assertRequestDesktopButton() =
 private fun assertFindInPageButton() =
     findInPage().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 private fun assertOpenInBrowserButton() =
-    openInBrowser().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    openInBrowserButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 private fun assertRequestDesktopSiteIsTurnedOff() {
     assertFalse(
         mDevice.findObject(UiSelector().textContains("Request desktop site")).isChecked


### PR DESCRIPTION
► Added an assertion to the `verifyUrl` function.
✔️ Successfully re-ran the affected tests for 5x on Firebase:
• `contextCopyLinkTest`
• `siteSearchSuggestionTest`
• `openNewTabTest`
• `openNewPrivateTabTest`
• `normalBrowsingTabNavigationTest`
• `privateBrowsingTabNavigationTest`
• `addToHomeScreenTest`

► Created a new `customTabOpenInBrowserTest`
✔️ Successfully ran 20x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
