### PR TITLE
Add Dependency Analysis Gradle Plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -243,24 +243,39 @@ project.configurations.configureEach {
 }
 
 dependencies {
+    implementation libs.androidx.activity
+    implementation libs.androidx.annotation
     implementation libs.androidx.appcompat
+    implementation libs.androidx.browser
+    implementation libs.androidx.cardview
     implementation libs.androidx.constraintlayout
+    implementation libs.androidx.coordinatorlayout
     implementation libs.androidx.core.ktx
+    implementation libs.androidx.fragment
+    implementation libs.androidx.lifecycle.common
     implementation libs.androidx.lifecycle.process
+    implementation libs.androidx.lifecycle.viewmodel.ktx
     implementation libs.androidx.preference.ktx
+    implementation libs.androidx.recyclerview
     implementation libs.androidx.swiperefreshlayout
     implementation libs.androidx.work.runtime.ktx
 
     implementation platform(libs.androidx.compose.bom)
     implementation libs.androidx.compose.foundation
     implementation libs.androidx.compose.material
+    implementation libs.androidx.compose.runtime
     implementation libs.androidx.compose.ui.base
+    implementation libs.androidx.compose.ui.graphics
+    implementation libs.androidx.compose.ui.text
     implementation libs.androidx.compose.ui.tooling
 
     implementation libs.google.material
 
+    implementation libs.kotlinx.coroutines.core
+
     implementation libs.mozilla.browser.domains
     implementation libs.mozilla.browser.engine.gecko
+    implementation libs.mozilla.browser.errorpages
     implementation libs.mozilla.browser.icons
     implementation libs.mozilla.browser.menu
     implementation libs.mozilla.browser.menu2
@@ -274,7 +289,9 @@ dependencies {
     implementation libs.mozilla.compose.awesomebar
 
     implementation libs.mozilla.concept.awesomebar
+    implementation libs.mozilla.concept.base
     implementation libs.mozilla.concept.engine
+    implementation libs.mozilla.concept.fetch
     implementation libs.mozilla.concept.menu
     implementation libs.mozilla.concept.push
     implementation libs.mozilla.concept.storage
@@ -313,11 +330,13 @@ dependencies {
     implementation libs.mozilla.lib.dataprotect
     implementation libs.mozilla.lib.publicsuffixlist
     implementation libs.mozilla.lib.push.firebase
+    implementation libs.mozilla.lib.state
 
     implementation libs.mozilla.service.firefox.accounts
     implementation libs.mozilla.service.location
     implementation libs.mozilla.service.sync.logins
 
+    implementation libs.mozilla.support.base
     implementation libs.mozilla.support.ktx
     implementation libs.mozilla.support.rusthttp
     implementation libs.mozilla.support.rustlog
@@ -331,11 +350,17 @@ dependencies {
 
     androidTestImplementation libs.androidx.test.espresso.core
     androidTestImplementation libs.androidx.test.espresso.idling.resources
+    androidTestImplementation libs.androidx.test.monitor
     androidTestImplementation libs.androidx.test.rules
     androidTestImplementation libs.androidx.test.runner
     androidTestImplementation libs.androidx.test.uiautomator
 
+    androidTestImplementation libs.hamcrest.core
+    androidTestImplementation libs.hamcrest.library
+    androidTestImplementation libs.junit
     androidTestImplementation libs.mockwebserver
+    androidTestImplementation libs.okhttp
+    androidTestImplementation libs.okio
 
     androidTestUtil libs.androidx.test.orchestrator
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -252,15 +252,12 @@ dependencies {
     implementation libs.androidx.work.runtime.ktx
 
     implementation platform(libs.androidx.compose.bom)
-    implementation libs.androidx.activity.compose
     implementation libs.androidx.compose.foundation
     implementation libs.androidx.compose.material
     implementation libs.androidx.compose.ui.base
     implementation libs.androidx.compose.ui.tooling
 
     implementation libs.google.material
-
-    implementation libs.kotlinx.coroutines.android
 
     implementation libs.mozilla.browser.domains
     implementation libs.mozilla.browser.engine.gecko
@@ -282,7 +279,6 @@ dependencies {
     implementation libs.mozilla.concept.push
     implementation libs.mozilla.concept.storage
     implementation libs.mozilla.concept.sync
-    implementation libs.mozilla.concept.tabstray
     implementation libs.mozilla.concept.toolbar
 
     implementation libs.mozilla.feature.accounts.base
@@ -322,37 +318,19 @@ dependencies {
     implementation libs.mozilla.service.location
     implementation libs.mozilla.service.sync.logins
 
-    implementation libs.mozilla.support.images
     implementation libs.mozilla.support.ktx
     implementation libs.mozilla.support.rusthttp
     implementation libs.mozilla.support.rustlog
     implementation libs.mozilla.support.utils
     implementation libs.mozilla.support.webextensions
 
-    implementation libs.mozilla.ui.autocomplete
     implementation libs.mozilla.ui.colors
     implementation libs.mozilla.ui.icons
     implementation libs.mozilla.ui.tabcounter
     implementation libs.mozilla.ui.widgets
 
-    implementation libs.thirdparty.sentry
-
-    androidTestImplementation(libs.androidx.test.espresso.contrib) {
-        exclude module: 'appcompat-v7'
-        exclude module: 'support-v4'
-        exclude module: 'support-annotations'
-        exclude module: 'recyclerview-v7'
-        exclude module: 'design'
-        exclude module: 'espresso-core'
-    }
-    androidTestImplementation libs.androidx.test.espresso.core, {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    }
+    androidTestImplementation libs.androidx.test.espresso.core
     androidTestImplementation libs.androidx.test.espresso.idling.resources
-    androidTestImplementation libs.androidx.test.espresso.web, {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    }
-    androidTestImplementation libs.androidx.test.junit.ext
     androidTestImplementation libs.androidx.test.rules
     androidTestImplementation libs.androidx.test.runner
     androidTestImplementation libs.androidx.test.uiautomator

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ buildscript {
 }
 
 plugins {
+    alias libs.plugins.dependency.analysis
     alias libs.plugins.detekt
 }
 
@@ -151,6 +152,27 @@ tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }
 
+dependencyAnalysis {
+    structure {
+        // Ignore Android KTX dependencies. See https://developer.android.com/kotlin/ktx#modules
+        ignoreKtx(true)
+    }
+    issues {
+        all {
+            onAny {
+                // Fail the run if any issues are found (default = 'warn')
+                severity('fail')
+                // Ignore warnings about kotlin-stdlib since we don't directly control its usage
+                exclude('org.jetbrains.kotlin:kotlin-stdlib')
+            }
+            onUsedTransitiveDependencies {
+                // We explicitly want to pull in these dependencies transitively from AC
+                exclude('org.mozilla.appservices.nightly:fxaclient', 'org.mozilla.geckoview:geckoview-nightly-omni')
+            }
+        }
+    }
+}
+
 detekt {
     source.setFrom(files("$projectDir/app", "$projectDir/buildSrc"))
     config.setFrom("$projectDir/config/detekt.yml")
@@ -178,7 +200,6 @@ dependencies {
         }
     }
 }
-
 
 tasks.register('ktlint', JavaExec) {
     description = "Check Kotlin code style."

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,6 @@ android.enableJetifier=true
 
 # Broken builds with AGP 8
 android.nonTransitiveRClass=false
+
+# Print dependency analysis results to the console
+dependency.analysis.print.build.health=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ androidx-test-uiautomator = "2.3.0"
 sentry = "7.8.0"
 
 # Third Party Linting & Static Code Analysis
+dependency-analysis = "1.31.0"
 detekt = "1.23.6"
 ktlint = "0.50.0"
 
@@ -166,4 +167,5 @@ mozilla-ui-tabcounter = { group = "org.mozilla.components", name = "ui-tabcounte
 mozilla-ui-widgets = { group = "org.mozilla.components", name = "ui-widgets", version.ref = "android-components" }
 
 [plugins]
+dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,6 @@ compose-compiler = "1.5.13"
 material = "1.9.0"
 
 # AndroidX
-androidx-activity-compose = "1.7.2"
 androidx-appcompat = "1.6.1"
 androidx-composeBom = "2024.05.00"
 androidx-constraintlayout = "2.1.4"
@@ -27,13 +26,9 @@ androidx-work = "2.9.0"
 # AndroidX Testing
 androidx-test-core = "1.5.0"
 androidx-test-espresso = "3.5.1"
-androidx-test-junit = "1.1.5"
 androidx-test-orchestrator = "1.4.2"
 androidx-test-runner = "1.5.2"
 androidx-test-uiautomator = "2.3.0"
-
-# Third Party
-sentry = "7.8.0"
 
 # Third Party Linting & Static Code Analysis
 dependency-analysis = "1.31.0"
@@ -50,13 +45,11 @@ tools-android-plugin = { group = "com.android.tools.build", name = "gradle", ver
 
 # Kotlin
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin-compiler" }
-kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 
 # Google
 google-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 # AndroidX
-androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activity-compose" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidx-appcompat" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core" }
@@ -73,18 +66,12 @@ androidx-compose-ui-base = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 
 # AndroidX Testing
-androidx-test-espresso-contrib = { group = "androidx.test.espresso", name = "espresso-contrib", version.ref = "androidx-test-espresso" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-test-espresso" }
 androidx-test-espresso-idling-resources = { group = "androidx.test.espresso", name = "espresso-idling-resource", version.ref = "androidx-test-espresso" }
-androidx-test-espresso-web = { group = "androidx.test.espresso", name = "espresso-web", version.ref = "androidx-test-espresso" }
-androidx-test-junit-ext = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidx-test-junit" }
 androidx-test-orchestrator = { group = "androidx.test", name = "orchestrator", version.ref = "androidx-test-orchestrator" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidx-test-core" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-test-runner" }
 androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidx-test-uiautomator" }
-
-# Third Party
-thirdparty-sentry = { group = "io.sentry", name = "sentry-android", version.ref = "sentry" }
 
 # Third Party Linting & Static Code Analysis
 ktlint = { module = "com.pinterest:ktlint", version.ref = "ktlint" }
@@ -113,7 +100,6 @@ mozilla-concept-menu = { group = "org.mozilla.components", name = "concept-menu"
 mozilla-concept-push = { group = "org.mozilla.components", name = "concept-push", version.ref = "android-components" }
 mozilla-concept-storage = { group = "org.mozilla.components", name = "concept-storage", version.ref = "android-components" }
 mozilla-concept-sync = { group = "org.mozilla.components", name = "concept-sync", version.ref = "android-components" }
-mozilla-concept-tabstray = { group = "org.mozilla.components", name = "concept-tabstray", version.ref = "android-components" }
 mozilla-concept-toolbar = { group = "org.mozilla.components", name = "concept-toolbar", version.ref = "android-components" }
 
 mozilla-feature-accounts-base = { group = "org.mozilla.components", name = "feature-accounts", version.ref = "android-components" }
@@ -153,14 +139,12 @@ mozilla-service-firefox-accounts = { group = "org.mozilla.components", name = "s
 mozilla-service-location = { group = "org.mozilla.components", name = "service-location", version.ref = "android-components" }
 mozilla-service-sync-logins = { group = "org.mozilla.components", name = "service-sync-logins", version.ref = "android-components" }
 
-mozilla-support-images = { group = "org.mozilla.components", name = "support-images", version.ref = "android-components" }
 mozilla-support-ktx = { group = "org.mozilla.components", name = "support-ktx", version.ref = "android-components" }
 mozilla-support-rusthttp = { group = "org.mozilla.components", name = "support-rusthttp", version.ref = "android-components" }
 mozilla-support-rustlog = { group = "org.mozilla.components", name = "support-rustlog", version.ref = "android-components" }
 mozilla-support-utils = { group = "org.mozilla.components", name = "support-utils", version.ref = "android-components" }
 mozilla-support-webextensions = { group = "org.mozilla.components", name = "support-webextensions", version.ref = "android-components" }
 
-mozilla-ui-autocomplete = { group = "org.mozilla.components", name = "ui-autocomplete", version.ref = "android-components" }
 mozilla-ui-colors = { group = "org.mozilla.components", name = "ui-colors", version.ref = "android-components" }
 mozilla-ui-icons = { group = "org.mozilla.components", name = "ui-icons", version.ref = "android-components" }
 mozilla-ui-tabcounter = { group = "org.mozilla.components", name = "ui-tabcounter", version.ref = "android-components" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,18 +14,26 @@ compose-compiler = "1.5.13"
 material = "1.9.0"
 
 # AndroidX
+androidx-activity = "1.7.2"
+androidx-annotation = "1.7.1"
 androidx-appcompat = "1.6.1"
+androidx-browser = "1.8.0"
+androidx-cardview = "1.0.0"
 androidx-composeBom = "2024.05.00"
 androidx-constraintlayout = "2.1.4"
+androidx-coordinatorlayout = "1.2.0"
 androidx-core = "1.13.1"
+androidx-fragment = "1.6.2"
 androidx-lifecycle = "2.7.0"
 androidx-preference = "1.2.1"
+androidx-recyclerview = "1.3.2"
 androidx-swiperefreshlayout = "1.1.0"
 androidx-work = "2.9.0"
 
 # AndroidX Testing
 androidx-test-core = "1.5.0"
 androidx-test-espresso = "3.5.1"
+androidx-test-monitor = "1.6.1"
 androidx-test-orchestrator = "1.4.2"
 androidx-test-runner = "1.5.2"
 androidx-test-uiautomator = "2.3.0"
@@ -36,8 +44,11 @@ detekt = "1.23.6"
 ktlint = "0.50.0"
 
 # Third Party Testing
+hamcrest = "1.3"
 jacoco = "0.8.11"
-mockwebserver = "4.12.0"
+junit = "4.13.2"
+okhttp = "4.12.0"
+okio = "3.4.0"
 
 [libraries]
 # AGP
@@ -45,16 +56,26 @@ tools-android-plugin = { group = "com.android.tools.build", name = "gradle", ver
 
 # Kotlin
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin-compiler" }
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 
 # Google
 google-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 # AndroidX
+androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "androidx-activity" }
+androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidx-annotation" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidx-appcompat" }
+androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "androidx-browser" }
+androidx-cardview = { group = "androidx.cardview", name = "cardview", version.ref = "androidx-cardview" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
+androidx-coordinatorlayout = { group = "androidx.coordinatorlayout", name = "coordinatorlayout", version.ref = "androidx-coordinatorlayout" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core" }
+androidx-fragment = { group = "androidx.fragment", name = "fragment", version.ref = "androidx-fragment" }
+androidx-lifecycle-common = { group = "androidx.lifecycle", name = "lifecycle-common", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidx-preference" }
+androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "androidx-recyclerview" }
 androidx-swiperefreshlayout = { group = "androidx.swiperefreshlayout", name = "swiperefreshlayout", version.ref = "androidx-swiperefreshlayout" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "androidx-work" }
 
@@ -62,12 +83,16 @@ androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx"
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-composeBom" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-material = { group = "androidx.compose.material", name = "material" }
+androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
 androidx-compose-ui-base = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-compose-ui-text = { group = "androidx.compose.ui", name = "ui-text" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 
 # AndroidX Testing
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-test-espresso" }
 androidx-test-espresso-idling-resources = { group = "androidx.test.espresso", name = "espresso-idling-resource", version.ref = "androidx-test-espresso" }
+androidx-test-monitor = { group = "androidx.test", name = "monitor", version.ref = "androidx-test-monitor" }
 androidx-test-orchestrator = { group = "androidx.test", name = "orchestrator", version.ref = "androidx-test-orchestrator" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidx-test-core" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-test-runner" }
@@ -77,11 +102,17 @@ androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiaut
 ktlint = { module = "com.pinterest:ktlint", version.ref = "ktlint" }
 
 # Third Party Testing
-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver" }
+hamcrest-core = { group = "org.hamcrest", name = "hamcrest-core", version.ref = "hamcrest" }
+hamcrest-library = { group = "org.hamcrest", name = "hamcrest-library", version.ref = "hamcrest" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+okio = { group = "com.squareup.okio", name = "okio", version.ref = "okio" }
 
 # Android Components
 mozilla-browser-domains = { group = "org.mozilla.components", name = "browser-domains", version.ref = "android-components" }
 mozilla-browser-engine-gecko = { group = "org.mozilla.components", name = "browser-engine-gecko", version.ref = "android-components" }
+mozilla-browser-errorpages = { group = "org.mozilla.components", name = "browser-errorpages", version.ref = "android-components" }
 mozilla-browser-icons = { group = "org.mozilla.components", name = "browser-icons", version.ref = "android-components" }
 mozilla-browser-menu = { group = "org.mozilla.components", name = "browser-menu", version.ref = "android-components" }
 mozilla-browser-menu2 = { group = "org.mozilla.components", name = "browser-menu2", version.ref = "android-components" }
@@ -95,7 +126,9 @@ mozilla-browser-toolbar = { group = "org.mozilla.components", name = "browser-to
 mozilla-compose-awesomebar = { group = "org.mozilla.components", name = "compose-awesomebar", version.ref = "android-components" }
 
 mozilla-concept-awesomebar = { group = "org.mozilla.components", name = "concept-awesomebar", version.ref = "android-components" }
+mozilla-concept-base = { group = "org.mozilla.components", name = "concept-base", version.ref = "android-components" }
 mozilla-concept-engine = { group = "org.mozilla.components", name = "concept-engine", version.ref = "android-components" }
+mozilla-concept-fetch = { group = "org.mozilla.components", name = "concept-fetch", version.ref = "android-components" }
 mozilla-concept-menu = { group = "org.mozilla.components", name = "concept-menu", version.ref = "android-components" }
 mozilla-concept-push = { group = "org.mozilla.components", name = "concept-push", version.ref = "android-components" }
 mozilla-concept-storage = { group = "org.mozilla.components", name = "concept-storage", version.ref = "android-components" }
@@ -134,11 +167,13 @@ mozilla-lib-crash-sentry = { group = "org.mozilla.components", name = "lib-crash
 mozilla-lib-dataprotect = { group = "org.mozilla.components", name = "lib-dataprotect", version.ref = "android-components" }
 mozilla-lib-publicsuffixlist = { group = "org.mozilla.components", name = "lib-publicsuffixlist", version.ref = "android-components" }
 mozilla-lib-push-firebase = { group = "org.mozilla.components", name = "lib-push-firebase", version.ref = "android-components" }
+mozilla-lib-state = { group = "org.mozilla.components", name = "lib-state", version.ref = "android-components" }
 
 mozilla-service-firefox-accounts = { group = "org.mozilla.components", name = "service-firefox-accounts", version.ref = "android-components" }
 mozilla-service-location = { group = "org.mozilla.components", name = "service-location", version.ref = "android-components" }
 mozilla-service-sync-logins = { group = "org.mozilla.components", name = "service-sync-logins", version.ref = "android-components" }
 
+mozilla-support-base = { group = "org.mozilla.components", name = "support-base", version.ref = "android-components" }
 mozilla-support-ktx = { group = "org.mozilla.components", name = "support-ktx", version.ref = "android-components" }
 mozilla-support-rusthttp = { group = "org.mozilla.components", name = "support-rusthttp", version.ref = "android-components" }
 mozilla-support-rustlog = { group = "org.mozilla.components", name = "support-rustlog", version.ref = "android-components" }

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -42,6 +42,18 @@ tasks:
         treeherder:
             symbol: compare-locale
             tier: 2
+    dependency-analysis:
+        description: 'Running dependency-analysis over all modules'
+        run:
+            using: gradlew
+            gradlew: [buildHealth]
+        treeherder:
+            symbol: deps
+        worker:
+            artifacts:
+               - name: public/build-health-report.txt
+                 path: /builds/worker/checkouts/vcs/build/reports/dependency-analysis/build-health-report.txt
+                 type: file
     detekt:
         description: 'Running detekt over all modules'
         run:
@@ -57,7 +69,7 @@ tasks:
         treeherder:
             symbol: ktlint
     lint:
-        description: 'Running tlint over all modules'
+        description: 'Running lint over all modules'
         run:
             using: gradlew
             gradlew: [lintDebug]


### PR DESCRIPTION
This patch:
* Adds the [Dependency Analysis Gradle Plugin](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/) to our Gradle setup
* Creates a new linter job in Taskcluster that will fail on any new issues, ensuring we stay up to date down the road
* Cleans up the existing issues found (initial report shown below).

Sample output:
```
Advice for :app
Unused dependencies which should be removed:
  androidTestImplementation libs.espresso.contrib
  androidTestImplementation libs.espresso.web
  androidTestImplementation libs.junit.ktx
  implementation libs.androidx.activity.compose
  implementation libs.mozilla.concept.tabstray
  implementation libs.mozilla.support.images
  implementation libs.mozilla.ui.autocomplete
  implementation libs.thirdparty.sentry

These transitive dependencies should be declared directly:
  androidTestImplementation 'androidx.test:monitor:1.6.1'
  androidTestImplementation 'com.squareup.okhttp3:okhttp:4.12.0'
  androidTestImplementation 'com.squareup.okio:okio:3.4.0'
  androidTestImplementation 'junit:junit:4.13.2'
  androidTestImplementation 'org.hamcrest:hamcrest:2.2'
  implementation 'androidx.activity:activity:1.7.2'
  implementation 'androidx.annotation:annotation:1.7.1'
  implementation 'androidx.browser:browser:1.8.0'
  implementation 'androidx.cardview:cardview:1.0.0'
  implementation 'androidx.compose.runtime:runtime:1.6.6'
  implementation 'androidx.compose.ui:ui-graphics:1.6.6'
  implementation 'androidx.compose.ui:ui-text:1.6.6'
  implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
  implementation 'androidx.fragment:fragment:1.6.2'
  implementation 'androidx.lifecycle:lifecycle-common:2.7.0'
  implementation 'androidx.lifecycle:lifecycle-viewmodel:2.7.0'
  implementation 'androidx.recyclerview:recyclerview:1.3.2'
  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0'
  implementation 'org.mozilla.appservices.nightly:fxaclient:127.20240427050414'
  implementation 'org.mozilla.components:browser-errorpages:127.0.20240427215438'
  implementation 'org.mozilla.components:concept-base:127.0.20240427215438'
  implementation 'org.mozilla.components:concept-fetch:127.0.20240427215438'
  implementation 'org.mozilla.components:lib-state:127.0.20240427215438'
  implementation 'org.mozilla.components:support-base:127.0.20240427215438'
  implementation 'org.mozilla.geckoview:geckoview-nightly-omni:127.0.20240427215438'

Existing dependencies which should be modified to be as indicated:
  implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.9.23' (was api)

Dependencies which should be removed or changed to runtime-only:
  runtimeOnly libs.kotlinx.coroutines.android (was implementation)
```

Obviously I would like to extend this to other projects eventually, probably A-S and Glean next since they should be pretty easy. For mozilla-central, it'll probably go hand in hand with an eventual migration to a version catalog as we might as well get all the churn out of the way in one shot.

To run it locally, you just need to use `./gradlew buildHealth`.