### PR TITLE
Update Kotlin to version 2.1.21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ android-components = "140.0.20250512213630"
 android-gradle-plugin = "8.10.0"
 
 # Kotlin
-kotlin = "2.1.20"
+kotlin = "2.1.21"
 kotlinx-coroutines = "1.10.2"
 
 # Google


### PR DESCRIPTION
Release notes: https://github.com/JetBrains/kotlin/releases/tag/v2.1.21