### PR TITLE
For #1650 fix failing openLinksInAppsTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
@@ -44,12 +44,21 @@ private fun assertAutofillServices() {
         .waitForExists(waitingTime))
 }
 
+@Suppress("SwallowedException")
 private fun assertYouTubeApp() {
-    mDevice.waitForIdle()
-    assertTrue(mDevice.findObject(UiSelector().text("Home"))
-        .waitForExists(waitingTime))
-    assertTrue(mDevice.findObject(UiSelector().text("Subscriptions"))
-        .waitForExists(waitingTime))
+    try {
+        // Check youtube's home buttons
+        mDevice.waitForIdle()
+        assertTrue(mDevice.findObject(UiSelector().text("Home"))
+            .waitForExists(waitingTime))
+        assertTrue(mDevice.findObject(UiSelector().text("Subscriptions"))
+            .waitForExists(waitingTime))
+    } catch (e: AssertionError) {
+        println("The native youtube app opens but needs to be updated")
+        // In case the app isn't up to date on the emulator an update message will be displayed
+        assertTrue(mDevice.findObject(UiSelector().text("Update for a faster, better YouTube"))
+            .waitForExists(waitingTime))
+    }
 }
 
 private fun assertFXAQrCode() {


### PR DESCRIPTION
For #1650 fix failing `openLinksInAppsTest` UI test.
✔️ Successfully passed 25x on Firebase
❗ The root cause for the failures was the fact that the You Tube app required an update after opening a link from RB. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
