### PR TITLE
Bug 1647219 - let tests get retriggered rather than rerun

### DIFF
--- a/taskcluster/kinds/test/kind.yml
+++ b/taskcluster/kinds/test/kind.yml
@@ -31,6 +31,8 @@ task-defaults:
         docker-image: {in-tree: base}
         max-run-time: 7200
         chain-of-trust: true
+    attributes:
+        retrigger: true
 
 
 tasks:


### PR DESCRIPTION
Note: I'm not sure we should do this, because the pr-complete task depends on tests so if a test fails and we retrigger it the pr-complete task still won't go green.