### PR TITLE
Add origins to required permissions dialog

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/addons/WebExtensionPromptFeature.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/WebExtensionPromptFeature.kt
@@ -102,6 +102,7 @@ class WebExtensionPromptFeature(
             addon = addon,
             promptRequest = promptRequest,
             permissions = promptRequest.permissions,
+            origins = promptRequest.origins,
         )
     }
 
@@ -155,12 +156,14 @@ class WebExtensionPromptFeature(
         addon: Addon,
         promptRequest: WebExtensionPromptRequest.AfterInstallation.Permissions,
         permissions: List<String> = emptyList(),
+        origins: List<String> = emptyList(),
         forOptionalPermissions: Boolean = false,
     ) {
         if (!isInstallationInProgress && !hasExistingPermissionDialogFragment()) {
             val dialog = PermissionsDialogFragment.newInstance(
                 addon = addon,
                 permissions = permissions,
+                origins = origins,
                 forOptionalPermissions = forOptionalPermissions,
                 onPositiveButtonClicked = { _, privateBrowsingAllowed ->
                     handlePermissions(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Android Components
-android-components = "137.0.20250207164009"
+android-components = "137.0.20250211214755"
 
 # AGP
 android-gradle-plugin = "8.8.1"


### PR DESCRIPTION
Fixes AC version 137.0.20250213205200 and unblocks [PR 3409](https://github.com/mozilla-mobile/reference-browser/pull/3409) by adding the required `origins` to the required permissions prompt.

Note: The work to add `origins` is only for required permissions prompt but in the future there may be work to add these to optional permissions as well and that will require similar changes.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
