### PR TITLE
Tabstray in Jetpack Compose

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,10 @@ android {
         compose true
     }
 
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.0.0-beta07'
+    }
+
     buildTypes {
         debug {
             applicationIdSuffix ".debug"

--- a/app/src/main/java/mozilla/components/compose/tabs/BrowserTabsTrayList.kt
+++ b/app/src/main/java/mozilla/components/compose/tabs/BrowserTabsTrayList.kt
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.compose.tabs
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.tabstray.TabsTray
+import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.lib.state.observeAsState
+
+/**
+ * Observes the tabs that the [TabsTray] API tells us to in [TabsTray.updateTabs].
+ */
+@Composable
+fun BrowserTabsTrayList(
+    adapter: ComposableTrayAdapter,
+    useCases: TabsUseCases? = null,
+    closeTabsTray: () -> Unit = {}
+) {
+    val tabs = remember { adapter.observe() }
+
+    TabsTrayList(tabs.value, useCases, closeTabsTray)
+}
+
+/**
+ * Observes the [BrowserState.tabs] directly to display all of them.
+ */
+@Composable
+fun BrowserTabsTrayList(
+    browserStore: BrowserStore,
+    useCases: TabsUseCases? = null,
+    closeTabsTray: () -> Unit = {}
+) {
+    val tabs by browserStore.observeAsState { state -> state.toTabs() }
+
+    tabs?.let { TabsTrayList(it, useCases, closeTabsTray) }
+}

--- a/app/src/main/java/mozilla/components/compose/tabs/BrowserThumbnail.kt
+++ b/app/src/main/java/mozilla/components/compose/tabs/BrowserThumbnail.kt
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.compose.tabs
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import mozilla.components.concept.tabstray.Tab
+import org.mozilla.reference.browser.R
+
+@Composable
+fun BrowserThumbnail(tab: Tab) {
+    Surface(
+        modifier = Modifier
+            .requiredSize(width = 100.dp, height = Dp.Unspecified)
+            .fillMaxHeight()
+            .clip(RoundedCornerShape(4.dp)),
+        color = MaterialTheme.colors.onSurface.copy(alpha = 0.2f)
+    ) {
+        val image = tab.thumbnail?.asImageBitmap()
+        val description = "thumbnail image of " + tab.title
+        if (image != null) {
+            Image(
+                bitmap = image,
+                contentDescription = description,
+                contentScale = ContentScale.FillWidth,
+                alignment = Alignment.TopStart
+            )
+        } else {
+            @Suppress("MagicNumber")
+            Box(
+                modifier = Modifier
+                    .size(16.dp)
+                    .alpha(0.5f),
+                contentAlignment = Alignment.Center
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.mozac_ic_globe),
+                    contentDescription = description
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/mozilla/components/compose/tabs/ComposableTrayAdapter.kt
+++ b/app/src/main/java/mozilla/components/compose/tabs/ComposableTrayAdapter.kt
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.compose.tabs
+
+import androidx.compose.runtime.mutableStateOf
+import mozilla.components.concept.tabstray.Tabs
+import mozilla.components.concept.tabstray.TabsTray
+import mozilla.components.feature.tabs.tabstray.TabsFeature
+import mozilla.components.support.base.observer.Observable
+import mozilla.components.support.base.observer.ObserverRegistry
+import androidx.compose.runtime.MutableState as ComposeState
+
+/**
+ * An implementation of [TabsTray] that that can be use to [observe] from a Composable UI.
+ *
+ * See also [TabsFeature].
+ */
+class ComposableTrayAdapter(
+    delegate: ObserverRegistry<TabsTray.Observer> = ObserverRegistry()
+) : TabsTray, Observable<TabsTray.Observer> by delegate {
+
+    val state = mutableStateOf(Tabs(emptyList(), 0))
+
+    override fun updateTabs(tabs: Tabs) {
+        state.value = tabs
+    }
+
+    fun observe(): ComposeState<Tabs> {
+        return state
+    }
+
+    override fun isTabSelected(tabs: Tabs, position: Int) = false
+    override fun onTabsChanged(position: Int, count: Int) = Unit
+    override fun onTabsInserted(position: Int, count: Int) = Unit
+    override fun onTabsMoved(fromPosition: Int, toPosition: Int) = Unit
+    override fun onTabsRemoved(position: Int, count: Int) = Unit
+}

--- a/app/src/main/java/mozilla/components/compose/tabs/Extensions.kt
+++ b/app/src/main/java/mozilla/components/compose/tabs/Extensions.kt
@@ -1,0 +1,39 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.compose.tabs
+
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.concept.tabstray.Tabs
+
+/**
+ * Copied from [mozilla.components.feature.tabs.ext.toTab].
+ */
+internal fun TabSessionState.toTab() = mozilla.components.concept.tabstray.Tab(
+    id,
+    content.url,
+    content.title,
+    content.private,
+    content.icon,
+    content.thumbnail,
+    mediaSessionState?.playbackState,
+    mediaSessionState?.controller
+)
+
+/**
+ * Copied from [mozilla.components.feature.tabs.ext.toTabs].
+ */
+internal fun BrowserState.toTabs(
+    tabsFilter: (TabSessionState) -> Boolean = { true }
+) = Tabs(
+    list = tabs
+        .filter(tabsFilter)
+        .map { it.toTab() },
+    selectedIndex = tabs
+        .filter(tabsFilter)
+        .indexOfFirst { it.id == selectedTabId }
+)

--- a/app/src/main/java/mozilla/components/compose/tabs/TabsTray.kt
+++ b/app/src/main/java/mozilla/components/compose/tabs/TabsTray.kt
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.compose.tabs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.concept.tabstray.Tabs
+import mozilla.components.feature.tabs.TabsUseCases
+import org.mozilla.reference.browser.R
+import java.util.UUID
+import androidx.compose.ui.graphics.Color as Colour
+import mozilla.components.concept.tabstray.Tab as BrowserTab
+
+@Composable
+fun Tab(
+    tab: BrowserTab,
+    selected: Boolean = false,
+    onClick: (String) -> Unit = {},
+    onClose: (String) -> Unit = {}
+) {
+    Box(
+        modifier = Modifier
+            .background(if (selected) Colour(0xFFFF45A1FF.toInt()) else Colour.Unspecified)
+            .size(width = Dp.Unspecified, height = 72.dp)
+            .fillMaxWidth()
+            .clickable { onClick.invoke(tab.id) }
+            .padding(8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceAround
+        ) {
+            BrowserThumbnail(tab)
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .align(Alignment.CenterVertically)
+                    .padding(8.dp)
+            ) {
+                Text(
+                    text = tab.title,
+                    fontWeight = FontWeight.Bold,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
+                    color = Colour.White
+                )
+                Text(
+                    text = tab.url,
+                    style = MaterialTheme.typography.body2,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
+                    color = Colour.White.copy(alpha = ContentAlpha.medium)
+                )
+            }
+            IconButton(
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+                    .requiredSize(24.dp),
+                onClick = { onClose.invoke(tab.id) }
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.mozac_ic_close),
+                    contentDescription = "close",
+                    tint = Colour.White
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun TabsTrayList(
+    tabs: Tabs,
+    useCases: TabsUseCases? = null,
+    closeTabsTray: () -> Unit = {}
+) {
+    LazyColumn {
+        itemsIndexed(tabs.list) { index, tab ->
+            Tab(
+                tab = tab,
+                selected = index == tabs.selectedIndex,
+                onClick = {
+                    useCases?.selectTab?.invoke(it)
+                    closeTabsTray.invoke()
+                },
+                onClose = { useCases?.removeTab?.invoke(it) }
+            )
+        }
+    }
+}
+
+@Preview(name = "Tab preview", showBackground = true)
+@Composable
+fun TabPreview() {
+    val tab = BrowserTab(
+        id = UUID.randomUUID().toString(),
+        url = "https://mozilla.org",
+        title = "Mozilla - Maker of Reference Browser and other stuff."
+    )
+    Tab(tab = tab)
+}
+
+@Preview(name = "TabsTray preview", showBackground = true)
+@Composable
+fun TabsTrayListPreview() {
+    val list = listOf(
+        createTab(id = "1", url = "https://mozilla.org", title = "Mozilla - Maker of Reference Browser.").toTab(),
+        createTab(id = "2", url = "https://firefox.com", title = "Firefox - Firefox, does things.").toTab()
+    )
+
+    val tabs = Tabs(list, 1)
+
+    TabsTrayList(tabs)
+}

--- a/app/src/main/res/layout/fragment_tabstray.xml
+++ b/app/src/main/res/layout/fragment_tabstray.xml
@@ -25,6 +25,17 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/tabsPanel"/>
 
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_tabstray"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_gravity="top"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/tabsToolbar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tabsPanel"/>
+
     <org.mozilla.reference.browser.tabs.TabsToolbar
         android:id="@+id/tabsToolbar"
         android:layout_width="match_parent"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -7,7 +7,7 @@
 
 // Synchronized version numbers for dependencies used by (some) modules
 private object Versions {
-    const val kotlin = "1.4.30"
+    const val kotlin = "1.4.32"
     const val coroutines = "1.3.9"
 
     const val androidx_appcompat = "1.3.0-rc01"
@@ -17,7 +17,7 @@ private object Versions {
     const val workmanager = "2.0.0"
     const val google_material = "1.0.0"
 
-    const val android_gradle_plugin = "7.0.0-alpha14"
+    const val android_gradle_plugin = "7.1.0-alpha02"
 
     const val mozilla_android_components = AndroidComponents.VERSION
 
@@ -34,7 +34,7 @@ private object Versions {
     object AndroidX {
         const val activity_compose = "1.3.0-alpha05"
         const val core = "1.1.0"
-        const val compose = "1.0.0-beta03"
+        const val compose = "1.0.0-beta07"
     }
 }
 


### PR DESCRIPTION
A quick implementation of the current tabs tray as a Compose UI that connects to our existing concept-tabstray APIs. Didn't connect the thumbnail cache to the UI for now at least, so the thumbnails disappear pretty soon when we cause memory pressure, but it's possible to it in a future iteration.

The first commit is because my IDE (Canary) was complaining about using an older version of the compose compiler that conflicted with what the IDE had, but I can remove that bit if needed since not everyone uses Canary.

https://user-images.githubusercontent.com/1370580/123530580-1b054480-d6ca-11eb-8152-f9a617967165.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
