### PR TITLE
Closes #2580: Add mediaPlayback as foreground service type

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -188,6 +188,7 @@
         </service>
 
         <service android:name=".media.MediaSessionService"
+            android:foregroundServiceType="mediaPlayback"
             android:exported="false" />
 
         <service


### PR DESCRIPTION
This is something we have been missing in Reference Browser for a while, that was added to our other applications.

See https://github.com/mozilla-mobile/firefox-android/commit/102fb8538ecd918d5cc3d8e4625ebeb5ad70b9d3 for more details.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
