### PR TITLE
Closes #2522: Removed mutable pending intent flags

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/NotificationManager.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/NotificationManager.kt
@@ -59,7 +59,7 @@ object NotificationManager {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
             }
             val flags = if (SDK_INT >= Build.VERSION_CODES.S) {
-                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_ONE_SHOT
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_ONE_SHOT
             } else {
                 PendingIntent.FLAG_ONE_SHOT
             }
@@ -130,7 +130,7 @@ object NotificationManager {
         }
 
         val flags = if (SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_MUTABLE
+            PendingIntent.FLAG_IMMUTABLE
         } else {
             0
         }

--- a/app/src/main/java/org/mozilla/reference/browser/components/Analytics.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Analytics.kt
@@ -5,7 +5,6 @@
 package org.mozilla.reference.browser.components
 
 import android.app.PendingIntent
-import android.app.PendingIntent.FLAG_MUTABLE
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -54,7 +53,7 @@ class Analytics(private val context: Context) {
         }
 
         val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            FLAG_MUTABLE
+            PendingIntent.FLAG_IMMUTABLE
         } else {
             0
         }


### PR DESCRIPTION
Having mutable pending intents is disallowed on android 14+ and results in app crashing on launch. I don't think there was any particular reason why the PendingIntets we are using were set to be mutable instead of immutable – we are creating new PendingIntent for each tab, without intention to alter (or override in this case) existing ones. My hunch, the system was using mutable flags by default prior to API 31, so the behaviour was kept the same.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
