### PR TITLE
Bug 1940823 - Exchanging Removed Strings in Reference Browser

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/addons/WebExtensionPromptFeature.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/WebExtensionPromptFeature.kt
@@ -281,11 +281,11 @@ class WebExtensionPromptFeature(
         var title = context.getString(R.string.mozac_feature_addons_cant_install_extension, "")
         val message = when (exception) {
             is WebExtensionInstallException.Blocklisted -> {
-                context.getString(R.string.mozac_feature_addons_blocklisted_1, addonName)
+                context.getString(R.string.mozac_feature_addons_blocklisted_2, addonName, R.string.app_name)
             }
 
             is WebExtensionInstallException.SoftBlocked -> {
-                context.getString(R.string.mozac_feature_addons_soft_blocked, addonName)
+                context.getString(R.string.mozac_feature_addons_soft_blocked_1, addonName, R.string.app_name)
             }
 
             is WebExtensionInstallException.UserCancelled -> {


### PR DESCRIPTION
Patch substitutes strings on `WebExtensionInstallException.Blocklisted ` and `mozac_feature_addons_soft_blocked_1` that were recently removed.

Basing the exchange on bug 1923268, which updated soft/hard block strings.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
