### PR TITLE
Update JaCoCo to version 0.8.11

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -42,7 +42,7 @@ object Versions {
         const val androidx_runner = "1.5.2"
         const val androidx_uiautomator = "2.2.0"
         const val detekt = "1.23.3"
-        const val jacoco = "0.8.10"
+        const val jacoco = "0.8.11"
         const val ktlint = "0.50.0"
         const val mockwebserver = "4.11.0"
     }


### PR DESCRIPTION
Changelog available at https://www.jacoco.org/jacoco/trunk/doc/changes.html