### PR TITLE
Update AGP to version 8.4.1 and switch to plugins DSL

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 plugins {
+    alias libs.plugins.android.application
     alias libs.plugins.compose.compiler
     alias libs.plugins.kotlin.android
 }
 
-apply plugin: 'com.android.application'
 apply from: "$project.rootDir/automation/gradle/versionCode.gradle"
 
 import com.android.build.api.variant.FilterConfiguration

--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,10 @@ buildscript {
             mavenCentral()
         }
     }
-
-    dependencies {
-        classpath libs.tools.android.plugin
-    }
 }
 
 plugins {
+    alias libs.plugins.android.application apply false
     alias libs.plugins.compose.compiler apply false
     alias libs.plugins.dependency.analysis
     alias libs.plugins.detekt

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 android-components = "128.0.20240521213834"
 
 # AGP
-android-plugin = "8.4.0"
+android-plugin = "8.4.1"
 
 # Kotlin
 kotlin = "2.0.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 android-components = "128.0.20240521213834"
 
 # AGP
-android-plugin = "8.4.1"
+android-gradle-plugin = "8.4.1"
 
 # Kotlin
 kotlin = "2.0.0"
@@ -50,9 +50,6 @@ okhttp = "4.12.0"
 okio = "3.4.0"
 
 [libraries]
-# AGP
-tools-android-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-plugin" }
-
 # Kotlin
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 
@@ -184,6 +181,7 @@ mozilla-ui-tabcounter = { group = "org.mozilla.components", name = "ui-tabcounte
 mozilla-ui-widgets = { group = "org.mozilla.components", name = "ui-widgets", version.ref = "android-components" }
 
 [plugins]
+android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,10 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include ':app'
 
 def log(message) {


### PR DESCRIPTION
Seems a bit cleaner to me to have all the plugins running through the DSL. Feel free to push back if you disagree, though. I had to add the settings.gradle change or else Gradle couldn't find AGP when it was added to the top-level `plugins{}` block.