### PR TITLE
Replace BrowserAwesomeBar view with AwesomeBar() composable

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -213,6 +213,7 @@ project.configurations.all {
 }
 
 dependencies {
+    implementation Deps.mozilla_concept_awesomebar
     implementation Deps.mozilla_concept_engine
     implementation Deps.mozilla_concept_menu
     implementation Deps.mozilla_concept_tabstray
@@ -221,9 +222,10 @@ dependencies {
     implementation Deps.mozilla_concept_sync
     implementation Deps.mozilla_concept_push
 
+    implementation Deps.mozilla_compose_awesomebar
+
     implementation Deps.mozilla_browser_engine_gecko
 
-    implementation Deps.mozilla_browser_awesomebar
     implementation Deps.mozilla_browser_domains
     implementation Deps.mozilla_browser_tabstray
     implementation Deps.mozilla_browser_toolbar

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.preference.PreferenceManager
 import com.google.android.material.floatingactionbutton.FloatingActionButton
-import mozilla.components.browser.awesomebar.BrowserAwesomeBar
 import mozilla.components.browser.thumbnails.BrowserThumbnails
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.engine.EngineView
@@ -23,6 +22,7 @@ import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.components
 import org.mozilla.reference.browser.ext.requireComponents
+import org.mozilla.reference.browser.search.AwesomeBarWrapper
 import org.mozilla.reference.browser.tabs.TabsTrayFragment
 
 /**
@@ -33,7 +33,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     private val readerViewFeature = ViewBoundFeatureWrapper<ReaderViewIntegration>()
     private val webExtToolbarFeature = ViewBoundFeatureWrapper<WebExtensionToolbarFeature>()
 
-    private val awesomeBar: BrowserAwesomeBar
+    private val awesomeBar: AwesomeBarWrapper
         get() = requireView().findViewById(R.id.awesomeBar)
     private val toolbar: BrowserToolbar
         get() = requireView().findViewById(R.id.toolbar)
@@ -60,6 +60,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 fetchClient = requireComponents.core.client,
                 mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS,
                 engine = requireComponents.core.engine,
+                limit = 5,
                 filterExactMatch = true
             )
             .addSessionProvider(

--- a/app/src/main/java/org/mozilla/reference/browser/search/AwesomeBarWrapper.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/search/AwesomeBarWrapper.kt
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.reference.browser.search
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.AbstractComposeView
+import mozilla.components.compose.browser.awesomebar.AwesomeBar
+import mozilla.components.compose.browser.awesomebar.AwesomeBarDefaults
+import mozilla.components.compose.browser.awesomebar.AwesomeBarOrientation
+import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.support.ktx.android.view.hideKeyboard
+import org.mozilla.reference.browser.ext.components
+
+/**
+ * This wrapper wraps the `AwesomeBar()` composable and exposes it as a `View` and `concept-awesomebar`
+ * implementation to be integrated as a `View` until more parts of the app have been refactored to
+ * use Jetpack Compose.
+ */
+class AwesomeBarWrapper @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : AbstractComposeView(context, attrs, defStyleAttr), AwesomeBar {
+    private val providers = mutableStateOf(emptyList<AwesomeBar.SuggestionProvider>())
+    private val text = mutableStateOf("")
+    private var onEditSuggestionListener: ((String) -> Unit)? = null
+    private var onStopListener: (() -> Unit)? = null
+
+    @Composable
+    @Suppress("MagicNumber")
+    override fun Content() {
+        if (providers.value.isEmpty()) {
+            return
+        }
+
+        AwesomeBar(
+            text = text.value,
+            providers = providers.value,
+            orientation = AwesomeBarOrientation.BOTTOM,
+            colors = AwesomeBarDefaults.colors(
+                background = Color(0xff222222),
+                title = Color(0xffffffff),
+                description = Color(0xffdddddd),
+                autocompleteIcon = Color(0xffdddddd)
+            ),
+            onSuggestionClicked = { suggestion ->
+                suggestion.onSuggestionClicked?.invoke()
+                onStopListener?.invoke()
+            },
+            onAutoComplete = { suggestion ->
+                onEditSuggestionListener?.invoke(suggestion.editSuggestion!!)
+            },
+            onScroll = { hideKeyboard() },
+            profiler = context.components.core.engine.profiler
+        )
+    }
+
+    override fun addProviders(vararg providers: AwesomeBar.SuggestionProvider) {
+        val newProviders = this.providers.value.toMutableList()
+        newProviders.addAll(providers)
+        this.providers.value = newProviders
+    }
+
+    override fun containsProvider(provider: AwesomeBar.SuggestionProvider): Boolean {
+        return providers.value.any { current -> current.id == provider.id }
+    }
+
+    override fun onInputChanged(text: String) {
+        this.text.value = text
+    }
+
+    override fun removeAllProviders() {
+        providers.value = emptyList()
+    }
+
+    override fun removeProviders(vararg providers: AwesomeBar.SuggestionProvider) {
+        val newProviders = this.providers.value.toMutableList()
+        newProviders.removeAll(providers)
+        this.providers.value = newProviders
+    }
+
+    override fun setOnEditSuggestionListener(listener: (String) -> Unit) {
+        onEditSuggestionListener = listener
+    }
+
+    override fun setOnStopListener(listener: () -> Unit) {
+        onStopListener = listener
+    }
+}

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -30,16 +30,12 @@
             android:layout_height="match_parent" />
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <mozilla.components.browser.awesomebar.BrowserAwesomeBar
+    <org.mozilla.reference.browser.search.AwesomeBarWrapper
         android:id="@+id/awesomeBar"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:padding="4dp"
-        android:visibility="gone"
-        mozac:awesomeBarTitleTextColor="#ffffff"
-        mozac:awesomeBarDescriptionTextColor="#dddddd"
-        mozac:awesomeBarChipTextColor="#ffffff"
-        mozac:awesomeBarChipBackgroundColor="#444444" />
+        android:visibility="gone" />
 
     <mozilla.components.feature.findinpage.view.FindInPageBar
         android:id="@+id/findInPageBar"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -47,6 +47,7 @@ object Deps {
     const val kotlin_stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Versions.kotlin}"
     const val kotlin_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}"
 
+    const val mozilla_concept_awesomebar = "org.mozilla.components:concept-awesomebar:${Versions.mozilla_android_components}"
     const val mozilla_concept_engine = "org.mozilla.components:concept-engine:${Versions.mozilla_android_components}"
     const val mozilla_concept_menu = "org.mozilla.components:concept-menu:${Versions.mozilla_android_components}"
     const val mozilla_concept_tabstray = "org.mozilla.components:concept-tabstray:${Versions.mozilla_android_components}"
@@ -55,7 +56,8 @@ object Deps {
     const val mozilla_concept_sync = "org.mozilla.components:concept-sync:${Versions.mozilla_android_components}"
     const val mozilla_concept_push = "org.mozilla.components:concept-push:${Versions.mozilla_android_components}"
 
-    const val mozilla_browser_awesomebar = "org.mozilla.components:browser-awesomebar:${Versions.mozilla_android_components}"
+    const val mozilla_compose_awesomebar = "org.mozilla.components:compose-awesomebar:${Versions.mozilla_android_components}"
+
     const val mozilla_browser_engine_gecko = "org.mozilla.components:browser-engine-gecko:${Versions.mozilla_android_components}"
     const val mozilla_browser_domains = "org.mozilla.components:browser-domains:${Versions.mozilla_android_components}"
     const val mozilla_browser_session_storage = "org.mozilla.components:browser-session-storage:${Versions.mozilla_android_components}"


### PR DESCRIPTION
Just landed the PR in A-C that will remove `browser-awesomebar`. This patch introduces a wrapper around the compose implementation to make it work with the existing code without much refactoring.