### PR TITLE
Bump SDK target to 32

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -9,9 +9,9 @@ import java.util.Locale
 
 object Config {
     // Synchronized build configuration for all modules
-    const val compileSdkVersion = 31
+    const val compileSdkVersion = 32
     const val minSdkVersion = 21
-    const val targetSdkVersion = 31
+    const val targetSdkVersion = 32
 
     @JvmStatic
     fun generateDebugVersionName(): String {


### PR DESCRIPTION
We made this change in AC/Fenix/Focus awhile ago but forgot r-b. It's breaking AC updates now.