### PR TITLE
Rename android-sdk fetch job

### DIFF
--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -13,7 +13,7 @@ task-defaults:
     docker-image: {in-tree: base}
 
 tasks:
-    android-sdk-3859397:
+    android-sdk:
         description: Android SDK
         fetch:
             type: static-url


### PR DESCRIPTION
I'm not sure how this isn't already broken because AFAICT, jobs which depend on this fetch are looking for android-sdk. There's literally no other references to the current form in tree.