### PR TITLE
No issue: Update Flank to v21.08.1

### DIFF
--- a/taskcluster/docker/ui-tests/Dockerfile
+++ b/taskcluster/docker/ui-tests/Dockerfile
@@ -15,7 +15,7 @@ USER worker:worker
 
 ENV GOOGLE_SDK_DOWNLOAD ./gcloud.tar.gz
 ENV GOOGLE_SDK_VERSION 233
-ENV FLANK_VERSION v21.07.1
+ENV FLANK_VERSION v21.08.1
 
 ENV TEST_TOOLS /builds/worker/test-tools
 ENV PATH ${PATH}:${TEST_TOOLS}:${TEST_TOOLS}/google-cloud-sdk/bin


### PR DESCRIPTION
Flank https://github.com/Flank/flank/releases/tag/v21.08.1 has the fix for avoiding crash one of their API calls that we hit a couple times.