### PR TITLE
Fix ClickableViewAccessibility lint in AboutFragment

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.11.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.11.1)" variant="all" version="8.11.1">
+<issues format="6" by="lint 8.12.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.12.1)" variant="all" version="8.12.1">
 
     <issue
         id="GestureBackNavigation"
@@ -50,17 +50,6 @@
             file="src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml"
             line="2"
             column="1"/>
-    </issue>
-
-    <issue
-        id="ClickableViewAccessibility"
-        message="Custom view ``TextView`` has `setOnTouchListener` called on it but does not override `performClick`"
-        errorLine1="        versionInfoView.setOnTouchListener { v, _ ->"
-        errorLine2="        ^">
-        <location
-            file="src/main/java/org/mozilla/reference/browser/settings/AboutFragment.kt"
-            line="74"
-            column="9"/>
     </issue>
 
     <issue

--- a/app/src/main/java/org/mozilla/reference/browser/settings/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/AboutFragment.kt
@@ -71,13 +71,11 @@ class AboutFragment : Fragment() {
         val versionInfoView = view.findViewById<TextView>(R.id.version_info)
         versionInfoView.text = versionInfo
 
-        versionInfoView.setOnTouchListener { v, _ ->
+        versionInfoView.setOnClickListener { v ->
             val clipBoard = requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
             clipBoard.setPrimaryClip(ClipData.newPlainText(versionInfo, versionInfo))
 
             Toast.makeText(requireContext(), getString(R.string.toast_copied), Toast.LENGTH_SHORT).show()
-
-            v.performClick()
         }
     }
 }


### PR DESCRIPTION
Replaced setOnTouchListener on versionInfoView with setOnClickListener. Using OnClickListener preserves accessibility semantics automatically (e.g., TalkBack, switch access) and avoids the need to manually call performClick().