### PR TITLE
Update Sentry to version 6.28.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -48,7 +48,7 @@ object Versions {
     }
 
     object ThirdParty {
-        const val sentry = "6.27.0"
+        const val sentry = "6.28.0"
     }
 
     // Workaround for a Gradle parsing bug that prevents using nested objects directly in Gradle files.


### PR DESCRIPTION
Changelog: https://github.com/getsentry/sentry-java/releases/tag/6.28.0