### PR TITLE
Fix new UseKtx lint warnings in AGP 8.9.0-alpha09

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/CrashListActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/CrashListActivity.kt
@@ -5,7 +5,7 @@
 package org.mozilla.reference.browser
 
 import android.content.Intent
-import android.net.Uri
+import androidx.core.net.toUri
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.ui.AbstractCrashListActivity
 import org.mozilla.reference.browser.ext.components
@@ -15,7 +15,7 @@ class CrashListActivity : AbstractCrashListActivity() {
 
     override fun onCrashServiceSelected(url: String) {
         val intent = Intent(Intent.ACTION_VIEW).apply {
-            data = Uri.parse(url)
+            data = url.toUri()
             `package` = packageName
         }
         startActivity(intent)

--- a/app/src/main/java/org/mozilla/reference/browser/ExternalAppBrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/ExternalAppBrowserActivity.kt
@@ -4,7 +4,7 @@
 
 package org.mozilla.reference.browser
 
-import android.net.Uri
+import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.feature.pwa.ext.getWebAppManifest
@@ -21,7 +21,7 @@ class ExternalAppBrowserActivity : BrowserActivity() {
             val scope = when (manifest?.display) {
                 WebAppManifest.DisplayMode.FULLSCREEN,
                 WebAppManifest.DisplayMode.STANDALONE,
-                -> Uri.parse(manifest.scope ?: manifest.startUrl)
+                -> (manifest.scope ?: manifest.startUrl).toUri()
 
                 WebAppManifest.DisplayMode.MINIMAL_UI,
                 WebAppManifest.DisplayMode.BROWSER,

--- a/app/src/main/java/org/mozilla/reference/browser/NotificationManager.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/NotificationManager.kt
@@ -15,6 +15,7 @@ import android.os.Build.VERSION.SDK_INT
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.preference.PreferenceManager
 import mozilla.components.concept.sync.Device
@@ -151,10 +152,10 @@ object NotificationManager {
         NotificationManagerCompat.from(context)
             .notify(DATA_REPORTING_TAG, DATA_REPORTING_NOTIFICATION_ID, notificationBuilder.build())
 
-        preferences.edit()
-            .putLong(PREFS_POLICY_NOTIFIED_TIME, System.currentTimeMillis())
-            .putInt(PREFS_POLICY_VERSION, DATA_REPORTING_VERSION)
-            .apply()
+        preferences.edit {
+            putLong(PREFS_POLICY_NOTIFIED_TIME, System.currentTimeMillis())
+            putInt(PREFS_POLICY_VERSION, DATA_REPORTING_VERSION)
+        }
     }
 
     private fun getNotificationChannelId(

--- a/app/src/main/java/org/mozilla/reference/browser/NotificationManager.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/NotificationManager.kt
@@ -10,12 +10,12 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
-import android.net.Uri
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.net.toUri
 import androidx.preference.PreferenceManager
 import mozilla.components.concept.sync.Device
 import mozilla.components.concept.sync.TabData
@@ -53,7 +53,7 @@ object NotificationManager {
         logger.debug("Showing ${tabs.size} tab(s) received from deviceID=${device?.id}")
 
         tabs.forEach { tab ->
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(tab.url)).apply {
+            val intent = Intent(Intent.ACTION_VIEW, tab.url.toUri()).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
             }
             val flags = if (SDK_INT >= Build.VERSION_CODES.S) {
@@ -123,7 +123,7 @@ object NotificationManager {
         val notificationSummary = resources.getString(R.string.datareporting_notification_summary)
 
         val intent = Intent(Intent.ACTION_VIEW).apply {
-            data = Uri.parse(PRIVACY_NOTICE_URL)
+            data = PRIVACY_NOTICE_URL.toUri()
             setPackage(context.packageName)
         }
 

--- a/app/src/main/java/org/mozilla/reference/browser/addons/AddonDetailsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/AddonDetailsActivity.kt
@@ -5,13 +5,13 @@
 package org.mozilla.reference.browser.addons
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
 import android.view.View
 import android.widget.RatingBar
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.net.toUri
 import androidx.core.text.HtmlCompat
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.ui.translateDescription
@@ -66,8 +66,7 @@ class AddonDetailsActivity : AppCompatActivity() {
 
     private fun bindWebsite(addon: Addon) {
         findViewById<View>(R.id.home_page_text).setOnClickListener {
-            val intent =
-                Intent(Intent.ACTION_VIEW).setData(Uri.parse(addon.homepageUrl))
+            val intent = Intent(Intent.ACTION_VIEW, addon.homepageUrl.toUri())
             startActivity(intent)
         }
     }

--- a/app/src/main/java/org/mozilla/reference/browser/addons/PermissionsDetailsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/PermissionsDetailsActivity.kt
@@ -5,13 +5,13 @@
 package org.mozilla.reference.browser.addons
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.net.toUri
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.feature.addons.Addon
@@ -86,8 +86,7 @@ class PermissionsDetailsActivity : AppCompatActivity(), View.OnClickListener {
     ) : RecyclerView.ViewHolder(view)
 
     override fun onClick(v: View?) {
-        val intent =
-            Intent(Intent.ACTION_VIEW).setData(Uri.parse(LEARN_MORE_URL))
+        val intent = Intent(Intent.ACTION_VIEW).setData(LEARN_MORE_URL.toUri())
         startActivity(intent)
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/autofill/AutofillPreference.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/autofill/AutofillPreference.kt
@@ -6,13 +6,13 @@ package org.mozilla.reference.browser.autofill
 
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 import android.util.AttributeSet
 import android.view.autofill.AutofillManager
 import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.SwitchCompat
+import androidx.core.net.toUri
 import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
 import org.mozilla.reference.browser.R
@@ -45,8 +45,9 @@ class AutofillPreference @JvmOverloads constructor(
 
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onClick() {
-        val intent = Intent(Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE)
-        intent.data = Uri.parse("package:${context.packageName}")
+        val intent = Intent(Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE).apply {
+            data = "package:${context.packageName}".toUri()
+        }
         context.startActivity(intent)
     }
 

--- a/app/src/main/java/org/mozilla/reference/browser/settings/Settings.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/Settings.kt
@@ -5,6 +5,7 @@
 package org.mozilla.reference.browser.settings
 
 import android.content.Context
+import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import org.mozilla.reference.browser.R
 
@@ -29,18 +30,16 @@ object Settings {
 
     fun setOverrideAmoUser(context: Context, value: String) {
         val key = context.getString(R.string.pref_key_override_amo_user)
-        PreferenceManager.getDefaultSharedPreferences(context)
-            .edit()
-            .putString(key, value)
-            .apply()
+        PreferenceManager.getDefaultSharedPreferences(context).edit {
+            putString(key, value)
+        }
     }
 
     fun setOverrideAmoCollection(context: Context, value: String) {
         val key = context.getString(R.string.pref_key_override_amo_collection)
-        PreferenceManager.getDefaultSharedPreferences(context)
-            .edit()
-            .putString(key, value)
-            .apply()
+        PreferenceManager.getDefaultSharedPreferences(context).edit {
+            putString(key, value)
+        }
     }
 
     fun isAmoCollectionOverrideConfigured(context: Context): Boolean {

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/synced/SyncedTabsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/synced/SyncedTabsFragment.kt
@@ -5,11 +5,11 @@
 package org.mozilla.reference.browser.tabs.synced
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import mozilla.components.browser.storage.sync.Tab
 import mozilla.components.feature.syncedtabs.SyncedTabsFeature
@@ -49,7 +49,7 @@ class SyncedTabsFragment : Fragment() {
     }
 
     private fun handleTabClicked(tab: Tab) {
-        val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(tab.active().url))
+        val browserIntent = Intent(Intent.ACTION_VIEW, tab.active().url.toUri())
         requireContext().startActivity(browserIntent)
     }
 }


### PR DESCRIPTION
Looks like AGP is getting more strict around using KTX extension functions. Seeing multiple linter errors like the following:
`Error: Use the KTX extension function String.toUri instead? [UseKtx]`
`Error: Use the KTX extension function SharedPreferences.edit instead? [UseKtx]`

Fixes are easy at least!