### PR TITLE
Miscellaneous Gradle dependency cleanups

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -337,7 +337,7 @@ dependencies {
 
     implementation libs.thirdparty.sentry
 
-    androidTestImplementation(libs.espresso.contrib) {
+    androidTestImplementation(libs.androidx.test.espresso.contrib) {
         exclude module: 'appcompat-v7'
         exclude module: 'support-v4'
         exclude module: 'support-annotations'
@@ -345,21 +345,21 @@ dependencies {
         exclude module: 'design'
         exclude module: 'espresso-core'
     }
-    androidTestImplementation libs.espresso.core, {
+    androidTestImplementation libs.androidx.test.espresso.core, {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
-    androidTestImplementation libs.espresso.idling.resources
-    androidTestImplementation libs.espresso.web, {
+    androidTestImplementation libs.androidx.test.espresso.idling.resources
+    androidTestImplementation libs.androidx.test.espresso.web, {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
+    androidTestImplementation libs.androidx.test.junit.ext
+    androidTestImplementation libs.androidx.test.rules
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.androidx.test.uiautomator
 
-    androidTestImplementation libs.junit.ktx
     androidTestImplementation libs.mockwebserver
-    androidTestImplementation libs.tools.test.rules
-    androidTestImplementation libs.tools.test.runner
-    androidTestImplementation libs.uiautomator
 
-    androidTestUtil libs.orchestrator
+    androidTestUtil libs.androidx.test.orchestrator
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -243,29 +243,47 @@ project.configurations.configureEach {
 }
 
 dependencies {
-    implementation libs.mozilla.concept.awesomebar
-    implementation libs.mozilla.concept.engine
-    implementation libs.mozilla.concept.menu
-    implementation libs.mozilla.concept.tabstray
-    implementation libs.mozilla.concept.toolbar
-    implementation libs.mozilla.concept.storage
-    implementation libs.mozilla.concept.sync
-    implementation libs.mozilla.concept.push
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.constraintlayout
+    implementation libs.androidx.core.ktx
+    implementation libs.androidx.lifecycle.process
+    implementation libs.androidx.preference.ktx
+    implementation libs.androidx.swiperefreshlayout
+    implementation libs.androidx.work.runtime.ktx
 
-    implementation libs.mozilla.compose.awesomebar
+    implementation platform(libs.androidx.compose.bom)
+    implementation libs.androidx.activity.compose
+    implementation libs.androidx.compose.foundation
+    implementation libs.androidx.compose.material
+    implementation libs.androidx.compose.ui.base
+    implementation libs.androidx.compose.ui.tooling
 
-    implementation libs.mozilla.browser.engine.gecko
+    implementation libs.google.material
+
+    implementation libs.kotlinx.coroutines.android
 
     implementation libs.mozilla.browser.domains
-    implementation libs.mozilla.browser.tabstray
-    implementation libs.mozilla.browser.toolbar
+    implementation libs.mozilla.browser.engine.gecko
+    implementation libs.mozilla.browser.icons
     implementation libs.mozilla.browser.menu
     implementation libs.mozilla.browser.menu2
     implementation libs.mozilla.browser.session.storage
     implementation libs.mozilla.browser.state
     implementation libs.mozilla.browser.storage.sync
-    implementation libs.mozilla.browser.icons
+    implementation libs.mozilla.browser.tabstray
     implementation libs.mozilla.browser.thumbnails
+    implementation libs.mozilla.browser.toolbar
+
+    implementation libs.mozilla.compose.awesomebar
+
+    implementation libs.mozilla.concept.awesomebar
+    implementation libs.mozilla.concept.engine
+    implementation libs.mozilla.concept.menu
+    implementation libs.mozilla.concept.push
+    implementation libs.mozilla.concept.storage
+    implementation libs.mozilla.concept.sync
+    implementation libs.mozilla.concept.tabstray
+    implementation libs.mozilla.concept.toolbar
 
     implementation libs.mozilla.feature.accounts.base
     implementation libs.mozilla.feature.accounts.push
@@ -275,24 +293,41 @@ dependencies {
     implementation libs.mozilla.feature.autofill
     implementation libs.mozilla.feature.contextmenu
     implementation libs.mozilla.feature.customtabs
-    implementation libs.mozilla.feature.findinpage
-    implementation libs.mozilla.feature.media
-    implementation libs.mozilla.feature.sitepermissions
-    implementation libs.mozilla.feature.intent
-    implementation libs.mozilla.feature.search
-    implementation libs.mozilla.feature.session
-    implementation libs.mozilla.feature.toolbar
-    implementation libs.mozilla.feature.tabs
     implementation libs.mozilla.feature.downloads
+    implementation libs.mozilla.feature.findinpage
+    implementation libs.mozilla.feature.intent
+    implementation libs.mozilla.feature.media
     implementation libs.mozilla.feature.prompts
     implementation libs.mozilla.feature.push
     implementation libs.mozilla.feature.pwa
     implementation libs.mozilla.feature.qr
     implementation libs.mozilla.feature.readerview
+    implementation libs.mozilla.feature.search
+    implementation libs.mozilla.feature.session
+    implementation libs.mozilla.feature.sitepermissions
     implementation libs.mozilla.feature.syncedtabs
+    implementation libs.mozilla.feature.tabs
+    implementation libs.mozilla.feature.toolbar
     implementation libs.mozilla.feature.webauthn
     implementation libs.mozilla.feature.webcompat
     implementation libs.mozilla.feature.webnotifications
+
+    implementation libs.mozilla.lib.crash.base
+    implementation libs.mozilla.lib.crash.sentry
+    implementation libs.mozilla.lib.dataprotect
+    implementation libs.mozilla.lib.publicsuffixlist
+    implementation libs.mozilla.lib.push.firebase
+
+    implementation libs.mozilla.service.firefox.accounts
+    implementation libs.mozilla.service.location
+    implementation libs.mozilla.service.sync.logins
+
+    implementation libs.mozilla.support.images
+    implementation libs.mozilla.support.ktx
+    implementation libs.mozilla.support.rusthttp
+    implementation libs.mozilla.support.rustlog
+    implementation libs.mozilla.support.utils
+    implementation libs.mozilla.support.webextensions
 
     implementation libs.mozilla.ui.autocomplete
     implementation libs.mozilla.ui.colors
@@ -300,50 +335,7 @@ dependencies {
     implementation libs.mozilla.ui.tabcounter
     implementation libs.mozilla.ui.widgets
 
-    implementation libs.mozilla.service.firefox.accounts
-    implementation libs.mozilla.service.location
-    implementation libs.mozilla.service.sync.logins
-
-    implementation libs.mozilla.support.images
-    implementation libs.mozilla.support.utils
-    implementation libs.mozilla.support.ktx
-    implementation libs.mozilla.support.rustlog
-    implementation libs.mozilla.support.rusthttp
-    implementation libs.mozilla.support.webextensions
-
-    implementation libs.mozilla.lib.crash.base
-    implementation libs.mozilla.lib.crash.sentry
-    implementation libs.mozilla.lib.push.firebase
-    implementation libs.mozilla.lib.publicsuffixlist
-    implementation libs.mozilla.lib.dataprotect
-
     implementation libs.thirdparty.sentry
-
-    implementation libs.kotlinx.coroutines.android
-
-    implementation libs.androidx.appcompat
-    implementation libs.androidx.core.ktx
-    implementation libs.androidx.constraintlayout
-    implementation libs.androidx.lifecycle.process
-    implementation libs.androidx.preference.ktx
-    implementation libs.androidx.swiperefreshlayout
-    implementation libs.androidx.work.runtime.ktx
-
-    implementation platform(libs.androidx.compose.bom)
-    implementation libs.androidx.activity.compose
-    implementation libs.androidx.compose.ui.base
-    implementation libs.androidx.compose.ui.tooling
-    implementation libs.androidx.compose.foundation
-    implementation libs.androidx.compose.material
-
-    implementation libs.google.material
-
-    androidTestImplementation libs.uiautomator
-    androidTestImplementation libs.junit.ktx
-
-    androidTestImplementation libs.espresso.core, {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    }
 
     androidTestImplementation(libs.espresso.contrib) {
         exclude module: 'appcompat-v7'
@@ -353,19 +345,21 @@ dependencies {
         exclude module: 'design'
         exclude module: 'espresso-core'
     }
-
+    androidTestImplementation libs.espresso.core, {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
     androidTestImplementation libs.espresso.idling.resources
     androidTestImplementation libs.espresso.web, {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
 
+    androidTestImplementation libs.junit.ktx
     androidTestImplementation libs.mockwebserver
-    androidTestImplementation libs.tools.test.runner
     androidTestImplementation libs.tools.test.rules
+    androidTestImplementation libs.tools.test.runner
+    androidTestImplementation libs.uiautomator
+
     androidTestUtil libs.orchestrator
-    androidTestImplementation libs.espresso.core, {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    }
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ buildscript {
     }
 
     dependencies {
-        classpath libs.tools.android.plugin
         classpath libs.kotlin.gradle.plugin
+        classpath libs.tools.android.plugin
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,20 +1,19 @@
 [versions]
-
 # Android Components
 android-components = "127.0.20240429210502"
 
 # AGP
 android-plugin = "8.3.1"
 
-#Kotlin
-kotlinx-coroutines = "1.8.0"
+# Kotlin
 kotlin-compiler = "1.9.23"
+kotlinx-coroutines = "1.8.0"
 
-#Google
+# Google
 compose-compiler = "1.5.12"
 material = "1.9.0"
 
-#AndroidX
+# AndroidX
 activity-compose = "1.7.2"
 appcompat = "1.6.1"
 composeBom = "2024.04.01"
@@ -25,7 +24,7 @@ preference = "1.2.1"
 swiperefreshlayout = "1.1.0"
 work = "2.9.0"
 
-#AndroidX Testing
+# AndroidX Testing
 androidx-core = "1.5.0"
 androidx-espresso = "3.5.1"
 androidx-ext-junit = "1.1.5"
@@ -33,19 +32,18 @@ androidx-orchestrator = "1.4.2"
 androidx-runner = "1.5.2"
 androidx-uiautomator = "2.3.0"
 
-#Third Party
+# Third Party
 sentry = "7.8.0"
 
 # Third Party Linting & Static Code Analysis
 detekt = "1.23.6"
 pinterest-ktlint = "0.50.0"
 
-#Third Party Testing
+# Third Party Testing
 jacoco = "0.8.11"
 mockwebserver = "4.12.0"
 
 [libraries]
-
 # AGP
 tools-android-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-plugin" }
 
@@ -53,25 +51,25 @@ tools-android-plugin = { group = "com.android.tools.build", name = "gradle", ver
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin-compiler" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 
-#Google
+# Google
 google-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 # AndroidX
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preference" }
-androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 androidx-swiperefreshlayout = { group = "androidx.swiperefreshlayout", name = "swiperefreshlayout", version.ref = "swiperefreshlayout" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 
 # AndroidX Compose
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
-androidx-compose-ui-base = { group = "androidx.compose.ui", name = "ui" }
-androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-material = { group = "androidx.compose.material", name = "material" }
+androidx-compose-ui-base = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 
 # AndroidX Testing
 espresso-contrib = { group = "androidx.test.espresso", name = "espresso-contrib", version.ref = "androidx-espresso" }
@@ -94,27 +92,28 @@ ktlint = { module = "com.pinterest:ktlint", version.ref = "pinterest-ktlint" }
 mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver" }
 
 # Android Components
-mozilla-browser-engine-gecko = { group = "org.mozilla.components", name = "browser-engine-gecko", version.ref = "android-components" }
 mozilla-browser-domains = { group = "org.mozilla.components", name = "browser-domains", version.ref = "android-components" }
-mozilla-browser-session-storage = { group = "org.mozilla.components", name = "browser-session-storage", version.ref = "android-components" }
-mozilla-browser-state = { group = "org.mozilla.components", name = "browser-state", version.ref = "android-components" }
-mozilla-browser-tabstray = { group = "org.mozilla.components", name = "browser-tabstray", version.ref = "android-components" }
-mozilla-browser-toolbar = { group = "org.mozilla.components", name = "browser-toolbar", version.ref = "android-components" }
+mozilla-browser-engine-gecko = { group = "org.mozilla.components", name = "browser-engine-gecko", version.ref = "android-components" }
+mozilla-browser-icons = { group = "org.mozilla.components", name = "browser-icons", version.ref = "android-components" }
 mozilla-browser-menu = { group = "org.mozilla.components", name = "browser-menu", version.ref = "android-components" }
 mozilla-browser-menu2 = { group = "org.mozilla.components", name = "browser-menu2", version.ref = "android-components" }
+mozilla-browser-session-storage = { group = "org.mozilla.components", name = "browser-session-storage", version.ref = "android-components" }
+mozilla-browser-state = { group = "org.mozilla.components", name = "browser-state", version.ref = "android-components" }
 mozilla-browser-storage-sync = { group = "org.mozilla.components", name = "browser-storage-sync", version.ref = "android-components" }
-mozilla-browser-icons = { group = "org.mozilla.components", name = "browser-icons", version.ref = "android-components" }
+mozilla-browser-tabstray = { group = "org.mozilla.components", name = "browser-tabstray", version.ref = "android-components" }
 mozilla-browser-thumbnails = { group = "org.mozilla.components", name = "browser-thumbnails", version.ref = "android-components" }
+mozilla-browser-toolbar = { group = "org.mozilla.components", name = "browser-toolbar", version.ref = "android-components" }
 
 mozilla-compose-awesomebar = { group = "org.mozilla.components", name = "compose-awesomebar", version.ref = "android-components" }
+
 mozilla-concept-awesomebar = { group = "org.mozilla.components", name = "concept-awesomebar", version.ref = "android-components" }
 mozilla-concept-engine = { group = "org.mozilla.components", name = "concept-engine", version.ref = "android-components" }
 mozilla-concept-menu = { group = "org.mozilla.components", name = "concept-menu", version.ref = "android-components" }
-mozilla-concept-tabstray = { group = "org.mozilla.components", name = "concept-tabstray", version.ref = "android-components" }
-mozilla-concept-toolbar = { group = "org.mozilla.components", name = "concept-toolbar", version.ref = "android-components" }
+mozilla-concept-push = { group = "org.mozilla.components", name = "concept-push", version.ref = "android-components" }
 mozilla-concept-storage = { group = "org.mozilla.components", name = "concept-storage", version.ref = "android-components" }
 mozilla-concept-sync = { group = "org.mozilla.components", name = "concept-sync", version.ref = "android-components" }
-mozilla-concept-push = { group = "org.mozilla.components", name = "concept-push", version.ref = "android-components" }
+mozilla-concept-tabstray = { group = "org.mozilla.components", name = "concept-tabstray", version.ref = "android-components" }
+mozilla-concept-toolbar = { group = "org.mozilla.components", name = "concept-toolbar", version.ref = "android-components" }
 
 mozilla-feature-accounts-base = { group = "org.mozilla.components", name = "feature-accounts", version.ref = "android-components" }
 mozilla-feature-accounts-push = { group = "org.mozilla.components", name = "feature-accounts-push", version.ref = "android-components" }
@@ -124,47 +123,47 @@ mozilla-feature-autofill = { group = "org.mozilla.components", name = "feature-a
 mozilla-feature-awesomebar = { group = "org.mozilla.components", name = "feature-awesomebar", version.ref = "android-components" }
 mozilla-feature-contextmenu = { group = "org.mozilla.components", name = "feature-contextmenu", version.ref = "android-components" }
 mozilla-feature-customtabs = { group = "org.mozilla.components", name = "feature-customtabs", version.ref = "android-components" }
-mozilla-feature-findinpage = { group = "org.mozilla.components", name = "feature-findinpage", version.ref = "android-components" }
-mozilla-feature-media = { group = "org.mozilla.components", name = "feature-media", version.ref = "android-components" }
-mozilla-feature-sitepermissions = { group = "org.mozilla.components", name = "feature-sitepermissions", version.ref = "android-components" }
-mozilla-feature-intent = { group = "org.mozilla.components", name = "feature-intent", version.ref = "android-components" }
-mozilla-feature-search = { group = "org.mozilla.components", name = "feature-search", version.ref = "android-components" }
-mozilla-feature-session = { group = "org.mozilla.components", name = "feature-session", version.ref = "android-components" }
-mozilla-feature-toolbar = { group = "org.mozilla.components", name = "feature-toolbar", version.ref = "android-components" }
-mozilla-feature-tabs = { group = "org.mozilla.components", name = "feature-tabs", version.ref = "android-components" }
 mozilla-feature-downloads = { group = "org.mozilla.components", name = "feature-downloads", version.ref = "android-components" }
+mozilla-feature-findinpage = { group = "org.mozilla.components", name = "feature-findinpage", version.ref = "android-components" }
+mozilla-feature-intent = { group = "org.mozilla.components", name = "feature-intent", version.ref = "android-components" }
+mozilla-feature-media = { group = "org.mozilla.components", name = "feature-media", version.ref = "android-components" }
 mozilla-feature-prompts = { group = "org.mozilla.components", name = "feature-prompts", version.ref = "android-components" }
 mozilla-feature-push = { group = "org.mozilla.components", name = "feature-push", version.ref = "android-components" }
 mozilla-feature-pwa = { group = "org.mozilla.components", name = "feature-pwa", version.ref = "android-components" }
 mozilla-feature-qr = { group = "org.mozilla.components", name = "feature-qr", version.ref = "android-components" }
 mozilla-feature-readerview = { group = "org.mozilla.components", name = "feature-readerview", version.ref = "android-components" }
+mozilla-feature-search = { group = "org.mozilla.components", name = "feature-search", version.ref = "android-components" }
+mozilla-feature-session = { group = "org.mozilla.components", name = "feature-session", version.ref = "android-components" }
+mozilla-feature-sitepermissions = { group = "org.mozilla.components", name = "feature-sitepermissions", version.ref = "android-components" }
 mozilla-feature-syncedtabs = { group = "org.mozilla.components", name = "feature-syncedtabs", version.ref = "android-components" }
+mozilla-feature-tabs = { group = "org.mozilla.components", name = "feature-tabs", version.ref = "android-components" }
+mozilla-feature-toolbar = { group = "org.mozilla.components", name = "feature-toolbar", version.ref = "android-components" }
 mozilla-feature-webauthn = { group = "org.mozilla.components", name = "feature-webauthn", version.ref = "android-components" }
 mozilla-feature-webcompat = { group = "org.mozilla.components", name = "feature-webcompat", version.ref = "android-components" }
 mozilla-feature-webnotifications = { group = "org.mozilla.components", name = "feature-webnotifications", version.ref = "android-components" }
 
 mozilla-lib-crash-base = { group = "org.mozilla.components", name = "lib-crash", version.ref = "android-components" }
 mozilla-lib-crash-sentry = { group = "org.mozilla.components", name = "lib-crash-sentry", version.ref = "android-components" }
-mozilla-lib-push-firebase = { group = "org.mozilla.components", name = "lib-push-firebase", version.ref = "android-components" }
 mozilla-lib-dataprotect = { group = "org.mozilla.components", name = "lib-dataprotect", version.ref = "android-components" }
 mozilla-lib-publicsuffixlist = { group = "org.mozilla.components", name = "lib-publicsuffixlist", version.ref = "android-components" }
-
-mozilla-ui-autocomplete = { group = "org.mozilla.components", name = "ui-autocomplete", version.ref = "android-components" }
-mozilla-ui-colors = { group = "org.mozilla.components", name = "ui-colors", version.ref = "android-components" }
-mozilla-ui-icons = { group = "org.mozilla.components", name = "ui-icons", version.ref = "android-components" }
-mozilla-ui-tabcounter = { group = "org.mozilla.components", name = "ui-tabcounter", version.ref = "android-components" }
-mozilla-ui-widgets = { group = "org.mozilla.components", name = "ui-widgets", version.ref = "android-components" }
+mozilla-lib-push-firebase = { group = "org.mozilla.components", name = "lib-push-firebase", version.ref = "android-components" }
 
 mozilla-service-firefox-accounts = { group = "org.mozilla.components", name = "service-firefox-accounts", version.ref = "android-components" }
 mozilla-service-location = { group = "org.mozilla.components", name = "service-location", version.ref = "android-components" }
 mozilla-service-sync-logins = { group = "org.mozilla.components", name = "service-sync-logins", version.ref = "android-components" }
 
 mozilla-support-images = { group = "org.mozilla.components", name = "support-images", version.ref = "android-components" }
-mozilla-support-utils = { group = "org.mozilla.components", name = "support-utils", version.ref = "android-components" }
 mozilla-support-ktx = { group = "org.mozilla.components", name = "support-ktx", version.ref = "android-components" }
-mozilla-support-rustlog = { group = "org.mozilla.components", name = "support-rustlog", version.ref = "android-components" }
 mozilla-support-rusthttp = { group = "org.mozilla.components", name = "support-rusthttp", version.ref = "android-components" }
+mozilla-support-rustlog = { group = "org.mozilla.components", name = "support-rustlog", version.ref = "android-components" }
+mozilla-support-utils = { group = "org.mozilla.components", name = "support-utils", version.ref = "android-components" }
 mozilla-support-webextensions = { group = "org.mozilla.components", name = "support-webextensions", version.ref = "android-components" }
+
+mozilla-ui-autocomplete = { group = "org.mozilla.components", name = "ui-autocomplete", version.ref = "android-components" }
+mozilla-ui-colors = { group = "org.mozilla.components", name = "ui-colors", version.ref = "android-components" }
+mozilla-ui-icons = { group = "org.mozilla.components", name = "ui-icons", version.ref = "android-components" }
+mozilla-ui-tabcounter = { group = "org.mozilla.components", name = "ui-tabcounter", version.ref = "android-components" }
+mozilla-ui-widgets = { group = "org.mozilla.components", name = "ui-widgets", version.ref = "android-components" }
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,30 +14,30 @@ compose-compiler = "1.5.12"
 material = "1.9.0"
 
 # AndroidX
-activity-compose = "1.7.2"
-appcompat = "1.6.1"
-composeBom = "2024.04.01"
-constraintlayout = "2.1.4"
-core = "1.13.0"
-lifecycle = "2.7.0"
-preference = "1.2.1"
-swiperefreshlayout = "1.1.0"
-work = "2.9.0"
+androidx-activity-compose = "1.7.2"
+androidx-appcompat = "1.6.1"
+androidx-composeBom = "2024.04.01"
+androidx-constraintlayout = "2.1.4"
+androidx-core = "1.13.0"
+androidx-lifecycle = "2.7.0"
+androidx-preference = "1.2.1"
+androidx-swiperefreshlayout = "1.1.0"
+androidx-work = "2.9.0"
 
 # AndroidX Testing
-androidx-core = "1.5.0"
-androidx-espresso = "3.5.1"
-androidx-ext-junit = "1.1.5"
-androidx-orchestrator = "1.4.2"
-androidx-runner = "1.5.2"
-androidx-uiautomator = "2.3.0"
+androidx-test-core = "1.5.0"
+androidx-test-espresso = "3.5.1"
+androidx-test-junit = "1.1.5"
+androidx-test-orchestrator = "1.4.2"
+androidx-test-runner = "1.5.2"
+androidx-test-uiautomator = "2.3.0"
 
 # Third Party
 sentry = "7.8.0"
 
 # Third Party Linting & Static Code Analysis
 detekt = "1.23.6"
-pinterest-ktlint = "0.50.0"
+ktlint = "0.50.0"
 
 # Third Party Testing
 jacoco = "0.8.11"
@@ -55,38 +55,38 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 google-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 # AndroidX
-androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core" }
-androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
-androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preference" }
-androidx-swiperefreshlayout = { group = "androidx.swiperefreshlayout", name = "swiperefreshlayout", version.ref = "swiperefreshlayout" }
-androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activity-compose" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidx-appcompat" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "androidx-lifecycle" }
+androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidx-preference" }
+androidx-swiperefreshlayout = { group = "androidx.swiperefreshlayout", name = "swiperefreshlayout", version.ref = "androidx-swiperefreshlayout" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "androidx-work" }
 
 # AndroidX Compose
-androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-composeBom" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-material = { group = "androidx.compose.material", name = "material" }
 androidx-compose-ui-base = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 
 # AndroidX Testing
-espresso-contrib = { group = "androidx.test.espresso", name = "espresso-contrib", version.ref = "androidx-espresso" }
-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-espresso" }
-espresso-idling-resources = { group = "androidx.test.espresso", name = "espresso-idling-resource", version.ref = "androidx-espresso" }
-espresso-web = { group = "androidx.test.espresso", name = "espresso-web", version.ref = "androidx-espresso" }
-junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidx-ext-junit" }
-orchestrator = { group = "androidx.test", name = "orchestrator", version.ref = "androidx-orchestrator" }
-tools-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidx-core" }
-tools-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-runner" }
-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidx-uiautomator" }
+androidx-test-espresso-contrib = { group = "androidx.test.espresso", name = "espresso-contrib", version.ref = "androidx-test-espresso" }
+androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-test-espresso" }
+androidx-test-espresso-idling-resources = { group = "androidx.test.espresso", name = "espresso-idling-resource", version.ref = "androidx-test-espresso" }
+androidx-test-espresso-web = { group = "androidx.test.espresso", name = "espresso-web", version.ref = "androidx-test-espresso" }
+androidx-test-junit-ext = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidx-test-junit" }
+androidx-test-orchestrator = { group = "androidx.test", name = "orchestrator", version.ref = "androidx-test-orchestrator" }
+androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidx-test-core" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-test-runner" }
+androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidx-test-uiautomator" }
 
 # Third Party
 thirdparty-sentry = { group = "io.sentry", name = "sentry-android", version.ref = "sentry" }
 
 # Third Party Linting & Static Code Analysis
-ktlint = { module = "com.pinterest:ktlint", version.ref = "pinterest-ktlint" }
+ktlint = { module = "com.pinterest:ktlint", version.ref = "ktlint" }
 
 # Third Party Testing
 mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver" }


### PR DESCRIPTION
No functional changes with this, but I'm playing around with some other things (dependency analysis plugins) and it would be nice to do this first. This also aligns some naming conventions with A-S and Glean and what I also hope to eventually use in mozilla-central as well once we start migrating to a version catalog there.