### PR TITLE
No Issue: Update Flank to v21.07.1

### DIFF
--- a/taskcluster/docker/ui-tests/Dockerfile
+++ b/taskcluster/docker/ui-tests/Dockerfile
@@ -8,6 +8,9 @@ LABEL maintainer="Richard Pappalardo <rpappalax@gmail.com>"
 #-- Test tools --------------------------------------------------------------------------------------------------------
 #----------------------------------------------------------------------------------------------------------------------
 
+RUN apt-get install -y jq \
+    && apt-get clean
+
 USER worker:worker
 
 ENV GOOGLE_SDK_DOWNLOAD ./gcloud.tar.gz
@@ -26,10 +29,10 @@ RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
     && ${TEST_TOOLS}/google-cloud-sdk/install.sh --quiet \
     && ${TEST_TOOLS}/google-cloud-sdk/bin/gcloud --quiet components update
 
-RUN URL_FLANK_BIN=$(curl -s "https://api.github.com/repos/Flank/flank/releases" | grep "browser_download_url*" | grep "${FLANK_VERSION}" | sed -r "s/\"//g" | cut -d ":" -f3) \
-    && wget "https:${URL_FLANK_BIN}" -O ${TEST_TOOLS}/flank.jar \
-    && chmod +x ${TEST_TOOLS}/flank.jar
-
+# Flank v21.07.1
+RUN URL_FLANK_BIN="$($CURL --silent 'https://api.github.com/repos/Flank/flank/releases/latest' | jq -r '.assets[] | select(.browser_download_url | test("flank.jar")) .browser_download_url')" \
+    && $CURL --output "${TEST_TOOLS}/flank.jar" "${URL_FLANK_BIN}" \
+    && chmod +x "${TEST_TOOLS}/flank.jar"
 
 # run-task expects to run as root
 USER root

--- a/taskcluster/docker/ui-tests/Dockerfile
+++ b/taskcluster/docker/ui-tests/Dockerfile
@@ -12,7 +12,7 @@ USER worker:worker
 
 ENV GOOGLE_SDK_DOWNLOAD ./gcloud.tar.gz
 ENV GOOGLE_SDK_VERSION 233
-ENV FLANK_VERSION v21.05.0
+ENV FLANK_VERSION v21.07.1
 
 ENV TEST_TOOLS /builds/worker/test-tools
 ENV PATH ${PATH}:${TEST_TOOLS}:${TEST_TOOLS}/google-cloud-sdk/bin


### PR DESCRIPTION
Flank changed some of the JSON in `matrix_ids.json` that I am parsing across projects (A-C upgraded already) in a separate project, which means time to update again. Also Flank adds a second `.sha256` release, so we need a little more finesse in downloading the `jar`.