### PR TITLE
Bug 1916252 - Make reference-browser use the Autograph production ins…

### DIFF
--- a/taskcluster/rb_taskgraph/transforms/signing_bundle.py
+++ b/taskcluster/rb_taskgraph/transforms/signing_bundle.py
@@ -22,7 +22,7 @@ def build_signing_task(config, tasks):
             "taskId": {"task-reference": "<build-bundle>"},
             "taskType": "build",
             "paths": [dep.attributes["aab"]],
-            "formats": ["autograph_stage_aab"],
+            "formats": ["autograph_apk"],
         }]
         del task["primary-dependency"]
         yield task


### PR DESCRIPTION
…tance again

`autograph_apk` is still available in signing-script: https://github.com/mozilla-releng/scriptworker-scripts/blob/70dd41e51f4f0408ad3d2b7c18a99d08a6ebbebd/signingscript/docker.d/passwords.yml#L282C16-L282C29

This format is used to sign the Fenix AAB too: https://searchfox.org/mozilla-central/rev/55f2ada1564baaeebd69d277b38737961a3ca5f3/taskcluster/kinds/signing-bundle/kind.yml#28

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
