### PR TITLE
Update Google Cloud CLI SDK in Dockerfile

### DIFF
--- a/taskcluster/docker/ui-tests/Dockerfile
+++ b/taskcluster/docker/ui-tests/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install -y jq \
 USER worker:worker
 
 ENV GOOGLE_SDK_DOWNLOAD ./gcloud.tar.gz
-ENV GOOGLE_SDK_VERSION 478
+ENV GOOGLE_SDK_VERSION 529
 
 ENV TEST_TOOLS /builds/worker/test-tools
 ENV PATH ${PATH}:${TEST_TOOLS}:${TEST_TOOLS}/google-cloud-sdk/bin


### PR DESCRIPTION
Been a while, `478` to `529`
https://cloud.google.com/sdk/docs/release-notes#52900_2025-07-01