### PR TITLE
Use RequiresApi instead of TargetApi in NotificationManager

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/NotificationManager.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/NotificationManager.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.reference.browser
 
-import android.annotation.TargetApi
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.PendingIntent
@@ -14,6 +13,7 @@ import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
+import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.preference.PreferenceManager
@@ -178,7 +178,7 @@ object NotificationManager {
         return channelId
     }
 
-    @TargetApi(Build.VERSION_CODES.O)
+    @RequiresApi(Build.VERSION_CODES.O)
     private fun createNotificationChannelIfNeeded(
         context: Context,
         channelId: String,


### PR DESCRIPTION
AGP 8.9.0 is tightening up the lint checks around TargetApi/RequiresApi. With the most recent alpha04 build, we see the following error:
```
/reference-browser/app/src/main/java/org/mozilla/reference/browser/NotificationManager.kt:181: Error: Use @RequiresApi(Build.VERSION_CODES.O) instead of @TargetApi` to propagate the requirement to callers of createNotificationChannelIfNeeded [UseRequiresApi]
    @TargetApi(Build.VERSION_CODES.O)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "UseRequiresApi":
   The @TargetApi annotation only suppresses API warnings locally.
   @RequiresApi on the other hand will propagate the requirement out to any
   callers of this API, making sure that they either perform API level checks
   (using for example SDK_INT), or defining @RequiresApi annotations
   themselves.

   (The @TargetApi annotation predates @RequiresApi, and was introduced as an
   early way to suppress lint API warnings for a particular API level.
   Accidentally using @TargetApi can lead to crashes since there is no check
   that other calls to this method actually check that the call is safe.)
```