### PR TITLE
Issue #3623 - Don't call super.onBackPressedDispatcher

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
@@ -77,21 +77,14 @@ open class BrowserActivity : AppCompatActivity() {
             this,
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
-                    onBackPressed()
+                    supportFragmentManager.fragments.forEach {
+                        if (it is UserInteractionHandler && it.onBackPressed()) {
+                            return
+                        }
+                    }
                 }
             },
         )
-    }
-
-    @Suppress("MissingSuperCall", "OVERRIDE_DEPRECATION")
-    override fun onBackPressed() {
-        supportFragmentManager.fragments.forEach {
-            if (it is UserInteractionHandler && it.onBackPressed()) {
-                return
-            }
-        }
-
-        super.onBackPressedDispatcher.onBackPressed()
     }
 
     @Suppress("DEPRECATION") // ComponentActivity wants us to use registerForActivityResult


### PR DESCRIPTION
Can cause a loop on the last tab.

Figured I'd remove the deprecated method as well here too.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
