### PR TITLE
Speed up and harden the android-gradle-dependencies toolchain task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,5 +221,8 @@ tasks.register('listRepositories') {
     doLast {
         println "Repositories:"
         project.repositories.each { println "Name: " + it.name + "; url: " + it.url }
+        // Plugin repositories have no url to report, being wrappers.
+        println "Buildscript repositories:"
+        buildscript.repositories.each { println "Name: " + it.name }
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,5 +7,15 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
+    // Mirrors the root project so that CI resolves through the local Nexus.
+    val centralRepo = providers.gradleProperty("centralRepo")
+    if (centralRepo.isPresent) {
+        maven {
+            name = "MavenCentral"
+            url = uri(centralRepo.get())
+            isAllowInsecureProtocol = true // Local Nexus in CI uses HTTP
+        }
+    } else {
+        mavenCentral()
+    }
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pluginManagement {
+    repositories {
+        // buildSrc resolves its plugins separately from the root project, and
+        // the Kotlin DSL plugin is only published to the plugin portal.
+        val pluginRepo = providers.gradleProperty("pluginRepo")
+        if (pluginRepo.isPresent) {
+            maven {
+                name = "GradlePlugins"
+                url = uri(pluginRepo.get())
+                isAllowInsecureProtocol = true // Local Nexus in CI uses HTTP
+            }
+        } else {
+            gradlePluginPortal()
+        }
+
+        val centralRepo = providers.gradleProperty("centralRepo")
+        if (centralRepo.isPresent) {
+            maven {
+                name = "MavenCentral"
+                url = uri(centralRepo.get())
+                isAllowInsecureProtocol = true // Local Nexus in CI uses HTTP
+            }
+        } else {
+            mavenCentral()
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,29 @@
 pluginManagement {
     repositories {
-        google()
-        mavenCentral()
+        // Without these, plugin resolution reaches past the local Nexus in CI to
+        // the real repositories, and whatever it fetches is missing from the
+        // android-gradle-dependencies artifact.
+        def googleRepo = providers.gradleProperty("googleRepo")
+        if (googleRepo.present) {
+            maven {
+                name "Google"
+                url googleRepo.get()
+                allowInsecureProtocol true // Local Nexus in CI uses HTTP
+            }
+        } else {
+            google()
+        }
+
+        def centralRepo = providers.gradleProperty("centralRepo")
+        if (centralRepo.present) {
+            maven {
+                name "MavenCentral"
+                url centralRepo.get()
+                allowInsecureProtocol true // Local Nexus in CI uses HTTP
+            }
+        } else {
+            mavenCentral()
+        }
     }
 }
 

--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -42,10 +42,11 @@ RUN apt-get update -qq \
                           locales \
                           unzip \
                           mercurial \
+                          zstd \
     && apt-get clean
 
 RUN pip3 install --upgrade pip
-RUN pip3 install taskcluster
+RUN pip3 install taskcluster zstandard
 
 RUN locale-gen "$LANG"
 

--- a/taskcluster/kinds/toolchain/android.yml
+++ b/taskcluster/kinds/toolchain/android.yml
@@ -41,7 +41,7 @@ linux64-android-gradle-dependencies:
             - 'gradle.properties'
             - 'gradle/**'
             - taskcluster/scripts/toolchain/android-gradle-dependencies/**
-        toolchain-artifact: public/build/android-gradle-dependencies.tar.xz
+        toolchain-artifact: public/build/android-gradle-dependencies.tar.zst
         toolchain-alias: android-gradle-dependencies
     treeherder:
         symbol: TL(gradle-dependencies)

--- a/taskcluster/kinds/toolchain/android.yml
+++ b/taskcluster/kinds/toolchain/android.yml
@@ -38,6 +38,7 @@ linux64-android-gradle-dependencies:
         resources:
             - '*.gradle'
             - 'app/*.gradle'
+            - 'buildSrc/**'
             - 'gradle.properties'
             - 'gradle/**'
             - taskcluster/scripts/toolchain/android-gradle-dependencies/**

--- a/taskcluster/rb_taskgraph/job.py
+++ b/taskcluster/rb_taskgraph/job.py
@@ -95,10 +95,14 @@ def _extract_gradlew_command(run, fetches_dir):
 
     maven_dependencies_dir = path.join(fetches_dir, "android-gradle-dependencies")
     gradle_repos_args = [
-        "-P{repo_name}Repo=file://{dir}/{repo_name}".format(
-            dir=maven_dependencies_dir, repo_name=repo_name
+        "-P{property_name}=file://{dir}/{repo_name}".format(
+            dir=maven_dependencies_dir, property_name=property_name, repo_name=repo_name
         )
-        for repo_name in ("google", "central")
+        for property_name, repo_name in (
+            ("centralRepo", "central"),
+            ("googleRepo", "google"),
+            ("pluginRepo", "gradle-plugins"),
+        )
     ]
     gradle_command = ["./gradlew"] + gradle_repos_args + ["listRepositories"] + run.pop("gradlew")
     post_gradle_commands = run.pop("post-gradlew", [])

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
@@ -28,7 +28,7 @@ GRADLE_FLAGS=(
 
 # Enumerates and downloads the dependencies of every resolvable configuration
 # without running the requested tasks.
-./gradlew "${GRADLE_FLAGS[@]}" --write-verification-metadata sha256 --dry-run assemble assembleAndroidTest bundle test lint ktlint detekt
+./gradlew "${GRADLE_FLAGS[@]}" --write-verification-metadata sha256 --dry-run detekt ktlint lint buildHealth build
 
 # AGP resolves the aapt2 binary while its tasks run, so the pass above misses it.
 ./gradlew "${GRADLE_FLAGS[@]}" :app:processDebugResources

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
@@ -19,7 +19,8 @@ pushd $PROJECT_DIR
 . taskcluster/scripts/toolchain/android-gradle-dependencies/before.sh
 
 GRADLE_FLAGS=(
-    --no-daemon
+    # Overrides the daemon=false the base image puts in GRADLE_OPTS.
+    --daemon
     --no-configuration-cache
     -Pcoverage
     -PgoogleRepo='http://localhost:8081/nexus/content/repositories/google/'
@@ -32,6 +33,9 @@ GRADLE_FLAGS=(
 
 # AGP resolves the aapt2 binary while its tasks run, so the pass above misses it.
 ./gradlew "${GRADLE_FLAGS[@]}" :app:processDebugResources
+
+# Don't leave a 4GB heap sitting there while `after.sh` packages everything up.
+./gradlew --stop
 
 . taskcluster/scripts/toolchain/android-gradle-dependencies/after.sh
 

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
@@ -23,8 +23,9 @@ GRADLE_FLAGS=(
     --daemon
     --no-configuration-cache
     -Pcoverage
-    -PgoogleRepo='http://localhost:8081/nexus/content/repositories/google/'
     -PcentralRepo='http://localhost:8081/nexus/content/repositories/central/'
+    -PgoogleRepo='http://localhost:8081/nexus/content/repositories/google/'
+    -PpluginRepo='http://localhost:8081/nexus/content/repositories/gradle-plugins/'
 )
 
 # Enumerates and downloads the dependencies of every resolvable configuration

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
@@ -18,8 +18,20 @@ pushd $PROJECT_DIR
 
 . taskcluster/scripts/toolchain/android-gradle-dependencies/before.sh
 
-# We build everything to be sure to fetch all dependencies
-./gradlew --no-daemon -Pcoverage -PgoogleRepo='http://localhost:8081/nexus/content/repositories/google/' -PcentralRepo='http://localhost:8081/nexus/content/repositories/central/' assemble assembleAndroidTest bundle test lint ktlint detekt
+GRADLE_FLAGS=(
+    --no-daemon
+    --no-configuration-cache
+    -Pcoverage
+    -PgoogleRepo='http://localhost:8081/nexus/content/repositories/google/'
+    -PcentralRepo='http://localhost:8081/nexus/content/repositories/central/'
+)
+
+# Enumerates and downloads the dependencies of every resolvable configuration
+# without running the requested tasks.
+./gradlew "${GRADLE_FLAGS[@]}" --write-verification-metadata sha256 --dry-run assemble assembleAndroidTest bundle test lint ktlint detekt
+
+# AGP resolves the aapt2 binary while its tasks run, so the pass above misses it.
+./gradlew "${GRADLE_FLAGS[@]}" :app:processDebugResources
 
 . taskcluster/scripts/toolchain/android-gradle-dependencies/after.sh
 

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies/after.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies/after.sh
@@ -23,6 +23,6 @@ mkdir -p android-gradle-dependencies /builds/worker/artifacts
 cp -R ${NEXUS_WORK}/storage/central android-gradle-dependencies
 cp -R ${NEXUS_WORK}/storage/google android-gradle-dependencies
 
-tar cf - android-gradle-dependencies | xz > /builds/worker/artifacts/android-gradle-dependencies.tar.xz
+tar cavf /builds/worker/artifacts/android-gradle-dependencies.tar.zst android-gradle-dependencies
 
 popd

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies/after.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies/after.sh
@@ -6,7 +6,7 @@
 
 # This is copy of
 # https://searchfox.org/mozilla-central/rev/2cd2d511c0d94a34fb7fa3b746f54170ee759e35/taskcluster/scripts/misc/android-gradle-dependencies/after.sh.
-# gradle-plugins was removed because it's not used in this project.
+# Later changes to that file have been picked up piecemeal.
 
 set -x -e
 
@@ -22,6 +22,10 @@ mkdir -p android-gradle-dependencies /builds/worker/artifacts
 
 cp -R ${NEXUS_WORK}/storage/central android-gradle-dependencies
 cp -R ${NEXUS_WORK}/storage/google android-gradle-dependencies
+cp -R ${NEXUS_WORK}/storage/gradle-plugins android-gradle-dependencies || {
+    echo "FATAL ERROR: no gradle-plugins storage. Did plugin resolution reach the proxy?"
+    exit 1
+}
 
 tar cavf /builds/worker/artifacts/android-gradle-dependencies.tar.zst android-gradle-dependencies
 

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies/after.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies/after.sh
@@ -16,6 +16,10 @@ echo "running as" $(id)
 
 set -v
 
+# Resolved before the `pushd` below leaves the project directory.
+DEPENDENCY_INVENTORY="$PWD/gradle/verification-metadata.dryrun.xml"
+VERIFY_DEPENDENCIES="$PWD/taskcluster/scripts/toolchain/android-gradle-dependencies/verify_dependencies.py"
+
 # Package everything up.
 pushd $WORKSPACE
 mkdir -p android-gradle-dependencies /builds/worker/artifacts
@@ -26,6 +30,15 @@ cp -R ${NEXUS_WORK}/storage/gradle-plugins android-gradle-dependencies || {
     echo "FATAL ERROR: no gradle-plugins storage. Did plugin resolution reach the proxy?"
     exit 1
 }
+
+# Bug 1953671: catch intermittently incomplete artifacts here rather than
+# downstream.
+# The Mozilla repositories in build.gradle are not proxied, so what they serve
+# is legitimately absent from the packaged tree.
+python3 "$VERIFY_DEPENDENCIES" --inventory "$DEPENDENCY_INVENTORY" \
+    --unproxied org/mozilla \
+    android-gradle-dependencies/central android-gradle-dependencies/google \
+    android-gradle-dependencies/gradle-plugins
 
 tar cavf /builds/worker/artifacts/android-gradle-dependencies.tar.zst android-gradle-dependencies
 

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies/verify_dependencies.py
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies/verify_dependencies.py
@@ -1,0 +1,170 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Check the packaged Gradle dependency cache against the inventory that
+`--write-verification-metadata` leaves behind, so that an incomplete artifact
+fails here rather than in a downstream task (bug 1953671).
+
+Some of what the inventory lists comes from repositories that aren't proxied
+through Nexus and so is expected to be absent from the packaged tree; --unproxied
+says which paths those are. Anything else absent, or any component packaged with
+one of its files missing, is a real fault.
+"""
+
+import argparse
+import hashlib
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def parse_inventory(path):
+    """Yield (relative_directory, {filename: sha256}) for each component."""
+    root = ET.parse(path).getroot()
+    for component in root.iter():
+        if not component.tag.endswith("component"):
+            continue
+        group = component.get("group")
+        name = component.get("name")
+        version = component.get("version")
+        if not (group and name and version):
+            continue
+
+        artifacts = {}
+        for artifact in component:
+            if not artifact.tag.endswith("artifact"):
+                continue
+            checksum = next(
+                (
+                    child.get("value")
+                    for child in artifact
+                    if child.tag.endswith("sha256")
+                ),
+                None,
+            )
+            artifacts[artifact.get("name")] = checksum
+
+        if artifacts:
+            yield Path(*group.split("."), name, version), artifacts
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for block in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def verify(inventory, repositories, unproxied):
+    problems = []
+    unpackaged = []
+    components = checked = artifacts = 0
+
+    for relative_dir, expected in inventory:
+        components += 1
+
+        # Downstream tasks are given every one of these as a repository, so an
+        # artifact only has to be in one of them.
+        directories = [
+            repository / relative_dir
+            for repository in repositories
+            if (repository / relative_dir).is_dir()
+        ]
+        if not directories:
+            if str(relative_dir).startswith(unproxied):
+                unpackaged.append(str(relative_dir))
+            else:
+                problems.append(f"absent: {relative_dir}")
+            continue
+
+        checked += 1
+        checksums = None
+        for filename, checksum in sorted(expected.items()):
+            found = next(
+                (d / filename for d in directories if (d / filename).is_file()), None
+            )
+            if found:
+                if checksum and sha256(found) != checksum:
+                    problems.append(f"corrupt: {found}")
+                else:
+                    artifacts += 1
+                continue
+
+            # The inventory records the file name from the module metadata,
+            # which for Kotlin Multiplatform is not the name the repository
+            # publishes it under. Fall back to matching the contents.
+            if checksums is None:
+                checksums = {
+                    sha256(path)
+                    for directory in directories
+                    for path in directory.iterdir()
+                    if path.is_file()
+                }
+            if checksum and checksum in checksums:
+                artifacts += 1
+            else:
+                problems.append(f"missing: {relative_dir}/{filename}")
+
+    return components, checked, artifacts, unpackaged, problems
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--inventory",
+        required=True,
+        type=Path,
+        help="verification-metadata.dryrun.xml written by the enumeration pass",
+    )
+    parser.add_argument(
+        "--unproxied",
+        action="append",
+        default=[],
+        metavar="PREFIX",
+        help="path prefix served by a repository that isn't proxied through "
+        "Nexus, so is expected to be absent from the packaged tree; repeatable",
+    )
+    parser.add_argument(
+        "repository",
+        nargs="+",
+        type=Path,
+        help="packaged repository directories to check, e.g. central google",
+    )
+    args = parser.parse_args()
+
+    if not args.inventory.is_file():
+        print(
+            f"FATAL ERROR: no inventory at {args.inventory}. Did the "
+            "enumeration pass run?"
+        )
+        return 1
+
+    components, checked, artifacts, unpackaged, problems = verify(
+        parse_inventory(args.inventory), args.repository, tuple(args.unproxied)
+    )
+    print(
+        f"verified {artifacts} artifacts across {checked} of {components} "
+        f"components; {len(unpackaged)} are not packaged, coming from a "
+        "repository we don't proxy"
+    )
+    for path in unpackaged:
+        print(f"  not packaged: {path}")
+
+    if not components:
+        print(f"FATAL ERROR: {args.inventory} lists no components at all.")
+        return 1
+
+    if problems:
+        print(f"FATAL ERROR: {len(problems)} absent, missing or corrupt:")
+        for problem in problems:
+            print(f"  {problem}")
+        print("The dependency cache is incomplete. Try re-running this task.")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The `android-gradle-dependencies` toolchain task currently builds the whole project just to populate the dependency cache. This stops it doing that, then closes the gaps that change exposed.

The first two commits port [bug 1977709](https://bugzilla.mozilla.org/show_bug.cgi?id=1977709) / [D257608](https://phabricator.services.mozilla.com/D257608) from mozilla-central. The rest picks up later changes to the upstream scripts that we never followed, plus two that are specific to this repo.

| commit | what |
| --- | --- |
| `ce3c15a3` | Enumerate dependencies rather than building everything |
| `de9403b1` | Request the task list CI actually runs |
| `26d6d865` | Package with zstd instead of xz |
| `d21af255` | Point buildSrc's dependencies at the local Nexus |
| `5506c867` | Share a daemon between the two Gradle passes |
| `f65cb2f4` | Point plugin resolution at the local Nexus too |
| `9b7a63cd` | Verify the packaged repositories against Gradle's inventory |

### Why one Gradle task still runs

mozilla-central gets away with running no Gradle tasks at all. We cannot. AGP resolves the aapt2 binary through a detached configuration while its tasks run, so the enumeration pass never sees it, and our downstream tasks are handed the packaged repository as their only `google()`. That makes a missing aapt2 a hard resolution failure. mozilla-central is unaffected because its builds resolve from `GRADLE_MAVEN_REPOSITORIES`, which normally points at the live remote repos.

`:app:processDebugResources` is the cheapest task that pulls aapt2 down. I confirmed it is both necessary and sufficient by deleting aapt2 from the Gradle cache and re-running the committed command.

### Why plugin resolution had to move too

Project dependencies already resolved through the proxies. Plugins did not, which left the artifact incomplete in a way that cannot be told apart from the packaging having dropped a file.

There were two holes. `pluginManagement` in `settings.gradle` declared `google()` and `mavenCentral()` outright, and Gradle contributes those to the buildscript classpath alongside the proxies, so resolution could take a component's pom through Nexus and its jar from the unproxied twin. buildSrc then resolves its own plugins separately again, from the plugin portal, which nothing pointed at Nexus.

This matters for the last commit. Until both holes were closed, the completeness check could not distinguish a real fault from a file that legitimately came from elsewhere, and would have had to tolerate both. `nexus.xml` already carried an unused `gradle-plugins` proxy for the portal, so this only had to point at it and package its storage.

### For reviewers

- **Downstream plugin resolution now comes from the artifact.** A gap there used to fall back to the network silently. It now fails at configuration time.
- **The base image changes, so images rebuild.** `zstd` is needed for `tar -a` and is priority optional on Ubuntu. `zstandard` is what run-task's `fetch-content` uses to unpack `.tar.zst`. Both `android-build` and `ui-tests` have `parent: base`, so one image covers producer and consumers.
- **The artifact is renamed to `.tar.zst`.** That name is part of the toolchain digest, so the toolchain regenerates and nothing reuses a cached `.tar.xz`.
- **`buildSrc/**` joins the task's `resources`.** buildSrc's classpath is part of the artifact now, and `*.gradle` does not match `.kts`.

### Testing

Green in CI, including every task that consumes the artifact: `build-debug`, `test-debug`, the four lint tasks and `signing-debug`.

- `build-debug` logs `__plugin_repository__MavenCentral`, so downstream really does resolve plugins through the packaged repository.
- The completeness check reports `verified 1430 artifacts across 825 of 923 components; 98 are not packaged`. All 98 are `org/mozilla`, which is what the two unproxied Mozilla repositories account for. Anything else absent, or any packaged component missing a file, fails the task.
- The enumeration pass takes 4m28s and the aapt2 pass 25s, the second reusing the warm daemon, for a 6m23s task.

### Pull Request checklist

- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

