### PR TITLE
Bug #2887 - Fix openFXATest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/TestHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/TestHelper.kt
@@ -81,10 +81,13 @@ object TestHelper {
     fun itemWithResId(resourceId: String) =
         mDevice.findObject(UiSelector().resourceId(resourceId))
 
+    fun itemWithText(itemText: String) =
+        mDevice.findObject(UiSelector().text(itemText))
+
     fun itemWithResIdContainingText(resourceId: String, text: String) =
         mDevice.findObject(UiSelector().resourceId(resourceId).textContains(text))
 
-    fun assertItemWithResIdExists(vararg appItems: UiObject, exists: Boolean = true) {
+    fun assertUIObjectExists(vararg appItems: UiObject, exists: Boolean = true) {
         if (exists) {
             for (appItem in appItems) {
                 assertTrue(appItem.waitForExists(waitingTime))
@@ -95,14 +98,6 @@ object TestHelper {
             }
         }
     }
-    fun assertItemWithResIdAndTextExists(vararg appItems: UiObject, exists: Boolean = true) {
-        for (appItem in appItems) {
-            if (exists) {
-                assertTrue(appItem.waitForExists(waitingTime))
-            } else {
-                assertFalse(appItem.waitForExists(waitingTimeShort))
-            }
-        }
-    }
+
     fun getStringResource(id: Int) = appContext.resources.getString(id, appName)
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddonsManagerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddonsManagerRobot.kt
@@ -26,8 +26,7 @@ import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.waitAndInteract
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTimeShort
-import org.mozilla.reference.browser.helpers.TestHelper.assertItemWithResIdAndTextExists
-import org.mozilla.reference.browser.helpers.TestHelper.assertItemWithResIdExists
+import org.mozilla.reference.browser.helpers.TestHelper.assertUIObjectExists
 import org.mozilla.reference.browser.helpers.TestHelper.getStringResource
 import org.mozilla.reference.browser.helpers.TestHelper.itemWithResId
 import org.mozilla.reference.browser.helpers.TestHelper.itemWithResIdContainingText
@@ -42,14 +41,14 @@ class AddonsManagerRobot {
     fun verifyAddonsRecommendedView() {
         assertTrue(mDevice.findObject(UiSelector().text("Recommended")).waitForExists(waitingTime))
         // Check uBlock is displayed in the "Recommended" section
-        assertItemWithResIdAndTextExists(
+        assertUIObjectExists(
             itemWithResIdContainingText("$packageName:id/add_on_name", "uBlock Origin"),
             itemWithResIdContainingText(
                 "$packageName:id/add_on_description",
                 "Finally, an efficient wide-spectrum content blocker. Easy on CPU and memory.",
             ),
         )
-        assertItemWithResIdExists(
+        assertUIObjectExists(
             itemWithResId("$packageName:id/rating"),
             itemWithResId("$packageName:id/review_count"),
             itemWithResId("$packageName:id/add_button"),

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
@@ -22,6 +22,9 @@ import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.TestAssetHelper
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestHelper
+import org.mozilla.reference.browser.helpers.TestHelper.assertUIObjectExists
+import org.mozilla.reference.browser.helpers.TestHelper.getStringResource
+import org.mozilla.reference.browser.helpers.TestHelper.itemWithText
 import org.mozilla.reference.browser.helpers.TestHelper.packageName
 import org.mozilla.reference.browser.helpers.click
 import org.mozilla.reference.browser.helpers.hasCousin
@@ -80,7 +83,7 @@ class SettingsViewRobot {
         }
 
         fun openFXASignin(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-            syncSigninButton().click()
+            syncSignInButton().click()
             BrowserRobot().interact()
             return BrowserRobot.Transition()
         }
@@ -132,7 +135,7 @@ private fun assertSettingsView() {
     Espresso.onView(withText(R.string.preferences_about_page))
 }
 
-private fun syncSigninButton() = Espresso.onView(withText(R.string.sign_in))
+private fun syncSignInButton() = itemWithText(getStringResource(R.string.sign_in))
 private fun syncHistorySummary() = Espresso.onView(withText(R.string.preferences_sign_in_summary))
 private fun syncQrCodeButton() = Espresso.onView(withText(R.string.pair_sign_in))
 private fun syncQrSummary() = Espresso.onView(withText(R.string.preferences_pair_sign_in_summary))
@@ -162,8 +165,7 @@ private fun aboutReferenceBrowserButton() = Espresso.onView(withText(R.string.pr
 private fun assertNavigateUpButton() {
     mDevice.wait(Until.findObject(By.text("Navigate up")), TestAssetHelper.waitingTimeShort)
 }
-private fun assertSyncSigninButton() = syncSigninButton()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertSyncSigninButton() = assertUIObjectExists(syncSignInButton())
 private fun assertSyncHistorySummary() = syncHistorySummary()
     .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 private fun assertSyncQrCodeButton() = syncQrCodeButton()


### PR DESCRIPTION
### Summary:
The UI test failed when trying to click the "Sign in" settings button.
Switched from using Espresso to UI automator

✅ Successfully passed 150x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
