### PR TITLE
Update Compose BOM to 2024.02.02

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ material = "1.9.0"
 #AndroidX
 activity-compose = "1.7.2"
 appcompat = "1.6.1"
-composeBom = "2024.02.01"
+composeBom = "2024.02.02"
 constraintlayout = "2.1.4"
 core = "1.12.0"
 lifecycle = "2.7.0"


### PR DESCRIPTION
Corresponds to Compose 1.6.3 for the most part.
https://developer.android.com/jetpack/androidx/releases/compose#versions