### PR TITLE
Fix the Nightly build task link on Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Signed Nightly builds can be downloaded from:
 
 > Please note that these builds do not auto-update, you will have to keep up to date manually.
 
-The latest Nightly build task can be found [here](https://firefox-ci-tc.services.mozilla.com/tasks/index/project.mobile.reference-browser.v3.nightly/latest).
+The latest Nightly build task can be found [here](https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v2.reference-browser.nightly.latest).
 
 # Getting Involved
 


### PR DESCRIPTION
The link pointing to the Nightly build task is currently broken on the Readme.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
