### PR TITLE
Update AndroidX Compose to version 1.4.3

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -10,7 +10,7 @@ object Versions {
     object AndroidX {
         const val activity_compose = "1.7.1"
         const val appcompat = "1.6.1"
-        const val compose = "1.4.2"
+        const val compose = "1.4.3"
         const val constraintlayout = "2.1.4"
         const val core = "1.10.0"
         const val lifecycle = "2.6.1"


### PR DESCRIPTION
Pretty minor update for us since we're already on version 1.4.2 across the board. Only Compose UI was actually updated - the remaining components were just no-op version bumps.

Changelog link: https://developer.android.com/jetpack/androidx/releases/compose-ui#1.4.3