### PR TITLE
Bug 1567912 - Switch AAB pushes from internal to nightly track

### DIFF
--- a/taskcluster/ci/push-bundle/kind.yml
+++ b/taskcluster/ci/push-bundle/kind.yml
@@ -22,6 +22,6 @@ job-template:
         symbol: gp-aab
     worker-type: push-apk
     worker:
-        channel: internal
+        channel: nightly
         commit: true
         product: reference-browser


### PR DESCRIPTION
For the next stage of AAB testing, we want to push reference-browser AABs to the nightly track.