### PR TITLE
Use VerticalSwipeRefreshLayout from AndroidComponents

### DIFF
--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -20,7 +20,7 @@
         android:layout_height="@dimen/browser_toolbar_height"
         android:visibility="gone" />
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+    <mozilla.components.ui.widgets.VerticalSwipeRefreshLayout
         android:id="@+id/swipeRefresh"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -28,7 +28,7 @@
             android:id="@+id/engineView"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    </mozilla.components.ui.widgets.VerticalSwipeRefreshLayout>
 
     <org.mozilla.reference.browser.search.AwesomeBarWrapper
         android:id="@+id/awesomeBar"


### PR DESCRIPTION
Use VerticalSwipeRefreshLayout from AndroidComponents instead of AndroidX SwipeRefreshLayout to represent better Fenix behavior

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
