### PR TITLE
Bug 1567912 - change push-bundle task reference back to signing-bundle

### DIFF
--- a/taskcluster/rb_taskgraph/transforms/push_android_app.py
+++ b/taskcluster/rb_taskgraph/transforms/push_android_app.py
@@ -33,7 +33,7 @@ def build_android_app_task(config, tasks):
         task["treeherder"] = inherit_treeherder_from_dep(task, dep)
         task["worker"]["upstream-artifacts"] = [
             {
-                "taskId": {"task-reference": f"<signing>"},
+                "taskId": {"task-reference": f"<{task_type}>"},
                 "taskType": "signing",
                 "paths": paths,
             }


### PR DESCRIPTION
Previous change caused:
https://firefoxci.taskcluster-artifacts.net/ZtKkLEM2RQ2NS2W4akuIPA/0/public/logs/live_backing.log
```
[task 2023-09-20T21:34:44.652Z] KeyError: "task 'push-bundle-nightly' has no dependency named 'signing'"
```
...so switch the task reference back to `signing-bundle`, keeping the taskType as `signing`.