### PR TITLE
restrict taskcluster on push tasks to `master` branch

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -100,7 +100,7 @@ tasks:
               $if: >
                 tasks_for in ["action", "cron"]
                 || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
-                || (tasks_for == "github-push" && head_branch[:10] != "refs/tags/" && head_branch != "staging.tmp" && head_branch != "trying.tmp")
+                || (tasks_for == "github-push" && head_branch == "refs/heads/master")
                 || (tasks_for == "github-release" && releaseAction == "published")
               then:
                   $let:


### PR DESCRIPTION
In https://bugzilla.mozilla.org/show_bug.cgi?id=1907217 we're becoming more explicit in the scopes that we grant to GitHub repositories. At the moment, any branch in this repository can receive level 3 scopes, which is less than ideal from a security perspective. This change will restrict on push building to the `master` branch. If other branch(es) are needed we can add them to the list. Alternatively, any testing that's currently being done on branches can be done through pull requests instead.

If this change will be problematic for any reason please let me know and we can find a solution.

cc @rvandermeulen, whom I see has recently done some testing on a branch.