### PR TITLE
Add AndroidX Lint to our linter configs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -179,6 +179,7 @@ project.configurations.configureEach {
 }
 
 dependencies {
+    lintChecks libs.androidx.lint
 
     // We pick up JNA transitively by way of Glean, which is currently on version 5.14.0.
     // However, we need to force version 5.17.0 due to Google Play's 16KB page size requirement.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ androidx-test-runner = "1.7.0"
 androidx-test-uiautomator = "2.4.0-beta02"
 
 # Third Party Linting & Static Code Analysis
+androidx-lint = "1.0.0-rc01"
 dependency-analysis = "3.10.0"
 detekt = "1.23.8"
 jspecify = "1.0.0"
@@ -104,6 +105,7 @@ androidx-test-runner = { group = "androidx.test", name = "runner", version.ref =
 androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidx-test-uiautomator" }
 
 # Third Party Linting & Static Code Analysis
+androidx-lint = { group = "androidx.lint", name = "lint-gradle", version.ref = "androidx-lint" }
 jspecify = { group = "org.jspecify", name = "jspecify", version.ref = "jspecify" }
 ktlint = { group = "com.pinterest.ktlint", name = "ktlint-cli", version.ref = "ktlint" }
 


### PR DESCRIPTION
AndroidX Lint adds some lint checks to verify usage of Gradle APIs to the existing lint job. Nothing of interest so far, but seems like a nice thing to add into the mix (which I also plan to explore for Gecko).
https://developer.android.com/jetpack/androidx/releases/lint#1.0.0-rc01