### PR TITLE
Force the use of JNA 5.17.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -236,6 +236,15 @@ project.configurations.configureEach {
 dependencies {
     coreLibraryDesugaring libs.desugar.jdk.libs
 
+    // We pick up JNA transitively by way of Glean, which is currently on version 5.14.0.
+    // However, we need to force version 5.17.0 due to Google Play's 16KB page size requirement.
+    // JNA 5.15.0+ crashes on Android <7, however, so it can't be bumped in Glean at this time.
+    // Therefore, manually force the use of version 5.17.0 at the app level since we only support
+    // running on Android 8+ now anyway.
+    constraints {
+        implementation(libs.jna)
+    }
+
     implementation libs.androidx.activity
     implementation libs.androidx.annotation
     implementation libs.androidx.appcompat

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,9 @@ kotlinx-coroutines = "1.10.2"
 desugar-jdk-libs = "2.1.5"
 material = "1.12.0"
 
+# JNA
+jna = "5.17.0"
+
 # AndroidX
 androidx-activity = "1.10.1"
 androidx-annotation = "1.9.1"
@@ -58,6 +61,9 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 # Google
 desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugar-jdk-libs" }
 google-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+
+# JNA
+jna = { group = "net.java.dev.jna", name = "jna", version.ref = "jna" }
 
 # AndroidX
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "androidx-activity" }


### PR DESCRIPTION
We pick up JNA transitively by way of Glean, which is currently on version 5.14.0. However, we need to force version 5.17.0 due to Google Play's 16KB page size requirement. JNA 5.15.0+ crashes on Android <7, however, so it can't be bumped in Glean at this time. Therefore, manually force the use of version 5.17.0 at the app level since we only support running on Android 8+ now anyway.