### PR TITLE
bug 1942364: switch to autograph gcp production

### DIFF
--- a/taskcluster/rb_taskgraph/transforms/signing_apks.py
+++ b/taskcluster/rb_taskgraph/transforms/signing_apks.py
@@ -22,7 +22,7 @@ def build_signing_task(config, tasks):
                 "taskId": {"task-reference": "<build>"},
                 "taskType": "build",
                 "paths": list(dep.attributes["apks"].values()),
-                "formats": ["autograph_apk"],
+                "formats": ["gcp_prod_autograph_apk"],
             }
         ]
         del task["primary-dependency"]

--- a/taskcluster/rb_taskgraph/transforms/signing_bundle.py
+++ b/taskcluster/rb_taskgraph/transforms/signing_bundle.py
@@ -22,7 +22,7 @@ def build_signing_task(config, tasks):
             "taskId": {"task-reference": "<build-bundle>"},
             "taskType": "build",
             "paths": [dep.attributes["aab"]],
-            "formats": ["autograph_aab"],
+            "formats": ["gcp_prod_autograph_aab"],
         }]
         del task["primary-dependency"]
         yield task


### PR DESCRIPTION
This needs to wait for https://github.com/mozilla-releng/scriptworker-scripts/pull/1123 to be deployed before it can land.