### PR TITLE
Remove obsolete AndroidX test workaround

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -340,12 +340,6 @@ dependencies {
     implementation libs.mozilla.ui.tabcounter
     implementation libs.mozilla.ui.widgets
 
-    constraints {
-        implementation (libs.androidx.tracing) {
-            because 'AndroidX Test gets force-downgraded to 1.0.0 and breaks otherwise'
-        }
-    }
-
     androidTestImplementation libs.androidx.test.espresso.core
     androidTestImplementation libs.androidx.test.espresso.idling.resources
     androidTestImplementation libs.androidx.test.monitor

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,6 @@ androidx-lifecycle = "2.8.7"
 androidx-preference = "1.2.1"
 androidx-recyclerview = "1.3.2"
 androidx-swiperefreshlayout = "1.1.0"
-androidx-tracing = "1.2.0"
 androidx-work = "2.10.0"
 
 # AndroidX Testing
@@ -74,7 +73,6 @@ androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidx-preference" }
 androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "androidx-recyclerview" }
 androidx-swiperefreshlayout = { group = "androidx.swiperefreshlayout", name = "swiperefreshlayout", version.ref = "androidx-swiperefreshlayout" }
-androidx-tracing = { group = "androidx.tracing", name = "tracing", version.ref = "androidx-tracing" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "androidx-work" }
 
 # AndroidX Compose


### PR DESCRIPTION
According to the upstream issue, the latest patch releases should include a fix that removes the need for the tracing workaround which was previously landed.