### PR TITLE
Fix incorrect reference to menuController in toolbar

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/ToolbarIntegration.kt
@@ -172,7 +172,7 @@ class ToolbarIntegration(
         )
     }
 
-    private val menuController: MenuController = BrowserMenuController()
+    private val browserMenuController: MenuController = BrowserMenuController()
 
     init {
         toolbar.display.apply {
@@ -181,7 +181,7 @@ class ToolbarIntegration(
                 DisplayToolbar.Indicators.TRACKING_PROTECTION,
             )
             displayIndicatorSeparator = true
-            menuController = menuController
+            menuController = browserMenuController
             hint = context.getString(R.string.toolbar_hint)
 
             setUrlBackground(
@@ -234,7 +234,7 @@ class ToolbarIntegration(
                 .map { state -> state.selectedTab }
                 .distinctUntilChanged()
                 .collect { tab ->
-                    menuController.submitList(menuItems(tab))
+                    browserMenuController.submitList(menuItems(tab))
                 }
         }
     }


### PR DESCRIPTION
The references were named the same so it didn't complain that it was using the same one to set itself. 😓 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
