### PR TITLE
Update Material Components to version 1.8.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -21,7 +21,7 @@ object Versions {
 
     object Google {
         const val compose_compiler = "1.4.3"
-        const val material = "1.7.0"
+        const val material = "1.8.0"
     }
 
     object Gradle {


### PR DESCRIPTION
Changelog: https://github.com/material-components/material-components-android/releases/tag/1.8.0