### PR TITLE
Update AndroidX Compose to version 1.4.2

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -10,7 +10,7 @@ object Versions {
     object AndroidX {
         const val activity_compose = "1.6.1"
         const val appcompat = "1.6.1"
-        const val compose = "1.3.1"
+        const val compose = "1.4.2"
         const val constraintlayout = "2.1.4"
         const val core = "1.9.0"
         const val lifecycle = "2.6.0"


### PR DESCRIPTION
Changelog:
* https://developer.android.com/jetpack/androidx/releases/compose-runtime#1.4.2