### PR TITLE
Update AndroidX Compose to version 1.5.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -10,7 +10,7 @@ object Versions {
     object AndroidX {
         const val activity_compose = "1.7.2"
         const val appcompat = "1.6.1"
-        const val compose = "1.4.3"
+        const val compose = "1.5.0"
         const val constraintlayout = "2.1.4"
         const val core = "1.10.1"
         const val lifecycle = "2.6.1"


### PR DESCRIPTION
Changelogs:
* https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.5.0
* https://developer.android.com/jetpack/androidx/releases/compose-material#1.5.0
* https://developer.android.com/jetpack/androidx/releases/compose-ui#1.5.0