### PR TITLE
Update AndroidX WorkManager to version 2.10.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ androidx-lifecycle = "2.9.1"
 androidx-preference = "1.2.1"
 androidx-recyclerview = "1.4.0"
 androidx-swiperefreshlayout = "1.1.0"
-androidx-work = "2.10.1"
+androidx-work = "2.10.2"
 
 # AndroidX Testing
 androidx-test-core = "1.6.1"


### PR DESCRIPTION
Release notes: https://developer.android.com/jetpack/androidx/releases/work#2.10.2