### PR TITLE
Bug 1567912 - Change reference-browser push-bundle channel to "internal"

### DIFF
--- a/taskcluster/ci/push-bundle/kind.yml
+++ b/taskcluster/ci/push-bundle/kind.yml
@@ -22,6 +22,6 @@ job-template:
         symbol: gp-aab
     worker-type: push-apk
     worker:
-        channel: "internal testing"
+        channel: internal
         commit: true
         product: reference-browser


### PR DESCRIPTION
See https://developers.google.com/android-publisher/tracks