### PR TITLE
Update Compose BOM to version 2024.03.00

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ material = "1.9.0"
 #AndroidX
 activity-compose = "1.7.2"
 appcompat = "1.6.1"
-composeBom = "2024.02.02"
+composeBom = "2024.03.00"
 constraintlayout = "2.1.4"
 core = "1.12.0"
 lifecycle = "2.7.0"


### PR DESCRIPTION
Looks like it's basically just a small update to Foundation.
* https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.6.4