### PR TITLE
Update AndroidX lifecycle to version 2.6.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -13,7 +13,7 @@ object Versions {
         const val compose = "1.3.1"
         const val constraintlayout = "2.1.4"
         const val core = "1.9.0"
-        const val lifecycle = "2.5.1"
+        const val lifecycle = "2.6.0"
         const val preference = "1.2.0"
         const val swiperefreshlayout = "1.1.0"
         const val work = "2.7.1"


### PR DESCRIPTION
Changelog: https://developer.android.com/jetpack/androidx/releases/lifecycle#2.6.0