### PR TITLE
Bug 2222 - Disable openNewTabTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/TabTrayMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/TabTrayMenuTest.kt
@@ -155,6 +155,7 @@ class TabTrayMenuTest {
     }
 
     // This test verifies the new tab is open and that its items are all in place
+    @Ignore("Failing, see: https://github.com/mozilla-mobile/reference-browser/issues/2222")
     @Test
     fun openNewTabTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)


### PR DESCRIPTION
Based on the video it seems that the google website is displayed instead of the local resource.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
