### PR TITLE
enable share image functionality

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
@@ -168,7 +168,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                 context = requireContext().applicationContext,
                 httpClient = requireComponents.core.client,
                 store = requireComponents.core.store,
-                tabId = null
+                tabId = sessionId
             ),
             owner = this,
             view = view

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
@@ -24,6 +24,7 @@ import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.app.links.AppLinksFeature
 import mozilla.components.feature.downloads.DownloadsFeature
 import mozilla.components.feature.downloads.manager.FetchDownloadManager
+import mozilla.components.feature.downloads.share.ShareDownloadFeature
 import mozilla.components.feature.findinpage.view.FindInPageBar
 import mozilla.components.feature.findinpage.view.FindInPageView
 import mozilla.components.feature.prompts.PromptFeature
@@ -64,6 +65,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
     private val toolbarIntegration = ViewBoundFeatureWrapper<ToolbarIntegration>()
     private val contextMenuIntegration = ViewBoundFeatureWrapper<ContextMenuIntegration>()
     private val downloadsFeature = ViewBoundFeatureWrapper<DownloadsFeature>()
+    private val shareDownloadsFeature = ViewBoundFeatureWrapper<ShareDownloadFeature>()
     private val appLinksFeature = ViewBoundFeatureWrapper<AppLinksFeature>()
     private val promptsFeature = ViewBoundFeatureWrapper<PromptFeature>()
     private val fullScreenFeature = ViewBoundFeatureWrapper<FullScreenFeature>()
@@ -157,6 +159,16 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                 engineView,
                 view,
                 sessionId
+            ),
+            owner = this,
+            view = view
+        )
+        shareDownloadsFeature.set(
+            ShareDownloadFeature(
+                context = requireContext().applicationContext,
+                httpClient = requireComponents.core.client,
+                store = requireComponents.core.store,
+                tabId = null
             ),
             owner = this,
             view = view


### PR DESCRIPTION
This does the same change for reference-browser that was done
for Fenix in https://github.com/mozilla-mobile/fenix/pull/17491

From https://github.com/mozilla-mobile/android-components/pull/9420

> This is a breaking change with clients expected to create and register a new
> instance of the this new feature otherwise the "Share image" from the
> browser contextual menu will do nothing.

I stumbled across this when working on https://github.com/mozilla-mobile/android-components/pull/12649


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
