### PR TITLE
Fix various UI test warnings

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddonsManagerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddonsManagerRobot.kt
@@ -19,9 +19,9 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import junit.framework.Assert.assertTrue
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
+import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.waitAndInteract
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AwesomeBarRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AwesomeBarRobot.kt
@@ -14,8 +14,8 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withSubstring
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
-import junit.framework.Assert.assertTrue
 import org.hamcrest.CoreMatchers.allOf
+import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
@@ -15,8 +15,8 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
-import junit.framework.Assert.assertTrue
 import org.hamcrest.CoreMatchers.allOf
+import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ContentPanelRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ContentPanelRobot.kt
@@ -19,7 +19,7 @@ class ContentPanelRobot {
     class Transition {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
-        fun contentPanel(interact: ContentPanelRobot.() -> Unit): ContentPanelRobot.Transition {
+        fun contentPanel(): ContentPanelRobot.Transition {
             mDevice.waitForIdle()
             return ContentPanelRobot.Transition()
         }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/DownloadRobot.kt
@@ -3,7 +3,7 @@ package org.mozilla.reference.browser.ui.robots
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestHelper.getPermissionAllowID
 import org.mozilla.reference.browser.helpers.TestHelper.packageName

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
@@ -12,7 +12,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTimeShort

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
@@ -28,7 +28,7 @@ class ExternalAppsRobot {
     fun verifyYouTubeApp() = assertYouTubeApp()
 
     class Transition {
-        fun externalApps(interact: ExternalAppsRobot.() -> Unit): ExternalAppsRobot.Transition {
+        fun externalApps(): ExternalAppsRobot.Transition {
             return ExternalAppsRobot.Transition()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/FindInPagePanelRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/FindInPagePanelRobot.kt
@@ -41,7 +41,7 @@ class FindInPagePanelRobot {
     }
 
     class Transition {
-        fun findInPage(interact: FindInPagePanelRobot.() -> Unit): FindInPagePanelRobot.Transition {
+        fun findInPage(): FindInPagePanelRobot.Transition {
             return FindInPagePanelRobot.Transition()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NotificationRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NotificationRobot.kt
@@ -2,8 +2,8 @@ package org.mozilla.reference.browser.ui.robots
 
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
-import junit.framework.Assert.assertFalse
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 
 class NotificationRobot {

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewPrivacyRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewPrivacyRobot.kt
@@ -28,7 +28,7 @@ class SettingsViewPrivacyRobot {
     fun verifyTelemetrySummary() = assertTelemetrySummary()
 
     class Transition {
-        fun settingsViewPrivacy(interact: SettingsViewPrivacyRobot.() -> Unit): SettingsViewPrivacyRobot.Transition {
+        fun settingsViewPrivacy(): SettingsViewPrivacyRobot.Transition {
             return SettingsViewPrivacyRobot.Transition()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SyncedTabsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SyncedTabsRobot.kt
@@ -7,8 +7,8 @@ package org.mozilla.reference.browser.ui.robots
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.UiSelector
-import junit.framework.Assert.assertTrue
 import org.hamcrest.CoreMatchers.allOf
+import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.TestAssetHelper
 import org.mozilla.reference.browser.helpers.TestHelper.packageName

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMenuRobot.kt
@@ -19,7 +19,7 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import junit.framework.Assert
+import org.junit.Assert
 import org.junit.Assert.assertNull
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.waitAndInteract

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
@@ -13,9 +13,9 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.uiautomator.UiSelector
-import junit.framework.Assert.assertFalse
-import junit.framework.Assert.assertTrue
 import junit.framework.AssertionFailedError
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestHelper.packageName


### PR DESCRIPTION
Fixes the below warnings:
```
> Task :app:compileDebugAndroidTestKotlin
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddonsManagerRobot.kt:22:24 'Assert' is deprecated. Deprecated in Java
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AwesomeBarRobot.kt:17:24 'Assert' is deprecated. Deprecated in Java
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt:18:24 'Assert' is deprecated. Deprecated in Java
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ContentPanelRobot.kt:22:26 Parameter 'interact' is never used
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/DownloadRobot.kt:6:24 'Assert' is deprecated. Deprecated in Java
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt:15:24 'Assert' is deprecated. Deprecated in Java
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt:31:26 Parameter 'interact' is never used
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/FindInPagePanelRobot.kt:44:24 Parameter 'interact' is never used
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NotificationRobot.kt:5:24 'Assert' is deprecated. Deprecated in Java
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NotificationRobot.kt:6:24 'Assert' is deprecated. Deprecated in Java
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewPrivacyRobot.kt:31:33 Parameter 'interact' is never used
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SyncedTabsRobot.kt:10:24 'Assert' is deprecated. Deprecated in Java
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMenuRobot.kt:22:24 'Assert' is deprecated. Deprecated in Java
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMenuRobot.kt:135:5 'Assert' is deprecated. Deprecated in Java
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt:16:24 'Assert' is deprecated. Deprecated in Java
w: file:///builds/worker/checkouts/vcs/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt:17:24 'Assert' is deprecated. Deprecated in Java
```