### PR TITLE
Status check UI tests on MediumPhone.arm

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
@@ -11,7 +11,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.reference.browser.helpers.BrowserActivityTestRule
 import org.mozilla.reference.browser.helpers.RetryTestRule
-import org.mozilla.reference.browser.helpers.TestHelper.scrollToElementByText
 import org.mozilla.reference.browser.ui.robots.mDevice
 import org.mozilla.reference.browser.ui.robots.navigationToolbar
 
@@ -137,7 +136,6 @@ class SettingsViewTest {
         navigationToolbar {
         }.openThreeDotMenu {
         }.openSettings {
-            scrollToElementByText("About Reference Browser")
         }.openAboutReferenceBrowser {
             verifyAboutBrowser()
         }
@@ -153,7 +151,6 @@ class SettingsViewTest {
         navigationToolbar {
         }.openThreeDotMenu {
         }.openSettings {
-            scrollToElementByText("About Reference Browser")
             verifyCustomAddonCollectionButton()
             clickCustomAddonCollectionButton()
             verifyCustomAddonCollectionPanelExist()

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
@@ -22,7 +22,6 @@ import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.helpers.TestAssetHelper
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
-import org.mozilla.reference.browser.helpers.TestHelper
 import org.mozilla.reference.browser.helpers.TestHelper.assertUIObjectExists
 import org.mozilla.reference.browser.helpers.TestHelper.getStringResource
 import org.mozilla.reference.browser.helpers.TestHelper.itemWithText
@@ -203,10 +202,8 @@ private fun assertRemoteDebugging() = remoteDebuggingToggle()
     .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 private fun assertCustomAddonCollectionButton() = customAddonCollectionButton()
     .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-private fun assertMozillaHeading() {
-    TestHelper.scrollToElementByText("About Reference Browser")
+private fun assertMozillaHeading() =
     mozillaHeading().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-}
 private fun assertAboutReferenceBrowserButton() = aboutReferenceBrowserButton()
     .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 private fun assertCustomAddonCollectionPanel() {

--- a/automation/taskcluster/androidTest/flank-arm64-v8a.yml
+++ b/automation/taskcluster/androidTest/flank-arm64-v8a.yml
@@ -23,7 +23,7 @@ gcloud:
     - package org.mozilla.reference.browser.ui
 
   device:
-    - model: Pixel2.arm
+    - model: MediumPhone.arm
       version: 30
       locale: en_US
 


### PR DESCRIPTION
### Summary:
As per @AaronMT 's suggestion I've switched the device on which the UI test will run from Pixel2.arm to MediumPhone.arm

There were 3 UI tests that were constantly failing:
`settingsItemsTest`, `customAddonsCollectionTest` and `aboutReferenceBrowserTest`

After fixing them, all UI tests successfully passed 3x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
