### PR TITLE
Update Kotlin to version 1.8.21 and AGP to version 7.4.2

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -20,17 +20,17 @@ object Versions {
     }
 
     object Google {
-        const val compose_compiler = "1.4.6"
+        const val compose_compiler = "1.4.7"
         const val material = "1.8.0"
     }
 
     object Gradle {
-        const val android_plugin = "7.4.1"
+        const val android_plugin = "7.4.2"
         const val kotlin_plugin = Kotlin.compiler
     }
 
     object Kotlin {
-        const val compiler = "1.8.20"
+        const val compiler = "1.8.21"
         const val coroutines = "1.6.4"
     }
 


### PR DESCRIPTION
Also picking up the latest Compose Compiler update for the needed version compatibility bump.

Changelogs:
* https://github.com/JetBrains/kotlin/releases/tag/v1.8.21
* https://developer.android.com/jetpack/androidx/releases/compose-compiler#1.4.7