### PR TITLE
Bug 1924657 - ci: index cron tasks by revision

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -166,17 +166,20 @@ tasks:
                                     - $if: 'level == "3"'
                                       then:
                                           - tc-treeherder.v2.${project}.${head_sha}
-                                          - $if: 'tasks_for == "github-push"'
-                                            then:
-                                                - index.mobile.v2.${project}.branch.${short_head_branch}.latest.taskgraph.decision
-                                                - index.mobile.v2.${project}.branch.${short_head_branch}.revision.${head_sha}.taskgraph.decision
-                                                - index.mobile.v2.${project}.revision.${head_sha}.taskgraph.decision
-                                          - $if: 'tasks_for == "cron"'
-                                            then:
-                                                # cron context provides ${head_branch} as a short one
-                                                - index.mobile.v2.${project}.branch.${head_branch}.latest.taskgraph.decision-${cron.job_name}
-                                                - index.mobile.v2.${project}.branch.${head_branch}.revision.${head_sha}.taskgraph.decision-${cron.job_name}
-                                                - index.mobile.v2.${project}.branch.${head_branch}.revision.${head_sha}.taskgraph.cron.${ownTaskId}
+                                          - $switch:
+                                              'tasks_for == "github-push"':
+                                                  - index.mobile.v2.${project}.branch.${short_head_branch}.latest.taskgraph.decision
+                                                  - index.mobile.v2.${project}.branch.${short_head_branch}.revision.${head_sha}.taskgraph.decision
+                                                  - index.mobile.v2.${project}.revision.${head_sha}.taskgraph.decision
+                                              'tasks_for == "action"':
+                                                  - index.${trustDomain}.v2.${project}.revision.${head_sha}.taskgraph.actions.${ownTaskId}
+                                              'tasks_for == "cron"':
+                                                  # cron context provides ${head_branch} as a short one
+                                                  - index.mobile.v2.${project}.branch.${head_branch}.latest.taskgraph.decision-${cron.job_name}
+                                                  - index.mobile.v2.${project}.branch.${head_branch}.revision.${head_sha}.taskgraph.decision-${cron.job_name}
+                                                  - index.mobile.v2.${project}.branch.${head_branch}.revision.${head_sha}.taskgraph.cron.${ownTaskId}
+                                                  # list each cron task on this revision, so actions can find them
+                                                  - index.mobile.v2.${project}.revision.${head_sha}.cron.${ownTaskId}
                             scopes:
                                 $if: 'tasks_for == "github-push"'
                                 then:


### PR DESCRIPTION
Taskgraph relies on this index for action tasks such as retrigger to find all tasks that ran on a given revision.

While at it, also add an index for action tasks.