### PR TITLE
Update AndroidX Compose to version 1.6.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ material = "1.9.0"
 #AndroidX
 activity-compose = "1.7.2"
 appcompat = "1.6.1"
-compose = "1.6.0"
+compose = "1.6.1"
 constraintlayout = "2.1.4"
 core = "1.12.0"
 lifecycle = "2.7.0"


### PR DESCRIPTION
Changelogs:
* https://developer.android.com/jetpack/androidx/releases/compose-animation#1.6.1
* https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.6.1
* https://developer.android.com/jetpack/androidx/releases/compose-material#1.6.1
* https://developer.android.com/jetpack/androidx/releases/compose-runtime#1.6.1
* https://developer.android.com/jetpack/androidx/releases/compose-ui#1.6.1