### PR TITLE
Set MOZ_AUTOMATION in decision tasks

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -215,6 +215,7 @@ tasks:
                                           MOBILE_PIP_REQUIREMENTS: taskcluster/requirements.txt
                                           MOBILE_REPOSITORY_TYPE: git
                                           REPOSITORIES: {$json: {mobile: "Reference Browser"}}
+                                          MOZ_AUTOMATION: '1'
                                         - $if: 'isPullRequest'
                                           then:
                                               MOBILE_PULL_REQUEST_NUMBER: '${event.pull_request.number}'


### PR DESCRIPTION
In #2584 I added a protection against running the nightly graph multiple times off the same revision, but it didn't actually work, because it's gated on the MOZ_AUTOMATION environment variable.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
