### PR TITLE
Re-enable Detekt and fix up newly-found issues

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/Constants.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/Constants.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.reference.browser.helpers
 
 object Constants {

--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/TestAssetHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/TestAssetHelper.kt
@@ -13,7 +13,6 @@ import java.util.concurrent.TimeUnit
  * Helper for hosting web pages locally for testing purposes.
  */
 object TestAssetHelper {
-    @Suppress("MagicNumber")
     val waitingTime: Long = TimeUnit.SECONDS.toMillis(15)
     val waitingTimeShort: Long = TimeUnit.SECONDS.toMillis(1)
     data class TestAsset(val url: Uri, val content: String, val title: String)
@@ -27,7 +26,6 @@ object TestAssetHelper {
      * content implementation details.
      */
     fun getGenericAssets(server: MockWebServer): List<TestAsset> {
-        @Suppress("MagicNumber")
         return (1..4).map {
             TestAsset(
                 server.url("pages/generic$it.html").toString().toUri()!!,

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/AddonsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/AddonsTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.reference.browser.ui
 
 import okhttp3.mockwebserver.MockWebServer

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/CustomTabsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/CustomTabsTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 @file:Suppress("DEPRECATION")
 
 package org.mozilla.reference.browser.ui

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/DownloadTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/DownloadTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.reference.browser.ui
 
 import okhttp3.mockwebserver.MockWebServer

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/MediaPlaybackTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/MediaPlaybackTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.reference.browser.ui
 
 import okhttp3.mockwebserver.MockWebServer

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ReaderViewTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.reference.browser.ui
 
 import okhttp3.mockwebserver.MockWebServer

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
@@ -73,7 +73,7 @@ class SettingsViewTest {
 
     // openFXAQrCodeTest tests that we get to the camera
     // Additional tests are needed to verify that the QR code reader works
-    @Ignore("Test instrumentation process is crashing, see: https://github.com/mozilla-mobile/reference-browser/issues/1502")
+    @Ignore("Test instrumentation process crash, see: https://github.com/mozilla-mobile/reference-browser/issues/1502")
     @Test
     fun openFXAQrCodeTest() {
         navigationToolbar {

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("DEPRECATION")
-
 package org.mozilla.reference.browser.ui
 
 import androidx.core.net.toUri

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:Suppress("ForbiddenComment")
+
 package org.mozilla.reference.browser.ui
 
 import androidx.test.platform.app.InstrumentationRegistry

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
@@ -240,7 +240,8 @@ class ThreeDotMenuTest {
         }
     }
 
-    // Verifies the Synced tabs menu opens from a tab's 3 dot menu and displays the correct view if the user isn't signed in
+    // Verifies the Synced tabs menu opens from a tab's 3 dot menu and
+    // displays the correct view if the user isn't signed in
     @Test
     fun openSyncedTabsTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddToHomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddToHomeScreenRobot.kt
@@ -32,5 +32,6 @@ class AddToHomeScreenRobot {
     }
 
     private fun cancelAddToHomeScreenButton() = mDevice.findObject(UiSelector().textContains("CANCEL"))
-    private fun addAutomaticallyToHomeScreenButton() = mDevice.findObject(UiSelector().textContains("ADD AUTOMATICALLY"))
+    private fun addAutomaticallyToHomeScreenButton() =
+        mDevice.findObject(UiSelector().textContains("ADD AUTOMATICALLY"))
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddonsManagerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddonsManagerRobot.kt
@@ -74,8 +74,18 @@ class AddonsManagerRobot {
         mDevice.waitForWindowUpdate(packageName, waitingTime)
         mDevice.findObject(UiSelector().text("$addonName has been added to Reference Browser"))
             .waitForExists(waitingTime)
-        mDevice.waitAndInteract(Until.findObject(By.text(getStringResource(R.string.mozac_feature_addons_installed_dialog_okay_button_2)))) {}
-        mDevice.findObject(UiSelector().textContains(getStringResource(R.string.mozac_feature_addons_installed_dialog_okay_button_2))).click()
+        mDevice.waitAndInteract(
+            Until.findObject(
+                By.text(
+                    getStringResource(R.string.mozac_feature_addons_installed_dialog_okay_button_2),
+                ),
+            ),
+        ) {}
+        mDevice.findObject(
+            UiSelector().textContains(
+                getStringResource(R.string.mozac_feature_addons_installed_dialog_okay_button_2),
+            ),
+        ).click()
     }
 
     fun clickRemoveAddonButton() {

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AwesomeBarRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AwesomeBarRobot.kt
@@ -73,7 +73,10 @@ class AwesomeBarRobot {
             return NavigationToolbarRobot.Transition()
         }
 
-        fun clickSearchSuggestion(searchSuggestionTitle: String, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+        fun clickSearchSuggestion(
+            searchSuggestionTitle: String,
+            interact: BrowserRobot.() -> Unit,
+        ): BrowserRobot.Transition {
             val searchSuggestion = mDevice.findObject(UiSelector().textContains(searchSuggestionTitle))
             searchSuggestion.clickAndWaitForNewWindow()
 

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
@@ -11,9 +11,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withSubstring
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
-import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert.assertTrue
@@ -261,8 +259,6 @@ class BrowserRobot {
         }
 
     class Transition {
-        private val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-
         fun checkExternalApps(interact: ExternalAppsRobot.() -> Unit): ExternalAppsRobot.Transition {
             mDevice.waitForWindowUpdate(packageName, waitingTime)
             ExternalAppsRobot().interact()

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/CustomTabRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/CustomTabRobot.kt
@@ -51,7 +51,6 @@ class CustomTabRobot {
         link.click()
     }
 
-    @Suppress("SwallowedException")
     fun switchRequestDesktopSiteToggle() {
         try {
             // Click the Request desktop site toggle

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/DownloadRobot.kt
@@ -4,12 +4,8 @@
 
 package org.mozilla.reference.browser.ui.robots
 
-import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
-import androidx.test.uiautomator.Until
-import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
-import org.mozilla.reference.browser.helpers.TestHelper.getPermissionAllowID
 import org.mozilla.reference.browser.helpers.TestHelper.packageName
 
 class DownloadRobot {
@@ -29,35 +25,6 @@ class DownloadRobot {
 fun downloadRobot(interact: DownloadRobot.() -> Unit): DownloadRobot.Transition {
     DownloadRobot().interact()
     return DownloadRobot.Transition()
-}
-
-private fun assertDownloadPopup() {
-    mDevice.waitForIdle()
-    assertTrue(
-        mDevice.findObject(UiSelector().resourceId("$packageName:id/filename"))
-            .waitForExists(waitingTime),
-    )
-}
-
-private fun clickAllowButton() {
-    mDevice.waitForIdle()
-    mDevice.wait(
-        Until.findObject(
-            By.res(getPermissionAllowID() + ":id/permission_message"),
-        ),
-        waitingTime,
-    )
-    mDevice.wait(
-        Until.findObject(
-            By.res(getPermissionAllowID() + ":id/permission_allow_button"),
-        ),
-        waitingTime,
-    )
-
-    val allowButton = mDevice.findObject(
-        By.res(getPermissionAllowID() + ":id/permission_allow_button"),
-    )
-    allowButton.click()
 }
 
 private val closeDownloadButton = mDevice.findObject(UiSelector().resourceId("$packageName:id/close_button"))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/DownloadRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.reference.browser.ui.robots
 
 import androidx.test.uiautomator.By

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
@@ -46,7 +46,6 @@ private fun assertAutofillServices() {
     )
 }
 
-@Suppress("SwallowedException")
 private fun assertYouTubeApp() {
     try {
         // Check youtube's home buttons

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NotificationRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NotificationRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.reference.browser.ui.robots
 
 import androidx.test.uiautomator.UiScrollable

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NotificationRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NotificationRobot.kt
@@ -12,7 +12,6 @@ import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 
 class NotificationRobot {
 
-    @Suppress("SwallowedException")
     fun verifySystemMediaNotificationExists(notificationMessage: String) {
         assertTrue(systemMediaNotification.waitForExists(waitingTime))
         assertTrue(systemMediaNotificationTitle(notificationMessage).waitForExists(waitingTime))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ReaderViewRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ReaderViewRobot.kt
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("TooManyFunctions")
-
 package org.mozilla.fenix.ui.robots
 
 import android.content.Context

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewPrivacyRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewPrivacyRobot.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.reference.browser.ui.robots
 

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewPrivacyRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewPrivacyRobot.kt
@@ -34,7 +34,6 @@ class SettingsViewPrivacyRobot {
     }
 }
 
-private fun privacyUpButton() = Espresso.onView(ViewMatchers.withContentDescription("Navigate up"))
 private fun privacySettingsView() = Espresso.onView(ViewMatchers.withText("Privacy Settings"))
 private fun trackingProtectionHeading() = Espresso.onView(ViewMatchers.withText("Tracking Protection"))
 private fun tpEnableInNormalBrowsing() = Espresso.onView(ViewMatchers.withText("Enable in Normal Browsing Mode"))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 @file:Suppress("TooManyFunctions")
 

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
@@ -73,7 +73,9 @@ class SettingsViewRobot {
     }
 
     class Transition {
-        fun openSettingsViewPrivacy(interact: SettingsViewPrivacyRobot.() -> Unit): SettingsViewPrivacyRobot.Transition {
+        fun openSettingsViewPrivacy(
+            interact: SettingsViewPrivacyRobot.() -> Unit,
+        ): SettingsViewPrivacyRobot.Transition {
             privacyButton().click()
             SettingsViewPrivacyRobot().interact()
             return SettingsViewPrivacyRobot.Transition()
@@ -138,13 +140,23 @@ private fun syncQrCodeButton() = Espresso.onView(withText(R.string.pair_sign_in)
 private fun syncQrSummary() = Espresso.onView(withText(R.string.preferences_pair_sign_in_summary))
 private fun privacyButton() = Espresso.onView(withText(R.string.privacy))
 private fun privacySummary() = Espresso.onView(withText(R.string.preferences_privacy_summary))
-private fun openLinksInAppsToggle() = Espresso.onView(allOf(withId(R.id.switchWidget), hasCousin(withText(R.string.open_links_in_apps))))
+private fun openLinksInAppsToggle() = Espresso.onView(
+    allOf(
+        withId(R.id.switchWidget),
+        hasCousin(withText(R.string.open_links_in_apps)),
+    ),
+)
 private fun makeDefaultBrowserButton() = Espresso.onView(withText(R.string.preferences_make_default_browser))
 private fun autofillAppsButton() = onView(withText("Autofill apps"))
 private fun jetpackComposeButton() = onView(withText("Use experimental Jetpack Compose UI"))
 private fun autofillAppsSummary() = onView(withText("Autofill logins and passwords in other apps"))
 private fun developerToolsHeading() = Espresso.onView(withText(R.string.developer_tools_category))
-private fun remoteDebuggingToggle() = Espresso.onView(allOf(withId(R.id.switchWidget), hasCousin(withText(R.string.preferences_remote_debugging))))
+private fun remoteDebuggingToggle() = Espresso.onView(
+    allOf(
+        withId(R.id.switchWidget),
+        hasCousin(withText(R.string.preferences_remote_debugging)),
+    ),
+)
 private fun customAddonCollectionButton() = onView(withText("Custom Add-on collection"))
 private fun mozillaHeading() = Espresso.onView(withText(R.string.mozilla_category))
 private fun aboutReferenceBrowserButton() = Espresso.onView(withText(R.string.preferences_about_page))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("TooManyFunctions")
-
 package org.mozilla.reference.browser.ui.robots
 
 import androidx.test.espresso.Espresso

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SyncedTabsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SyncedTabsRobot.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.reference.browser.ui.robots
 

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMenuRobot.kt
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("TooManyFunctions")
-
 package org.mozilla.reference.browser.ui.robots
 
 import android.content.Context

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMenuRobot.kt
@@ -72,8 +72,12 @@ class TabTrayMenuRobot {
             return NavigationToolbarRobot.Transition()
         }
 
-        fun openMoreOptionsMenu(context: Context, interact: TabTrayMoreOptionsMenuRobot.() -> Unit): TabTrayMoreOptionsMenuRobot.Transition {
-            // The 3dot "More options" button is actually an Android Options Menu (check tabstray_menu.xml) not a View that we treat as a menu
+        fun openMoreOptionsMenu(
+            context: Context,
+            interact: TabTrayMoreOptionsMenuRobot.() -> Unit,
+        ): TabTrayMoreOptionsMenuRobot.Transition {
+            // The 3dot "More options" button is actually an Android Options Menu (check tabstray_menu.xml),
+            // not a View that we treat as a menu
             openActionBarOverflowOrOptionsMenu(context)
 
             TabTrayMoreOptionsMenuRobot().interact()

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("TooManyFunctions")
-
 package org.mozilla.reference.browser.ui.robots
 
 import androidx.test.espresso.Espresso.onView
@@ -84,7 +82,6 @@ class ThreeDotMenuRobot {
             return ContentPanelRobot.Transition()
         }
 
-        @Suppress("SwallowedException")
         fun switchRequestDesktopSiteToggle(
             interact: NavigationToolbarRobot.() -> Unit,
         ): NavigationToolbarRobot.Transition {

--- a/app/src/main/java/org/mozilla/reference/browser/AppRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/AppRequestInterceptor.kt
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:Suppress("ForbiddenComment")
+
 package org.mozilla.reference.browser
 
 import android.content.Context

--- a/app/src/main/java/org/mozilla/reference/browser/IntentRequestCodes.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/IntentRequestCodes.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.reference.browser
 

--- a/app/src/main/java/org/mozilla/reference/browser/addons/InstalledAddonDetailsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/InstalledAddonDetailsActivity.kt
@@ -24,7 +24,6 @@ import org.mozilla.reference.browser.ext.components
 /**
  * An activity to show the details of a installed add-on.
  */
-@Suppress("TooManyFunctions")
 class InstalledAddonDetailsActivity : AppCompatActivity() {
     private val scope = CoroutineScope(Dispatchers.IO)
 

--- a/app/src/main/java/org/mozilla/reference/browser/addons/InstalledAddonDetailsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/InstalledAddonDetailsActivity.kt
@@ -7,7 +7,6 @@ package org.mozilla.reference.browser.addons
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SwitchCompat
@@ -80,11 +79,6 @@ class InstalledAddonDetailsActivity : AppCompatActivity() {
         bindAllowInPrivateBrowsingSwitch(addon)
 
         bindRemoveButton(addon)
-    }
-
-    private fun bindVersion(addon: Addon) {
-        val versionView = findViewById<TextView>(R.id.version_text)
-        versionView.text = addon.version
     }
 
     private fun bindEnableSwitch(addon: Addon) {

--- a/app/src/main/java/org/mozilla/reference/browser/addons/WebExtensionPromptFeature.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/WebExtensionPromptFeature.kt
@@ -191,7 +191,9 @@ class WebExtensionPromptFeature(
         findPreviousDialogFragment()?.let { dialog ->
             dialog.onPositiveButtonClicked = { addon ->
                 store.state.webExtensionPromptRequest?.let { promptRequest ->
-                    if (promptRequest is WebExtensionPromptRequest.AfterInstallation.Permissions && addon.id == promptRequest.extension.id) {
+                    if (promptRequest is WebExtensionPromptRequest.AfterInstallation.Permissions &&
+                        addon.id == promptRequest.extension.id
+                    ) {
                         handleApprovedPermissions(promptRequest)
                     }
                 }
@@ -229,7 +231,8 @@ class WebExtensionPromptFeature(
     }
 
     private fun hasExistingAddonPostInstallationDialogFragment(): Boolean {
-        return fragmentManager.findFragmentByTag(POST_INSTALLATION_DIALOG_FRAGMENT_TAG) as? AddonInstallationDialogFragment != null
+        return fragmentManager.findFragmentByTag(POST_INSTALLATION_DIALOG_FRAGMENT_TAG)
+            as? AddonInstallationDialogFragment != null
     }
 
     private fun handlePostInstallationButtonClicked(

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
@@ -135,6 +135,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
     abstract val shouldUseComposeUI: Boolean
 
     @CallSuper
+    @Suppress("LongMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         val prefs = PreferenceManager.getDefaultSharedPreferences(requireContext())
 

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
@@ -63,7 +63,6 @@ import mozilla.components.ui.widgets.behavior.ViewPosition as MozacToolbarBehavi
  * This class only contains shared code focused on the main browsing content.
  * UI code specific to the app or to custom tabs can be found in the subclasses.
  */
-@Suppress("TooManyFunctions")
 abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, ActivityResultHandler {
     private val sessionFeature = ViewBoundFeatureWrapper<SessionFeature>()
     private val toolbarIntegration = ViewBoundFeatureWrapper<ToolbarIntegration>()

--- a/app/src/main/java/org/mozilla/reference/browser/browser/ReaderViewIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/ReaderViewIntegration.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.reference.browser.browser
 

--- a/app/src/main/java/org/mozilla/reference/browser/components/Core.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Core.kt
@@ -205,7 +205,6 @@ class Core(private val context: Context) {
         }
     }
 
-    @Suppress("MagicNumber")
     val supportedAddonsChecker by lazy {
         DefaultSupportedAddonsChecker(
             context,

--- a/app/src/main/java/org/mozilla/reference/browser/components/Push.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Push.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.reference.browser.components
 

--- a/app/src/main/java/org/mozilla/reference/browser/customtabs/CustomTabsService.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/customtabs/CustomTabsService.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.reference.browser.customtabs
 

--- a/app/src/main/java/org/mozilla/reference/browser/ext/String.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/ext/String.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.reference.browser.ext
 

--- a/app/src/main/java/org/mozilla/reference/browser/pip/PictureInPictureIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/pip/PictureInPictureIntegration.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.reference.browser.pip
 

--- a/app/src/main/java/org/mozilla/reference/browser/settings/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/AboutFragment.kt
@@ -29,7 +29,6 @@ class AboutFragment : Fragment() {
         return inflater.inflate(R.layout.fragment_about, container, false)
     }
 
-    @Suppress("DEPRECATION")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/app/src/main/java/org/mozilla/reference/browser/settings/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/AboutFragment.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.reference.browser.settings
 

--- a/app/src/main/java/org/mozilla/reference/browser/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/SettingsFragment.kt
@@ -38,7 +38,6 @@ import kotlin.system.exitProcess
 
 private typealias RBSettings = org.mozilla.reference.browser.settings.Settings
 
-@Suppress("TooManyFunctions")
 class SettingsFragment : PreferenceFragmentCompat() {
 
     interface ActionBarUpdater {
@@ -63,7 +62,6 @@ class SettingsFragment : PreferenceFragmentCompat() {
         }
     }
 
-    @Suppress("LongMethod") // Yep, this should be refactored.
     private fun setupPreferences() {
         val signInKey = requireContext().getPreferenceKey(pref_key_sign_in)
         val signInPairKey = requireContext().getPreferenceKey(pref_key_pair_sign_in)

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/PrivatePage.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/PrivatePage.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.reference.browser.tabs
 

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/TabsPanel.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/TabsPanel.kt
@@ -6,13 +6,14 @@ package org.mozilla.reference.browser.tabs
 
 import android.content.Context
 import android.content.res.Resources
-import android.graphics.PorterDuff
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.graphics.BlendModeColorFilterCompat.createBlendModeColorFilterCompat
+import androidx.core.graphics.BlendModeCompat.SRC_IN
 import com.google.android.material.tabs.TabLayout
 import mozilla.components.feature.tabs.tabstray.TabsFeature
 import org.mozilla.reference.browser.R
@@ -77,7 +78,6 @@ class TabsPanel @JvmOverloads constructor(
 
     private fun Drawable.colorTint(@ColorRes color: Int) = apply {
         mutate()
-        @Suppress("DEPRECATION") // Deprecated warning appeared when switching to Java 11.
-        setColorFilter(ContextCompat.getColor(context, color), PorterDuff.Mode.SRC_IN)
+        createBlendModeColorFilterCompat(ContextCompat.getColor(context, color), SRC_IN)
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/TabsTouchHelper.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/TabsTouchHelper.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.reference.browser.tabs
 

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/synced/SyncedTabsViewHolder.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/synced/SyncedTabsViewHolder.kt
@@ -5,7 +5,6 @@
 package org.mozilla.reference.browser.tabs.synced
 
 import android.view.View
-import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.browser.storage.sync.Tab
@@ -17,7 +16,8 @@ sealed class SyncedTabsViewHolder(itemView: View) : RecyclerView.ViewHolder(item
     abstract fun <T : AdapterItem> bind(item: T, interactor: (Tab) -> Unit)
 
     class TabViewHolder(itemView: View) : SyncedTabsViewHolder(itemView) {
-        private val image = itemView.findViewById<ImageView>(R.id.synced_tabs_item_image)
+        // See TODO below
+        // private val image = itemView.findViewById<ImageView>(R.id.synced_tabs_item_image)
         private val title = itemView.findViewById<TextView>(R.id.synced_tabs_item_title)
         private val url = itemView.findViewById<TextView>(R.id.synced_tabs_item_desc)
 
@@ -35,7 +35,7 @@ sealed class SyncedTabsViewHolder(itemView: View) : RecyclerView.ViewHolder(item
             url.text = active.url
 
             // TODO download and set icon image.
-            //  requires https://github.com/mozilla-mobile/android-components/issues/5179
+            // Requires https://bugzilla.mozilla.org/show_bug.cgi?id=1793192
         }
 
         companion object {

--- a/app/src/main/java/org/mozilla/reference/browser/view/ToggleImageButton.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/view/ToggleImageButton.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.reference.browser.view
 

--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,7 @@ tasks.register('clean', Delete) {
 }
 
 detekt {
-    source.setFrom(files("$projectDir/components", "$projectDir/buildSrc", "$projectDir/samples"))
+    source.setFrom(files("$projectDir/app", "$projectDir/buildSrc"))
     config.setFrom("$projectDir/config/detekt.yml")
     baseline = file("$projectDir/config/detekt-baseline.xml")
 }

--- a/config/detekt-baseline.xml
+++ b/config/detekt-baseline.xml
@@ -2,26 +2,87 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>MaxLineLength:Dependencies.kt$Deps$const val androidx_constraintlayout = "androidx.constraintlayout:constraintlayout:${Versions.AndroidX.constraintlayout}"</ID>
-    <ID>MaxLineLength:Dependencies.kt$Deps$const val androidx_swiperefreshlayout = "androidx.swiperefreshlayout:swiperefreshlayout:${Versions.AndroidX.swiperefreshlayout}"</ID>
-    <ID>MaxLineLength:Dependencies.kt$Deps$const val espresso_idling_resources = "androidx.test.espresso:espresso-idling-resource:${Versions.Testing.androidx_espresso}"</ID>
-    <ID>MaxLineLength:Dependencies.kt$Deps$const val mozilla_browser_session_storage = "org.mozilla.components:browser-session-storage:${AndroidComponents.VERSION}"</ID>
-    <ID>MaxLineLength:Dependencies.kt$Deps$const val mozilla_feature_accounts_push = "org.mozilla.components:feature-accounts-push:${AndroidComponents.VERSION}"</ID>
-    <ID>MaxLineLength:Dependencies.kt$Deps$const val mozilla_feature_sitepermissions = "org.mozilla.components:feature-sitepermissions:${AndroidComponents.VERSION}"</ID>
-    <ID>MaxLineLength:Dependencies.kt$Deps$const val mozilla_feature_webnotifications = "org.mozilla.components:feature-webnotifications:${AndroidComponents.VERSION}"</ID>
-    <ID>MaxLineLength:Dependencies.kt$Deps$const val mozilla_service_firefox_accounts = "org.mozilla.components:service-firefox-accounts:${AndroidComponents.VERSION}"</ID>
-    <ID>MaxLineLength:Dependencies.kt$Deps$const val mozilla_support_webextensions = "org.mozilla.components:support-webextensions:${AndroidComponents.VERSION}"</ID>
-    <ID>UndocumentedPublicClass:AndroidComponents.kt$AndroidComponents</ID>
+    <ID>UndocumentedPublicClass:AboutFragment.kt$AboutFragment : Fragment</ID>
+    <ID>UndocumentedPublicClass:AccountSettingsFragment.kt$AccountSettingsFragment : PreferenceFragmentCompat</ID>
+    <ID>UndocumentedPublicClass:AppPermissionCodes.kt$AppPermissionCodes</ID>
+    <ID>UndocumentedPublicClass:AutofillConfirmActivity.kt$AutofillConfirmActivity : AbstractAutofillConfirmActivity</ID>
+    <ID>UndocumentedPublicClass:AutofillPreference.kt$AutofillPreference : Preference</ID>
+    <ID>UndocumentedPublicClass:AutofillSearchActivity.kt$AutofillSearchActivity : AbstractAutofillSearchActivity</ID>
+    <ID>UndocumentedPublicClass:AutofillService.kt$AutofillService : AbstractAutofillService</ID>
+    <ID>UndocumentedPublicClass:AutofillUnlockActivity.kt$AutofillUnlockActivity : AbstractAutofillUnlockActivity</ID>
+    <ID>UndocumentedPublicClass:BrowserApplication.kt$BrowserApplication : Application</ID>
     <ID>UndocumentedPublicClass:Config.kt$Config</ID>
-    <ID>UndocumentedPublicClass:Dependencies.kt$Deps</ID>
-    <ID>UndocumentedPublicClass:Dependencies.kt$Versions</ID>
-    <ID>UndocumentedPublicClass:Dependencies.kt$Versions$AndroidX</ID>
-    <ID>UndocumentedPublicClass:Dependencies.kt$Versions$Google</ID>
-    <ID>UndocumentedPublicClass:Dependencies.kt$Versions$Gradle</ID>
-    <ID>UndocumentedPublicClass:Dependencies.kt$Versions$Kotlin</ID>
-    <ID>UndocumentedPublicClass:Dependencies.kt$Versions$Testing</ID>
-    <ID>UndocumentedPublicClass:Dependencies.kt$Versions$ThirdParty</ID>
+    <ID>UndocumentedPublicClass:ContextMenuIntegration.kt$ContextMenuIntegration : LifecycleAwareFeature</ID>
+    <ID>UndocumentedPublicClass:CrashIntegration.kt$CrashIntegration : DefaultLifecycleObserver</ID>
+    <ID>UndocumentedPublicClass:CrashListActivity.kt$CrashListActivity : AbstractCrashListActivity</ID>
+    <ID>UndocumentedPublicClass:CustomTabsIntegration.kt$CustomTabsIntegration : LifecycleAwareFeatureUserInteractionHandler</ID>
+    <ID>UndocumentedPublicClass:CustomTabsService.kt$CustomTabsService : AbstractCustomTabsService</ID>
+    <ID>UndocumentedPublicClass:DownloadService.kt$DownloadService : AbstractFetchDownloadService</ID>
+    <ID>UndocumentedPublicClass:EngineProvider.kt$EngineProvider</ID>
+    <ID>UndocumentedPublicClass:FindInPageIntegration.kt$FindInPageIntegration : LifecycleAwareFeatureUserInteractionHandler</ID>
+    <ID>UndocumentedPublicClass:FirebasePush.kt$FirebasePush : AbstractFirebasePushService</ID>
+    <ID>UndocumentedPublicClass:IntentReceiverActivity.kt$IntentReceiverActivity : Activity</ID>
+    <ID>UndocumentedPublicClass:IntentRequestCodes.kt$IntentRequestCodes</ID>
+    <ID>UndocumentedPublicClass:PairSettingsFragment.kt$PairSettingsFragment : FragmentUserInteractionHandler</ID>
+    <ID>UndocumentedPublicClass:PictureInPictureIntegration.kt$PictureInPictureIntegration : LifecycleAwareFeature</ID>
+    <ID>UndocumentedPublicClass:PrivacySettingsFragment.kt$PrivacySettingsFragment : PreferenceFragmentCompat</ID>
+    <ID>UndocumentedPublicClass:PrivatePage.kt$PrivatePage</ID>
+    <ID>UndocumentedPublicClass:ReaderViewIntegration.kt$ReaderViewIntegration : LifecycleAwareFeatureUserInteractionHandler</ID>
+    <ID>UndocumentedPublicClass:Settings.kt$Settings</ID>
+    <ID>UndocumentedPublicClass:SettingsActivity.kt$SettingsActivity : AppCompatActivityActionBarUpdater</ID>
+    <ID>UndocumentedPublicClass:SettingsFragment.kt$SettingsFragment : PreferenceFragmentCompat</ID>
+    <ID>UndocumentedPublicClass:SettingsFragment.kt$SettingsFragment$ActionBarUpdater</ID>
+    <ID>UndocumentedPublicClass:SyncedTabsActivity.kt$SyncedTabsActivity : AppCompatActivity</ID>
+    <ID>UndocumentedPublicClass:SyncedTabsAdapter.kt$SyncedTabsAdapter : ListAdapter</ID>
+    <ID>UndocumentedPublicClass:SyncedTabsAdapter.kt$SyncedTabsAdapter$AdapterItem</ID>
+    <ID>UndocumentedPublicClass:SyncedTabsAdapter.kt$SyncedTabsAdapter.AdapterItem$Device : AdapterItem</ID>
+    <ID>UndocumentedPublicClass:SyncedTabsAdapter.kt$SyncedTabsAdapter.AdapterItem$Tab : AdapterItem</ID>
+    <ID>UndocumentedPublicClass:SyncedTabsFragment.kt$SyncedTabsFragment : Fragment</ID>
+    <ID>UndocumentedPublicClass:SyncedTabsIntegration.kt$SyncedTabsIntegration</ID>
+    <ID>UndocumentedPublicClass:SyncedTabsLayout.kt$SyncedTabsLayout : FrameLayoutSyncedTabsView</ID>
+    <ID>UndocumentedPublicClass:SyncedTabsViewHolder.kt$SyncedTabsViewHolder : ViewHolder</ID>
+    <ID>UndocumentedPublicClass:SyncedTabsViewHolder.kt$SyncedTabsViewHolder$DeviceViewHolder : SyncedTabsViewHolder</ID>
+    <ID>UndocumentedPublicClass:SyncedTabsViewHolder.kt$SyncedTabsViewHolder$TabViewHolder : SyncedTabsViewHolder</ID>
+    <ID>UndocumentedPublicClass:TabsPanel.kt$TabsPanel : TabLayoutOnTabSelectedListener</ID>
+    <ID>UndocumentedPublicClass:TabsToolbar.kt$TabsToolbar : Toolbar</ID>
+    <ID>UndocumentedPublicClass:TabsTouchHelper.kt$TabsTouchHelper : ItemTouchHelper</ID>
+    <ID>UndocumentedPublicClass:ToolbarIntegration.kt$ToolbarIntegration : LifecycleAwareFeatureUserInteractionHandler</ID>
+    <ID>UndocumentedPublicClass:WebPushEngineIntegration.kt$WebPushEngineIntegration : Observer</ID>
+    <ID>UndocumentedPublicFunction:AccountSettingsFragment.kt$AccountSettingsFragment$fun updateLastSyncedTimePref(context: Context, pref: Preference?, failed: Boolean = false)</ID>
+    <ID>UndocumentedPublicFunction:Analytics.kt$fun isSentryEnabled()</ID>
+    <ID>UndocumentedPublicFunction:AutofillPreference.kt$AutofillPreference$fun updateSwitch()</ID>
+    <ID>UndocumentedPublicFunction:AutofillPreference.kt$AutofillPreference.Companion$fun isSupported(context: Context): Boolean</ID>
+    <ID>UndocumentedPublicFunction:BrowserFragment.kt$BrowserFragment.Companion$fun create(sessionId: String? = null)</ID>
+    <ID>UndocumentedPublicFunction:BrowserToolbar.kt$@Composable fun BrowserDisplayToolbar( url: String, onUrlClicked: () -&gt; Unit = {}, )</ID>
+    <ID>UndocumentedPublicFunction:BrowserToolbar.kt$@Composable fun BrowserEditToolbar( url: String, onUrlCommitted: (String) -&gt; Unit = {}, )</ID>
+    <ID>UndocumentedPublicFunction:BrowserToolbar.kt$@Composable fun BrowserToolbar()</ID>
+    <ID>UndocumentedPublicFunction:ComposableComponents.kt$@Composable fun sessionUseCases(): SessionUseCases</ID>
     <ID>UndocumentedPublicFunction:Config.kt$Config$@JvmStatic fun generateDebugVersionName(): String</ID>
     <ID>UndocumentedPublicFunction:Config.kt$Config$@JvmStatic fun releaseVersionName(project: Project): String</ID>
+    <ID>UndocumentedPublicFunction:Context.kt$fun Context.getPreferenceKey(@StringRes resourceId: Int): String</ID>
+    <ID>UndocumentedPublicFunction:CrashIntegration.kt$CrashIntegration$@OptIn(DelicateCoroutinesApi::class) fun sendCrashReport(crash: Crash)</ID>
+    <ID>UndocumentedPublicFunction:EngineProvider.kt$EngineProvider$@Synchronized fun getOrCreateRuntime(context: Context): GeckoRuntime</ID>
+    <ID>UndocumentedPublicFunction:EngineProvider.kt$EngineProvider$fun createClient(context: Context): Client</ID>
+    <ID>UndocumentedPublicFunction:EngineProvider.kt$EngineProvider$fun createEngine(context: Context, defaultSettings: DefaultSettings): Engine</ID>
+    <ID>UndocumentedPublicFunction:ExternalAppBrowserFragment.kt$ExternalAppBrowserFragment.Companion$fun create( sessionId: String, manifest: WebAppManifest?, trustedScopes: List&lt;Uri&gt;, )</ID>
+    <ID>UndocumentedPublicFunction:Long.kt$@Suppress("MagicNumber") fun Long.timeSince(context: Context, time: Long): String</ID>
+    <ID>UndocumentedPublicFunction:NotificationManager.kt$NotificationManager$fun checkAndNotifyPolicy(context: Context)</ID>
+    <ID>UndocumentedPublicFunction:NotificationManager.kt$NotificationManager$fun showReceivedTabs(context: Context, device: Device?, tabs: List&lt;TabData&gt;)</ID>
+    <ID>UndocumentedPublicFunction:PictureInPictureIntegration.kt$PictureInPictureIntegration$fun onHomePressed()</ID>
+    <ID>UndocumentedPublicFunction:Settings.kt$Settings$fun getOverrideAmoCollection(context: Context): String</ID>
+    <ID>UndocumentedPublicFunction:Settings.kt$Settings$fun getOverrideAmoUser(context: Context): String</ID>
+    <ID>UndocumentedPublicFunction:Settings.kt$Settings$fun isAmoCollectionOverrideConfigured(context: Context): Boolean</ID>
+    <ID>UndocumentedPublicFunction:Settings.kt$Settings$fun isTelemetryEnabled(context: Context): Boolean</ID>
+    <ID>UndocumentedPublicFunction:Settings.kt$Settings$fun setOverrideAmoCollection(context: Context, value: String)</ID>
+    <ID>UndocumentedPublicFunction:Settings.kt$Settings$fun setOverrideAmoUser(context: Context, value: String)</ID>
+    <ID>UndocumentedPublicFunction:SettingsFragment.kt$SettingsFragment.ActionBarUpdater$fun updateTitle(titleResId: Int)</ID>
+    <ID>UndocumentedPublicFunction:SyncedTabsIntegration.kt$SyncedTabsIntegration$fun launch()</ID>
+    <ID>UndocumentedPublicFunction:SyncedTabsViewHolder.kt$SyncedTabsViewHolder$abstract fun &lt;T : AdapterItem&gt; bind(item: T, interactor: (Tab) -&gt; Unit)</ID>
+    <ID>UndocumentedPublicFunction:TabsPanel.kt$TabsPanel$fun initialize(tabsFeature: TabsFeature?, updateTabsToolbar: (isPrivate: Boolean) -&gt; Unit)</ID>
+    <ID>UndocumentedPublicFunction:TabsToolbar.kt$TabsToolbar$fun initialize(tabsFeature: TabsFeature?, closeTabsTray: () -&gt; Unit)</ID>
+    <ID>UndocumentedPublicFunction:TabsToolbar.kt$TabsToolbar$fun updateToolbar(isPrivate: Boolean)</ID>
+    <ID>UndocumentedPublicFunction:ToggleImageButton.kt$ToggleImageButton$fun setOnCheckedChangeListener(listener: (ToggleImageButton, Boolean) -&gt; Unit)</ID>
+    <ID>UndocumentedPublicFunction:WebPushEngineIntegration.kt$WebPushEngineIntegration$fun start()</ID>
+    <ID>UndocumentedPublicFunction:WebPushEngineIntegration.kt$WebPushEngineIntegration$fun stop()</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ androidx-uiautomator = "2.3.0"
 sentry = "7.8.0"
 
 # Third Party Linting & Static Code Analysis
-detekt = "1.23.5"
+detekt = "1.23.6"
 pinterest-ktlint = "0.50.0"
 
 #Third Party Testing


### PR DESCRIPTION
Turns out we accidentally disabled it across most of the repo around the time we bumped to version 1.22. Whoopsie. This PR re-enables it, updates Detekt to the latest version, and fixes up, suppresses, or baselines the new issues that are now being caught. As a bonus, I removed some suppressions which don't appear to be necessary anymore and refactored away another one.