### PR TITLE
Bug 1808338 - Update Sentry to version 6.11.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -46,7 +46,7 @@ object Versions {
     }
 
     object ThirdParty {
-        const val sentry = "6.8.0"
+        const val sentry = "6.11.0"
     }
 
     // Workaround for a Gradle parsing bug that prevents using nested objects directly in Gradle files.


### PR DESCRIPTION
See the bug for changelog links.