### PR TITLE
Bug 1899634 - Update AndroidX Appcompat to version 1.7.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ material = "1.9.0"
 # AndroidX
 androidx-activity = "1.7.2"
 androidx-annotation = "1.8.0"
-androidx-appcompat = "1.6.1"
+androidx-appcompat = "1.7.0"
 androidx-browser = "1.8.0"
 androidx-cardview = "1.0.0"
 androidx-composeBom = "2024.05.00"


### PR DESCRIPTION
Release notes: https://developer.android.com/jetpack/androidx/releases/appcompat#1.7.0