### PR TITLE
Bump Dependency Analysis Gradle Plugin to 3.14.0 and filter R-class duplicate warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,13 @@ dependencyAnalysis {
                 // We explicitly want to pull in these dependencies transitively from AC
                 exclude('org.mozilla.appservices.nightly:fxaclient', 'org.mozilla.geckoview:geckoview-nightly-omni')
             }
+            onDuplicateClassWarnings {
+                // Android R classes are duplicated by design between :app and its library
+                // dependencies, so they're not a real classpath conflict. Filter them out
+                // rather than disabling duplicate-class detection entirely.
+                // https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1335
+                excludeRegex('.*[./]R(\\$.*)?')
+            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,7 @@ androidx-test-uiautomator = "2.4.0-beta02"
 
 # Third Party Linting & Static Code Analysis
 androidx-lint = "1.0.0-rc01"
-dependency-analysis = "3.10.0"
+dependency-analysis = "3.14.0"
 detekt = "1.23.8"
 jspecify = "1.0.0"
 ktlint = "1.8.0"


### PR DESCRIPTION
`R` classes are duplicated by design between `:app` and its library dependencies (the app re-generates `R`/`R$id`/etc. for resources it references), so DAGP's duplicate-class detection flags them as false positives, e.g.:

```
androidx/appcompat/R is provided by multiple dependencies: [:app, androidx.appcompat:appcompat:1.7.1]
mozilla/components/browser/menu/R$id is provided by multiple dependencies: [:app, org.mozilla.components:browser-menu:...]
```

Rather than disabling duplicate-class detection entirely (which we still want for genuine classpath conflicts / supply-chain risks), this scopes an `excludeRegex` to just the `R` classes via the `onDuplicateClassWarnings` handler.

This is tracked upstream in autonomousapps/dependency-analysis-gradle-plugin#1335.