### PR TITLE
For #2130 - Fix fileDownloadTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NotificationRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NotificationRobot.kt
@@ -29,7 +29,7 @@ class NotificationRobot {
         val downloadFilename = mDevice.findObject(UiSelector().text(fileName))
 
         while (!notificationFound) {
-            notificationTray.swipeUp(2)
+            scrollToEnd()
             notificationFound = mDevice.findObject(notification).waitForExists(waitingTime)
         }
         assertTrue(notificationFound)
@@ -95,3 +95,11 @@ private val systemMediaNotification =
             .className("android.view.ViewGroup")
             .packageName("com.android.systemui")
     )
+
+private fun notificationTray() = UiScrollable(
+    UiSelector().resourceId("com.android.systemui:id/notification_stack_scroller")
+).setAsVerticalList()
+
+private fun scrollToEnd() {
+    notificationTray().scrollToEnd(1)
+}


### PR DESCRIPTION
This just adopts the same scrolling approach of the `notification_stack_scroller` that Fenix uses. Notification tray's have been notoriously annoying to scroll-through and image changes can cause change on a whim. 