### PR TITLE
Bug 1567912 - change upstream artifacts task type to signing

### DIFF
--- a/taskcluster/rb_taskgraph/transforms/push_android_app.py
+++ b/taskcluster/rb_taskgraph/transforms/push_android_app.py
@@ -33,8 +33,8 @@ def build_android_app_task(config, tasks):
         task["treeherder"] = inherit_treeherder_from_dep(task, dep)
         task["worker"]["upstream-artifacts"] = [
             {
-                "taskId": {"task-reference": f"<{task_type}>"},
-                "taskType": task_type,
+                "taskId": {"task-reference": f"<signing>"},
+                "taskType": "signing",
                 "paths": paths,
             }
         ]


### PR DESCRIPTION
Earlier run failed CoT: https://firefox-ci-tc.services.mozilla.com/tasks/CD-50gIhQYm_E7HvP1rTJw

This change produces diff:
```
       "payload": {
         "channel": "internal testing",
         "commit": true,
         "upstreamArtifacts": [
           {
             "paths": [
               "public/target.aab"
             ],
             "taskId": {
-              "task-reference": "<signing-bundle>"
+              "task-reference": "<signing>"
             },
-            "taskType": "signing-bundle"
+            "taskType": "signing"
           }
         ]
       },

```