### PR TITLE
Revert "Bug 1916252 - Make reference-browser use the Autograph production ins…"

### DIFF
--- a/taskcluster/rb_taskgraph/transforms/signing_bundle.py
+++ b/taskcluster/rb_taskgraph/transforms/signing_bundle.py
@@ -22,7 +22,7 @@ def build_signing_task(config, tasks):
             "taskId": {"task-reference": "<build-bundle>"},
             "taskType": "build",
             "paths": [dep.attributes["aab"]],
-            "formats": ["autograph_apk"],
+            "formats": ["autograph_stage_aab"],
         }]
         del task["primary-dependency"]
         yield task


### PR DESCRIPTION
Reverts mozilla-mobile/reference-browser#3056

We first need to sort out the prod autograph config, since it's failing right now.