### PR TITLE
Fix colours with removal of LightDark theme

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/ToolbarIntegration.kt
@@ -45,7 +45,6 @@ import org.mozilla.reference.browser.ext.components
 import org.mozilla.reference.browser.ext.share
 import org.mozilla.reference.browser.settings.SettingsActivity
 import org.mozilla.reference.browser.tabs.synced.SyncedTabsActivity
-import mozilla.components.ui.colors.R as colorsR
 
 @Suppress("LongParameterList")
 class ToolbarIntegration(
@@ -187,16 +186,10 @@ class ToolbarIntegration(
             setUrlBackground(
                 ResourcesCompat.getDrawable(context.resources, R.drawable.url_background, context.theme),
             )
-            colors = colors.copy(
-                text = ResourcesCompat.getColor(context.resources, colorsR.color.photonWhite, context.theme),
-            )
         }
 
         toolbar.edit.apply {
             hint = context.getString(R.string.toolbar_hint)
-            colors = colors.copy(
-                text = ResourcesCompat.getColor(context.resources, colorsR.color.photonWhite, context.theme),
-            )
         }
 
         ToolbarAutocompleteFeature(toolbar).apply {

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="AppThemeNotActionBar" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="AppThemeNotActionBar" parent="Theme.Material3.Dark.NoActionBar">
         <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
 
         <item name="colorPrimary">@color/dark</item>
@@ -15,7 +15,7 @@
         <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
     </style>
 
-    <style name="AppTheme" parent="Theme.Material3.DayNight">
+    <style name="AppTheme" parent="Theme.Material3.Dark">
         <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
 
         <item name="colorPrimary">@color/dark</item>


### PR DESCRIPTION
Undoing the changes from https://github.com/mozilla-mobile/reference-browser/pull/3878/commits/d4676e24a94538880e51da9fe1ee6e8b1a441ed3.

We only have a dark theme here so using LightDark theme was causing problems in different modes. We don't need to be fancy, so let's just remove that instead and only use the dark theme.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
