### PR TITLE
Update AndroidX appcompat to version 1.6.1

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -9,7 +9,7 @@
 object Versions {
     object AndroidX {
         const val activity_compose = "1.6.1"
-        const val appcompat = "1.5.1"
+        const val appcompat = "1.6.1"
         const val compose = "1.3.1"
         const val constraintlayout = "2.1.4"
         const val core = "1.9.0"


### PR DESCRIPTION
Changelog: https://developer.android.com/jetpack/androidx/releases/appcompat#1.6.1