### PR TITLE
Update Kotlin to version 2.1.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ android-components = "138.0.20250318090311"
 android-gradle-plugin = "8.9.0"
 
 # Kotlin
-kotlin = "2.1.10"
+kotlin = "2.1.20"
 kotlinx-coroutines = "1.10.0"
 
 # Google


### PR DESCRIPTION
Release notes: https://github.com/JetBrains/kotlin/releases/tag/v2.1.20