### PR TITLE
Bug 1892160 - Update AndroidX Compose BOM to 2024.04.01

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ material = "1.9.0"
 #AndroidX
 activity-compose = "1.7.2"
 appcompat = "1.6.1"
-composeBom = "2024.03.00"
+composeBom = "2024.04.01"
 constraintlayout = "2.1.4"
 core = "1.12.0"
 lifecycle = "2.7.0"


### PR DESCRIPTION
* https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.6.6
* https://developer.android.com/jetpack/androidx/releases/compose-ui#1.6.6