### PR TITLE
Actualize Android version requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Make sure you use the same Google Account for both steps.
 
 Signed Nightly builds can be downloaded from:
 
-* [⬇️ ARM64/Aarch64 devices (64 bit; Android 5+)](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mobile.v2.reference-browser.nightly.latest.arm64-v8a/artifacts/public/target.arm64-v8a.apk)
-* [⬇️ ARM devices (32 bit; Android 5+)](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mobile.v2.reference-browser.nightly.latest.armeabi-v7a/artifacts/public/target.armeabi-v7a.apk)
-* [⬇️ x86_64  devices (64 bit; Android 5+)](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mobile.v2.reference-browser.nightly.latest.x86_64/artifacts/public/target.x86_64.apk)
+* [⬇️ ARM64/Aarch64 devices (64 bit; Android 8+)](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mobile.v2.reference-browser.nightly.latest.arm64-v8a/artifacts/public/target.arm64-v8a.apk)
+* [⬇️ ARM devices (32 bit; Android 8+)](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mobile.v2.reference-browser.nightly.latest.armeabi-v7a/artifacts/public/target.armeabi-v7a.apk)
+* [⬇️ x86_64  devices (64 bit; Android 8+)](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mobile.v2.reference-browser.nightly.latest.x86_64/artifacts/public/target.x86_64.apk)
 
 > Please note that these builds do not auto-update, you will have to keep up to date manually.
 


### PR DESCRIPTION
144 onward requires Android 8 (SDK 26) and up, so the linked packages won't install on older Android versions



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
