### PR TITLE
Update some AndroidX dependencies to their latest releases

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -8,11 +8,11 @@
 // Synchronized version numbers for dependencies used by (some) modules
 object Versions {
     object AndroidX {
-        const val activity_compose = "1.7.1"
+        const val activity_compose = "1.7.2"
         const val appcompat = "1.6.1"
         const val compose = "1.4.3"
         const val constraintlayout = "2.1.4"
-        const val core = "1.10.0"
+        const val core = "1.10.1"
         const val lifecycle = "2.6.1"
         const val preference = "1.2.0"
         const val swiperefreshlayout = "1.1.0"


### PR DESCRIPTION
Just a couple minor point releases:
* https://developer.android.com/jetpack/androidx/releases/activity#1.7.2
* https://developer.android.com/jetpack/androidx/releases/core#1.10.1