### PR TITLE
Bug 1789398 - ensure task["metadata"]["owner"] is not empty on github…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -12,8 +12,10 @@ tasks:
               then: '${tasks_for}@noreply.mozilla.org'
               else:
                   $if: 'tasks_for == "github-push"'
-                  then: '${event.pusher.email}'
-                  # Assume Pull Request
+                  then:
+                      $if: 'event.pusher.email'
+                      then: '${event.pusher.email}'
+                      else: '${event.pusher.name}@users.noreply.github.com'
                   else:
                       $if: 'tasks_for == "github-pull-request"'
                       then: '${event.pull_request.user.login}@users.noreply.github.com'


### PR DESCRIPTION
…-push decision tasks

Treeherder won't ingest and show these tasks otherwise.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [n/a] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
