### PR TITLE
Fix geckoview substitution failures

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -414,7 +414,7 @@ if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcd
 
 if (gradle.hasProperty('localProperties.autoPublish.android-components.dir')) {
     ext.acSrcDir = gradle."localProperties.autoPublish.android-components.dir"
-    apply from: "../${acSrcDir}/substitute-local-ac.gradle"
+    apply from: "${acSrcDir}/substitute-local-ac.gradle"
 }
 
 if (gradle.hasProperty('localProperties.autoPublish.application-services.dir')) {


### PR DESCRIPTION
Currently, this requires that the developer manually publish geckoview (and exoplayer2) first which is the whole point of what this feature was supposed to help us do.

```bash
# From your mozilla-central checkout
./mach gradle geckoview:publishDebugPublicationToMavenLocal exoplayer2:publishDebugPublicationToMavenLocal
```



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
