### PR TITLE
Update JaCoCo to version 0.8.14

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ ktlint = "1.7.1"
 
 # Third Party Testing
 hamcrest = "1.3"
-jacoco = "0.8.13"
+jacoco = "0.8.14"
 junit = "4.13.2"
 okhttp = "5.2.0"
 okio = "3.16.0"


### PR DESCRIPTION
Release notes: https://github.com/jacoco/jacoco/releases/tag/v0.8.14