### PR TITLE
Update JaCoCo to version 0.8.15

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ ktlint = "1.8.0"
 
 # Third Party Testing
 hamcrest = "1.3"
-jacoco = "0.8.14"
+jacoco = "0.8.15"
 junit = "4.13.2"
 okhttp = "5.3.2"
 okio = "3.17.0"


### PR DESCRIPTION
Release notes: https://github.com/jacoco/jacoco/releases/tag/v0.8.15