### PR TITLE
Migrate from ktlint to ktfmt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,11 +4,4 @@ ij_kotlin_allow_trailing_comma=true
 
 [*]
 insert_final_newline = true
-max_line_length = 120 # same as detekt.yml
-ktlint_standard_expression-operand-wrapping = disabled
-
-# rules we should look into enabling
-ktlint_standard_function-naming = disabled
-ktlint_standard_indent = disabled
-ktlint_standard_multiline-expression-wrapping = disabled
-ktlint_standard_string-template-indent = disabled
+max_line_length = 120 # same as detekt.yml and ktfmt

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ out/
 .gradle/
 build/
 !taskcluster/ci/build
+gradle/verification-metadata.dryrun.xml
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ext/ViewGroup.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ext/ViewGroup.kt
@@ -7,8 +7,6 @@ package org.mozilla.reference.browser.ext
 import android.view.View
 import android.view.ViewGroup
 
-/**
- * The [ViewGroup] children as an [Iterable] on [View]s
- */
+/** The [ViewGroup] children as an [Iterable] on [View]s */
 val ViewGroup.children: Iterable<View>
     get() = (0 until childCount).map(this::getChildAt)

--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/Assert.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/Assert.kt
@@ -9,9 +9,8 @@ import android.graphics.Color
 import org.junit.Assert.assertEquals
 
 /**
- * Asserts the two bitmaps are the same by ensuring their dimensions, config, and
- * pixel data are the same (within the provided delta): this is the same metrics that
- * [Bitmap.sameAs] uses.
+ * Asserts the two bitmaps are the same by ensuring their dimensions, config, and pixel data are the same (within the
+ * provided delta): this is the same metrics that [Bitmap.sameAs] uses.
  */
 fun assertEqualsWithDelta(
     expectedB: Bitmap,

--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/BrowserActivityTestRule.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/BrowserActivityTestRule.kt
@@ -9,18 +9,15 @@ import androidx.test.espresso.IdlingRegistry
 import org.junit.rules.ExternalResource
 import org.mozilla.reference.browser.BrowserActivity
 
-/**
- * A [org.junit.Rule] to handle shared test set up for tests on [BrowserActivity].
- */
+/** A [org.junit.Rule] to handle shared test set up for tests on [BrowserActivity]. */
 class BrowserActivityTestRule : ExternalResource() {
     /**
      * Ensures the test doesn't advance until session page load is completed.
      *
-     * N.B.: in the current implementation, tests pass without this so it seems to be
-     * unnecessary: I think this is because the progress bar animation acts as the
-     * necessary idling resource. However, we leave this in just in case the
-     * implementation changes and the tests break. In that case, this code might be
-     * broken because it's not used, and thus tested, at present.
+     * N.B.: in the current implementation, tests pass without this so it seems to be unnecessary: I think this is
+     * because the progress bar animation acts as the necessary idling resource. However, we leave this in just in case
+     * the implementation changes and the tests break. In that case, this code might be broken because it's not used,
+     * and thus tested, at present.
      */
     private lateinit var loadingIdlingResource: SessionLoadedIdlingResource
     private lateinit var scenario: ActivityScenario<BrowserActivity>
@@ -33,9 +30,10 @@ class BrowserActivityTestRule : ExternalResource() {
         }
 
     override fun before() {
-        loadingIdlingResource = SessionLoadedIdlingResource().also {
-            IdlingRegistry.getInstance().register(it)
-        }
+        loadingIdlingResource =
+            SessionLoadedIdlingResource().also {
+                IdlingRegistry.getInstance().register(it)
+            }
         scenario = ActivityScenario.launch(BrowserActivity::class.java)
     }
 

--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/Matchers.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/Matchers.kt
@@ -6,69 +6,58 @@ package org.mozilla.reference.browser.helpers
 
 import android.view.View
 import android.view.ViewGroup
+import androidx.test.espresso.matcher.ViewMatchers.isChecked as espressoIsChecked
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled as espressoIsEnabled
+import androidx.test.espresso.matcher.ViewMatchers.isSelected as espressoIsSelected
 import org.hamcrest.BaseMatcher
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.mozilla.reference.browser.ext.children
-import androidx.test.espresso.matcher.ViewMatchers.isChecked as espressoIsChecked
-import androidx.test.espresso.matcher.ViewMatchers.isEnabled as espressoIsEnabled
-import androidx.test.espresso.matcher.ViewMatchers.isSelected as espressoIsSelected
 
-/**
- * The [espressoIsEnabled] function that can also handle disabled state through the boolean argument.
- */
+/** The [espressoIsEnabled] function that can also handle disabled state through the boolean argument. */
 fun isEnabled(isEnabled: Boolean): Matcher<View> = maybeInvertMatcher(espressoIsEnabled(), isEnabled)
 
-/**
- * The [espressoIsChecked] function that can also handle unchecked state through the boolean argument.
- */
+/** The [espressoIsChecked] function that can also handle unchecked state through the boolean argument. */
 fun isChecked(isChecked: Boolean): Matcher<View> = maybeInvertMatcher(espressoIsChecked(), isChecked)
 
-/**
- * The [espressoIsSelected] function that can also handle not selected state through the boolean argument.
- */
+/** The [espressoIsSelected] function that can also handle not selected state through the boolean argument. */
 fun isSelected(isSelected: Boolean): Matcher<View> = maybeInvertMatcher(espressoIsSelected(), isSelected)
 
 /**
- * Matches a View if there is a single View, grandson of the same grandfather, that matches the
- * given matcher.
+ * Matches a View if there is a single View, grandson of the same grandfather, that matches the given matcher.
  *
  * @param matcher The matcher that our view cousins will be checked against to
  */
 fun hasCousin(matcher: Matcher<View>): Matcher<View> =
     object : BaseMatcher<View>() {
-    override fun describeTo(description: Description?) {
-        description?.apply {
-            appendText("has cousin that matches: ")
-            matcher.describeTo(description)
+        override fun describeTo(description: Description?) {
+            description?.apply {
+                appendText("has cousin that matches: ")
+                matcher.describeTo(description)
+            }
+        }
+
+        override fun matches(item: Any?): Boolean {
+            val parent = (item as? View)?.parent
+            val grandParent = parent?.parent as? ViewGroup
+            return grandParent
+                ?.children
+                ?.filter { v -> v != parent && v is ViewGroup }
+                ?.filter(matchChildren(matcher))
+                ?.count() == 1
+        }
+
+        private fun matchChildren(matcher: Matcher<View>): (View?) -> Boolean = {
+            (it as? ViewGroup)?.children?.filter { v -> matcher.matches(v) }?.count() == 1
         }
     }
-
-    override fun matches(item: Any?): Boolean {
-        val parent = (item as? View)?.parent
-        val grandParent = parent?.parent as? ViewGroup
-        return grandParent
-            ?.children
-            ?.filter { v -> v != parent && v is ViewGroup }
-            ?.filter(matchChildren(matcher))
-            ?.count() == 1
-    }
-
-    private fun matchChildren(matcher: Matcher<View>): (View?) -> Boolean =
-        {
-        (it as? ViewGroup)
-            ?.children
-            ?.filter { v -> matcher.matches(v) }
-            ?.count() == 1
-    }
-}
 
 private fun maybeInvertMatcher(
     matcher: Matcher<View>,
     useUnmodifiedMatcher: Boolean,
 ): Matcher<View> =
     when {
-    useUnmodifiedMatcher -> matcher
-    else -> not(matcher)
-}
+        useUnmodifiedMatcher -> matcher
+        else -> not(matcher)
+    }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/MockWebServer.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/MockWebServer.kt
@@ -7,6 +7,8 @@ package org.mozilla.reference.browser.helpers
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
+import java.io.IOException
+import java.io.InputStream
 import mockwebserver3.Dispatcher
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
@@ -14,8 +16,6 @@ import mockwebserver3.RecordedRequest
 import okio.Buffer
 import okio.source
 import org.mozilla.reference.browser.helpers.ext.toUri
-import java.io.IOException
-import java.io.InputStream
 
 object MockWebServerHelper {
     fun initMockWebServerAndReturnEndpoints(vararg messages: String): List<Uri> {
@@ -35,9 +35,7 @@ object MockWebServerHelper {
     }
 }
 
-/**
- * A [MockWebServer] [Dispatcher] that will return Android assets in the body of requests.
- */
+/** A [MockWebServer] [Dispatcher] that will return Android assets in the body of requests. */
 const val HTTP_OK = 200
 const val HTTP_NOT_FOUND = 404
 
@@ -45,9 +43,7 @@ class AndroidAssetDispatcher : Dispatcher() {
     private val mainThreadHandler = Handler(Looper.getMainLooper())
 
     override fun dispatch(request: RecordedRequest): MockResponse {
-        val assetManager = androidx.test.platform.app.InstrumentationRegistry
-            .getInstrumentation()
-            .context.assets
+        val assetManager = androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().context.assets
 
         return try {
             val assetPath = request.url.encodedPath.removePrefix("/")
@@ -68,8 +64,7 @@ private fun fileToResponse(
     path: String,
     file: InputStream,
 ): MockResponse =
-    MockResponse
-        .Builder()
+    MockResponse.Builder()
         .code(HTTP_OK)
         .body(fileToBytes(file)!!)
         .addHeader("content-type: " + contentType(path))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/RetryTestRule.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/RetryTestRule.kt
@@ -6,38 +6,35 @@ package org.mozilla.reference.browser.helpers
 
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.uiautomator.UiObjectNotFoundException
+import java.lang.AssertionError
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
-import java.lang.AssertionError
 
-class RetryTestRule(
-    private val retryCount: Int = 5,
-) : TestRule {
+class RetryTestRule(private val retryCount: Int = 5) : TestRule {
     override fun apply(
         base: Statement,
         description: Description,
-    ): Statement =
-        statement {
-            for (i in 1..retryCount) {
-                try {
-                    base.evaluate()
-                    break
-                } catch (t: AssertionError) {
-                    if (i == retryCount) {
-                        throw t
-                    }
-                } catch (t: UiObjectNotFoundException) {
-                    if (i == retryCount) {
-                        throw t
-                    }
-                } catch (t: NoMatchingViewException) {
-                    if (i == retryCount) {
-                        throw t
-                    }
+    ): Statement = statement {
+        for (i in 1..retryCount) {
+            try {
+                base.evaluate()
+                break
+            } catch (t: AssertionError) {
+                if (i == retryCount) {
+                    throw t
+                }
+            } catch (t: UiObjectNotFoundException) {
+                if (i == retryCount) {
+                    throw t
+                }
+            } catch (t: NoMatchingViewException) {
+                if (i == retryCount) {
+                    throw t
                 }
             }
         }
+    }
 
     private inline fun statement(crossinline eval: () -> Unit): Statement =
         object : Statement() {

--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/SessionLoadedIdlingResource.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/SessionLoadedIdlingResource.kt
@@ -10,25 +10,21 @@ import mozilla.components.browser.state.selector.selectedTab
 import org.mozilla.reference.browser.BrowserApplication
 
 /**
- * An IdlingResource implementation that waits until the current session is not loading anymore.
- * Only after loading has completed further actions will be performed.
+ * An IdlingResource implementation that waits until the current session is not loading anymore. Only after loading has
+ * completed further actions will be performed.
  */
-
 class SessionLoadedIdlingResource : IdlingResource {
     private var resourceCallback: IdlingResource.ResourceCallback? = null
 
     override fun getName(): String = SessionLoadedIdlingResource::class.java.simpleName
 
     override fun isIdleNow(): Boolean {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-            as BrowserApplication
+        val context =
+            InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as BrowserApplication
 
         val store = context.components.core.store
 
-        return if (store.state.selectedTab
-            ?.content
-            ?.loading == true
-        ) {
+        return if (store.state.selectedTab?.content?.loading == true) {
             false
         } else {
             invokeCallback()

--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/TestAssetHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/TestAssetHelper.kt
@@ -5,13 +5,11 @@
 package org.mozilla.reference.browser.helpers
 
 import android.net.Uri
+import java.util.concurrent.TimeUnit
 import mockwebserver3.MockWebServer
 import org.mozilla.reference.browser.helpers.ext.toUri
-import java.util.concurrent.TimeUnit
 
-/**
- * Helper for hosting web pages locally for testing purposes.
- */
+/** Helper for hosting web pages locally for testing purposes. */
 object TestAssetHelper {
     val waitingTime: Long = TimeUnit.SECONDS.toMillis(15)
     val waitingTimeShort: Long = TimeUnit.SECONDS.toMillis(1)
@@ -23,12 +21,10 @@ object TestAssetHelper {
     )
 
     /**
-     * Hosts 3 simple websites, found at androidTest/assets/pages/generic[1|2|3].html
-     * Returns a list of TestAsset, which can be used to navigate to each and
-     * assert that the correct information is being displayed.
+     * Hosts 3 simple websites, found at androidTest/assets/pages/generic[1|2|3].html Returns a list of TestAsset, which
+     * can be used to navigate to each and assert that the correct information is being displayed.
      *
-     * Content for these pages all follow the same pattern. See [generic1.html] for
-     * content implementation details.
+     * Content for these pages all follow the same pattern. See [generic1.html] for content implementation details.
      */
     fun getGenericAssets(server: MockWebServer): List<TestAsset> =
         (1..4).map {

--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/TestHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/TestHelper.kt
@@ -47,20 +47,18 @@ object TestHelper {
         pageUrl: String,
         customActionButtonDescription: String = "",
     ): Intent {
-        val appContext = InstrumentationRegistry
-            .getInstrumentation()
-            .targetContext
-            .applicationContext
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
         val pendingIntent = PendingIntent.getActivity(appContext, 0, Intent(), PendingIntent.FLAG_IMMUTABLE)
-        val customTabsIntent = CustomTabsIntent
-            .Builder()
-            .setShareState(CustomTabsIntent.SHARE_STATE_ON)
-            .setActionButton(
-                createTestBitmap(),
-                customActionButtonDescription,
-                pendingIntent,
-                true,
-            ).build()
+        val customTabsIntent =
+            CustomTabsIntent.Builder()
+                .setShareState(CustomTabsIntent.SHARE_STATE_ON)
+                .setActionButton(
+                    createTestBitmap(),
+                    customActionButtonDescription,
+                    pendingIntent,
+                    true,
+                )
+                .build()
         customTabsIntent.intent.data = Uri.parse(pageUrl)
         return customTabsIntent.intent
     }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/ext/String.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/ext/String.kt
@@ -10,7 +10,7 @@ import android.net.Uri
 
 fun String?.toUri(): Uri? =
     if (this == null) {
-    null
-} else {
-    Uri.parse(this)
-}
+        null
+    } else {
+        Uri.parse(this)
+    }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/helpers/matchers/TabMatcher.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/helpers/matchers/TabMatcher.kt
@@ -11,9 +11,7 @@ import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
 import org.mozilla.reference.browser.R
 
-/**
- * A custom matcher for finding tabs to match text within them.
- */
+/** A custom matcher for finding tabs to match text within them. */
 class TabMatcher<T : View>(
     val id: Int,
     val matcher: (T) -> Boolean,
@@ -35,9 +33,7 @@ class TabMatcher<T : View>(
 
     companion object {
         fun withText(text: String): Matcher<View> =
-            TabMatcher<View>(
-                R.id.mozac_browser_tabstray_title,
-            ) {
+            TabMatcher<View>(R.id.mozac_browser_tabstray_title) {
                 (it as TextView).text == text
             }
     }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/AddonsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/AddonsTest.kt
@@ -17,19 +17,17 @@ import org.mozilla.reference.browser.ui.robots.navigationToolbar
 class AddonsTest {
     private lateinit var mockWebServer: MockWebServer
 
-    @get:Rule
-    val activityTestRule = BrowserActivityTestRule()
+    @get:Rule val activityTestRule = BrowserActivityTestRule()
 
-    @Rule
-    @JvmField
-    val retryTestRule = RetryTestRule(3)
+    @Rule @JvmField val retryTestRule = RetryTestRule(3)
 
     @Before
     fun setUp() {
-        mockWebServer = MockWebServer().apply {
-            dispatcher = AndroidAssetDispatcher()
-            start()
-        }
+        mockWebServer =
+            MockWebServer().apply {
+                dispatcher = AndroidAssetDispatcher()
+                start()
+            }
     }
 
     @After
@@ -39,74 +37,74 @@ class AddonsTest {
 
     @Test
     fun addonsListingPageTest() {
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openAddonsManager {
-            verifyAddonsRecommendedView()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openAddonsManager {
+                verifyAddonsRecommendedView()
+            }
     }
 
     @Test
     fun cancelAddonInstallTest() {
         val addonName = "uBlock Origin"
 
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openAddonsManager {
-            clickInstallAddonButton(addonName)
-            verifyInstallAddonPrompt(addonName)
-            clickCancelInstallButton()
-            verifyAddonsRecommendedView()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openAddonsManager {
+                clickInstallAddonButton(addonName)
+                verifyInstallAddonPrompt(addonName)
+                clickCancelInstallButton()
+                verifyAddonsRecommendedView()
+            }
     }
 
     @Test
     fun installAddonTest() {
         val addonName = "uBlock Origin"
 
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openAddonsManager {
-            clickInstallAddonButton(addonName)
-            verifyInstallAddonPrompt(addonName)
-            clickAllowInstallAddonButton()
-            waitForAddonDownloadComplete()
-            verifyAddonDownloadCompletedPrompt(addonName)
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openAddonsManager {
+                clickInstallAddonButton(addonName)
+                verifyInstallAddonPrompt(addonName)
+                clickAllowInstallAddonButton()
+                waitForAddonDownloadComplete()
+                verifyAddonDownloadCompletedPrompt(addonName)
+            }
     }
 
     @Test
     fun verifyAddonElementsTest() {
         val addonName = "uBlock Origin"
 
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openAddonsManager {
-            verifyAddonsRecommendedView()
-            clickInstallAddonButton(addonName)
-            clickAllowInstallAddonButton()
-            waitForAddonDownloadComplete()
-            dismissAddonDownloadCompletedPrompt(addonName)
-            openAddon(addonName)
-            verifyAddonElementsView(addonName)
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openAddonsManager {
+                verifyAddonsRecommendedView()
+                clickInstallAddonButton(addonName)
+                clickAllowInstallAddonButton()
+                waitForAddonDownloadComplete()
+                dismissAddonDownloadCompletedPrompt(addonName)
+                openAddon(addonName)
+                verifyAddonElementsView(addonName)
+            }
     }
 
     @Test
     fun removeAddonTest() {
         val addonName = "uBlock Origin"
 
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openAddonsManager {
-            verifyAddonsRecommendedView()
-            clickInstallAddonButton(addonName)
-            clickAllowInstallAddonButton()
-            waitForAddonDownloadComplete()
-            dismissAddonDownloadCompletedPrompt(addonName)
-            openAddon(addonName)
-            clickRemoveAddonButton()
-            verifyAddonsRecommendedView()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openAddonsManager {
+                verifyAddonsRecommendedView()
+                clickInstallAddonButton(addonName)
+                clickAllowInstallAddonButton()
+                waitForAddonDownloadComplete()
+                dismissAddonDownloadCompletedPrompt(addonName)
+                openAddon(addonName)
+                clickRemoveAddonButton()
+                verifyAddonsRecommendedView()
+            }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ContextMenusTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ContextMenusTest.kt
@@ -21,19 +21,17 @@ import org.mozilla.reference.browser.ui.robots.navigationToolbar
 class ContextMenusTest {
     private lateinit var mockWebServer: MockWebServer
 
-    @get:Rule
-    val activityTestRule = BrowserActivityTestRule()
+    @get:Rule val activityTestRule = BrowserActivityTestRule()
 
-    @Rule
-    @JvmField
-    val retryTestRule = RetryTestRule(3)
+    @Rule @JvmField val retryTestRule = RetryTestRule(3)
 
     @Before
     fun setUp() {
-        mockWebServer = MockWebServer().apply {
-            dispatcher = AndroidAssetDispatcher()
-            start()
-        }
+        mockWebServer =
+            MockWebServer().apply {
+                dispatcher = AndroidAssetDispatcher()
+                start()
+            }
 
         // Prevent the System UI from reading the clipboard content
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
@@ -55,11 +53,11 @@ class ContextMenusTest {
     fun verifyLinkContextMenuItems() {
         val pageLinks = TestAssetHelper.getGenericAsset(mockWebServer, 4)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(pageLinks.url) {
-            longClickMatchingText("Link 1")
-            verifyLinkContextMenuItems()
-        }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(pageLinks.url) {
+                longClickMatchingText("Link 1")
+                verifyLinkContextMenuItems()
+            }
     }
 
     @Test
@@ -67,18 +65,18 @@ class ContextMenusTest {
         val pageLinks = TestAssetHelper.getGenericAsset(mockWebServer, 4)
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(pageLinks.url) {
-            longClickMatchingText("Link 1")
-            clickContextOpenLinkInNewTab()
-            clickSnackbarSwitchButton()
-        }
-        navigationToolbar {
-        }.openTabTrayMenu {
-            verifyRegularBrowsingTab()
-            verifyExistingOpenTabs(pageLinks.title)
-            verifyExistingOpenTabs(genericURL.title)
-        }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(pageLinks.url) {
+                longClickMatchingText("Link 1")
+                clickContextOpenLinkInNewTab()
+                clickSnackbarSwitchButton()
+            }
+        navigationToolbar {}
+            .openTabTrayMenu {
+                verifyRegularBrowsingTab()
+                verifyExistingOpenTabs(pageLinks.title)
+                verifyExistingOpenTabs(genericURL.title)
+            }
     }
 
     @Test
@@ -86,18 +84,18 @@ class ContextMenusTest {
         val pageLinks = TestAssetHelper.getGenericAsset(mockWebServer, 4)
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(pageLinks.url) {
-            longClickMatchingText("Link 1")
-            clickContextOpenLinkInPrivateTab()
-            clickSnackbarSwitchButton()
-        }
-        navigationToolbar {
-        }.openTabTrayMenu {
-            openPrivateBrowsing()
-            verifyPrivateBrowsingTab()
-            verifyExistingOpenTabs(genericURL.title)
-        }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(pageLinks.url) {
+                longClickMatchingText("Link 1")
+                clickContextOpenLinkInPrivateTab()
+                clickSnackbarSwitchButton()
+            }
+        navigationToolbar {}
+            .openTabTrayMenu {
+                openPrivateBrowsing()
+                verifyPrivateBrowsingTab()
+                verifyExistingOpenTabs(genericURL.title)
+            }
     }
 
     @Test
@@ -105,16 +103,16 @@ class ContextMenusTest {
         val pageLinks = TestAssetHelper.getGenericAsset(mockWebServer, 4)
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(pageLinks.url) {
-            longClickMatchingText("Link 1")
-            clickContextCopyLink()
-            waitUntilCopyLinkSnackbarIsGone()
-        }
-        navigationToolbar {
-        }.clickToolbar {
-            pasteAndLoadCopiedLink()
-        }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(pageLinks.url) {
+                longClickMatchingText("Link 1")
+                clickContextCopyLink()
+                waitUntilCopyLinkSnackbarIsGone()
+            }
+        navigationToolbar {}
+            .clickToolbar {
+                pasteAndLoadCopiedLink()
+            }
 
         browser {
             verifyUrl(genericURL.url.toString())
@@ -125,45 +123,46 @@ class ContextMenusTest {
     fun contextShareLinkTest() {
         val pageLinks = TestAssetHelper.getGenericAsset(mockWebServer, 4)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(pageLinks.url) {
-            longClickMatchingText("Link 1")
-        }.clickContextShareLink {
-            verifyShareContentPanel()
-        }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(pageLinks.url) {
+                longClickMatchingText("Link 1")
+            }
+            .clickContextShareLink {
+                verifyShareContentPanel()
+            }
     }
 
     @Test
     fun copyTextTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(genericURL.url) {
-            longClickAndCopyText("content")
-        }
-        navigationToolbar {
-        }.clickToolbar {
-            clickClearToolbarButton()
-            longClickToolbar()
-            clickPasteText()
-            verifyPastedToolbarText("content")
-        }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(genericURL.url) {
+                longClickAndCopyText("content")
+            }
+        navigationToolbar {}
+            .clickToolbar {
+                clickClearToolbarButton()
+                longClickToolbar()
+                clickPasteText()
+                verifyPastedToolbarText("content")
+            }
     }
 
     @Test
     fun selectAllAndCopyTextTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(genericURL.url) {
-            longClickAndCopyText("content", true)
-        }
-        navigationToolbar {
-        }.clickToolbar {
-            clickClearToolbarButton()
-            longClickToolbar()
-            clickPasteText()
-            verifyPastedToolbarText("Page content: 1")
-        }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(genericURL.url) {
+                longClickAndCopyText("content", true)
+            }
+        navigationToolbar {}
+            .clickToolbar {
+                clickClearToolbarButton()
+                longClickToolbar()
+                clickPasteText()
+                verifyPastedToolbarText("Page content: 1")
+            }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/CustomTabsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/CustomTabsTest.kt
@@ -23,32 +23,31 @@ import org.mozilla.reference.browser.ui.robots.customTabScreen
 class CustomTabsTest {
     private lateinit var mockWebServer: MockWebServer
 
-    @get:Rule
-    val activityTestRule = BrowserActivityTestRule()
+    @get:Rule val activityTestRule = BrowserActivityTestRule()
 
-    @Rule
-    @JvmField
-    val retryTestRule = RetryTestRule(3)
+    @Rule @JvmField val retryTestRule = RetryTestRule(3)
 
     // ActivityScenario.launch resolves intents via normal Android routing, so an ACTION_VIEW
     // intent with an HTTP URL would resolve to the browser rather than IntentReceiverActivity.
     // Setting the component explicitly forces it to launch within the test process.
     private fun launchCustomTab(pageUrl: String) =
         ActivityScenario.launch<IntentReceiverActivity>(
-        createCustomTabIntent(pageUrl).apply {
-            component = ComponentName(
-                InstrumentationRegistry.getInstrumentation().targetContext,
-                IntentReceiverActivity::class.java,
-            )
-        },
-    )
+            createCustomTabIntent(pageUrl).apply {
+                component =
+                    ComponentName(
+                        InstrumentationRegistry.getInstrumentation().targetContext,
+                        IntentReceiverActivity::class.java,
+                    )
+            }
+        )
 
     @Before
     fun setUp() {
-        mockWebServer = MockWebServer().apply {
-            dispatcher = AndroidAssetDispatcher()
-            start()
-        }
+        mockWebServer =
+            MockWebServer().apply {
+                dispatcher = AndroidAssetDispatcher()
+                start()
+            }
     }
 
     @After
@@ -78,16 +77,16 @@ class CustomTabsTest {
         val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         launchCustomTab(customTabPage.url.toString()).use {
-            customTabScreen {
-            }.openMainMenu {
-                verifyForwardButton()
-                verifyRefreshButton()
-                verifyStopButton()
-                verifyShareButton()
-                verifyRequestDesktopButton()
-                verifyFindInPageButton()
-                verifyOpenInBrowserButton()
-            }
+            customTabScreen {}
+                .openMainMenu {
+                    verifyForwardButton()
+                    verifyRefreshButton()
+                    verifyStopButton()
+                    verifyShareButton()
+                    verifyRequestDesktopButton()
+                    verifyFindInPageButton()
+                    verifyOpenInBrowserButton()
+                }
         }
     }
 
@@ -101,14 +100,16 @@ class CustomTabsTest {
                 clickGenericLink("Link 1")
                 verifyPageTitle(genericURL.title)
                 verifyPageUrl(genericURL.url.toString())
-            }.goBack {
-                verifyPageTitle(pageLinks.title)
-                verifyPageUrl(pageLinks.url.toString())
-            }.openMainMenu {
-                clickForwardButton()
-                verifyPageTitle(genericURL.title)
-                verifyPageUrl(genericURL.url.toString())
             }
+                .goBack {
+                    verifyPageTitle(pageLinks.title)
+                    verifyPageUrl(pageLinks.url.toString())
+                }
+                .openMainMenu {
+                    clickForwardButton()
+                    verifyPageTitle(genericURL.title)
+                    verifyPageUrl(genericURL.url.toString())
+                }
         }
     }
 
@@ -117,11 +118,11 @@ class CustomTabsTest {
         val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         launchCustomTab(customTabPage.url.toString()).use {
-            customTabScreen {
-            }.openMainMenu {
-            }.clickShareButton {
-                verifyShareContentPanel()
-            }
+            customTabScreen {}
+                .openMainMenu {}
+                .clickShareButton {
+                    verifyShareContentPanel()
+                }
         }
     }
 
@@ -130,15 +131,17 @@ class CustomTabsTest {
         val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         launchCustomTab(customTabPage.url.toString()).use {
-            customTabScreen {
-            }.openMainMenu {
-                switchRequestDesktopSiteToggle()
-            }.openMainMenu {
-                verifyRequestDesktopSiteIsTurnedOn()
-                switchRequestDesktopSiteToggle()
-            }.openMainMenu {
-                verifyRequestDesktopSiteIsTurnedOff()
-            }
+            customTabScreen {}
+                .openMainMenu {
+                    switchRequestDesktopSiteToggle()
+                }
+                .openMainMenu {
+                    verifyRequestDesktopSiteIsTurnedOn()
+                    switchRequestDesktopSiteToggle()
+                }
+                .openMainMenu {
+                    verifyRequestDesktopSiteIsTurnedOff()
+                }
         }
     }
 
@@ -147,11 +150,11 @@ class CustomTabsTest {
         val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         launchCustomTab(customTabPage.url.toString()).use {
-            customTabScreen {
-            }.openMainMenu {
-            }.clickOpenInBrowserButton {
-                verifyUrl(customTabPage.url.toString())
-            }
+            customTabScreen {}
+                .openMainMenu {}
+                .clickOpenInBrowserButton {
+                    verifyUrl(customTabPage.url.toString())
+                }
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/DownloadTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/DownloadTest.kt
@@ -21,19 +21,17 @@ import org.mozilla.reference.browser.ui.robots.notificationShade
 class DownloadTest {
     private lateinit var mockWebServer: MockWebServer
 
-    @get:Rule
-    val activityTestRule = BrowserActivityTestRule()
+    @get:Rule val activityTestRule = BrowserActivityTestRule()
 
-    @Rule
-    @JvmField
-    val retryTestRule = RetryTestRule(3)
+    @Rule @JvmField val retryTestRule = RetryTestRule(3)
 
     @Before
     fun setUp() {
-        mockWebServer = MockWebServer().apply {
-            dispatcher = AndroidAssetDispatcher()
-            start()
-        }
+        mockWebServer =
+            MockWebServer().apply {
+                dispatcher = AndroidAssetDispatcher()
+                start()
+            }
     }
 
     @After
@@ -46,8 +44,7 @@ class DownloadTest {
         val downloadPage = TestAssetHelper.getDownloadAsset(mockWebServer)
         val downloadFileName = "web_icon.png"
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(downloadPage.url) {}
+        navigationToolbar {}.enterUrlAndEnterToBrowser(downloadPage.url) {}
 
         downloadRobot {
             cancelDownload()
@@ -55,7 +52,8 @@ class DownloadTest {
 
         notificationShade {
             verifyDownloadNotificationDoesNotExist("Download completed", downloadFileName)
-        }.closeNotification {}
+        }
+            .closeNotification {}
     }
 
     @Ignore("Disabled - https://github.com/mozilla-mobile/reference-browser/issues/2130")
@@ -64,8 +62,7 @@ class DownloadTest {
         val downloadPage = TestAssetHelper.getDownloadAsset(mockWebServer)
         val downloadFileName = "web_icon.png"
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(downloadPage.url) {}
+        navigationToolbar {}.enterUrlAndEnterToBrowser(downloadPage.url) {}
 
         downloadRobot {
             confirmDownload()
@@ -73,6 +70,7 @@ class DownloadTest {
 
         notificationShade {
             verifyDownloadNotificationExist("Download completed", downloadFileName)
-        }.closeNotification {}
+        }
+            .closeNotification {}
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/MediaPlaybackTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/MediaPlaybackTest.kt
@@ -19,19 +19,17 @@ import org.mozilla.reference.browser.ui.robots.notificationShade
 class MediaPlaybackTest {
     private lateinit var mockWebServer: MockWebServer
 
-    @get:Rule
-    val activityTestRule = BrowserActivityTestRule()
+    @get:Rule val activityTestRule = BrowserActivityTestRule()
 
-    @Rule
-    @JvmField
-    val retryTestRule = RetryTestRule(3)
+    @Rule @JvmField val retryTestRule = RetryTestRule(3)
 
     @Before
     fun setUp() {
-        mockWebServer = MockWebServer().apply {
-            dispatcher = AndroidAssetDispatcher()
-            start()
-        }
+        mockWebServer =
+            MockWebServer().apply {
+                dispatcher = AndroidAssetDispatcher()
+                start()
+            }
     }
 
     @After
@@ -43,45 +41,47 @@ class MediaPlaybackTest {
     fun audioPlaybackTest() {
         val audioTestPage = TestAssetHelper.getAudioPageAsset(mockWebServer)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(audioTestPage.url) {
-            verifyMediaPlayerControlButtonState("Play")
-            clickMediaPlayerControlButton("Play")
-        }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(audioTestPage.url) {
+                verifyMediaPlayerControlButtonState("Play")
+                clickMediaPlayerControlButton("Play")
+            }
 
         notificationShade {
             verifySystemMediaNotificationExists(audioTestPage.title)
             verifySystemMediaNotificationControlButtonState("Pause")
             clickSystemMediaNotificationControlButton("Pause")
             verifySystemMediaNotificationControlButtonState("Play")
-        }.closeNotification {}
+        }
+            .closeNotification {}
     }
 
     @Test
     fun videoPlaybackTest() {
         val videoTestPage = TestAssetHelper.getVideoPageAsset(mockWebServer)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(videoTestPage.url) {
-            clickMediaPlayerControlButton("Play")
-        }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(videoTestPage.url) {
+                clickMediaPlayerControlButton("Play")
+            }
 
         notificationShade {
             verifySystemMediaNotificationExists(videoTestPage.title)
             verifySystemMediaNotificationControlButtonState("Pause")
             clickSystemMediaNotificationControlButton("Pause")
             verifySystemMediaNotificationControlButtonState("Play")
-        }.closeNotification {}
+        }
+            .closeNotification {}
     }
 
     @Test
     fun hiddenVideoControlsContextMenuTest() {
         val noControlsVideoTestPage = TestAssetHelper.getNoControlsVideoPageAsset(mockWebServer)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(noControlsVideoTestPage.url) {
-            longClickMatchingText("test_link_video")
-            verifyNoControlsVideoContextMenuItems()
-        }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(noControlsVideoTestPage.url) {
+                longClickMatchingText("test_link_video")
+                verifyNoControlsVideoContextMenuItems()
+            }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ReaderViewTest.kt
@@ -18,19 +18,17 @@ import org.mozilla.reference.browser.ui.robots.navigationToolbar
 class ReaderViewTest {
     private lateinit var mockWebServer: MockWebServer
 
-    @get:Rule
-    val activityTestRule = BrowserActivityTestRule()
+    @get:Rule val activityTestRule = BrowserActivityTestRule()
 
-    @Rule
-    @JvmField
-    val retryTestRule = RetryTestRule(3)
+    @Rule @JvmField val retryTestRule = RetryTestRule(3)
 
     @Before
     fun setUp() {
-        mockWebServer = MockWebServer().apply {
-            dispatcher = AndroidAssetDispatcher()
-            start()
-        }
+        mockWebServer =
+            MockWebServer().apply {
+                dispatcher = AndroidAssetDispatcher()
+                start()
+            }
     }
 
     @After
@@ -42,87 +40,83 @@ class ReaderViewTest {
     fun verifyReaderViewDetectionTest() {
         val readerViewPage = TestAssetHelper.getLoremIpsumAsset(mockWebServer)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(readerViewPage.url) {
-        }
+        navigationToolbar {}.enterUrlAndEnterToBrowser(readerViewPage.url) {}
         navigationToolbar {
             verifyReaderViewButton()
-        }.clickReaderViewButton {
-            verifyAppearanceButtonExists()
-            clickAppearanceButton()
-            verifyAppearanceMenuExists()
-        }.dismissAppearanceMenu {
         }
-        navigationToolbar {
-        }.clickReaderViewButton {
-            verifyAppearanceButtonDoesntExists()
-        }
+            .clickReaderViewButton {
+                verifyAppearanceButtonExists()
+                clickAppearanceButton()
+                verifyAppearanceMenuExists()
+            }
+            .dismissAppearanceMenu {}
+        navigationToolbar {}
+            .clickReaderViewButton {
+                verifyAppearanceButtonDoesntExists()
+            }
     }
 
     @Test
     fun readerViewFontChangeTest() {
         val readerViewPage = TestAssetHelper.getLoremIpsumAsset(mockWebServer)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(readerViewPage.url) {
-        }
+        navigationToolbar {}.enterUrlAndEnterToBrowser(readerViewPage.url) {}
         navigationToolbar {
             verifyReaderViewButton()
-        }.clickReaderViewButton {
-            verifyAppearanceButtonExists()
-            clickAppearanceButton()
-            verifyAppearanceMenuExists()
-            verifyFontGroupButtons()
-            clickSansSerifButton()
-            verifyActiveAppearanceFont("SANSSERIF")
-            clickSerifButton()
-            verifyActiveAppearanceFont("SERIF")
         }
+            .clickReaderViewButton {
+                verifyAppearanceButtonExists()
+                clickAppearanceButton()
+                verifyAppearanceMenuExists()
+                verifyFontGroupButtons()
+                clickSansSerifButton()
+                verifyActiveAppearanceFont("SANSSERIF")
+                clickSerifButton()
+                verifyActiveAppearanceFont("SERIF")
+            }
     }
 
     @Test
     fun readerViewFontSizeChangeTest() {
         val readerViewPage = TestAssetHelper.getLoremIpsumAsset(mockWebServer)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(readerViewPage.url) {
-        }
+        navigationToolbar {}.enterUrlAndEnterToBrowser(readerViewPage.url) {}
         navigationToolbar {
             verifyReaderViewButton()
-        }.clickReaderViewButton {
-            verifyAppearanceButtonExists()
-            clickAppearanceButton()
-            verifyAppearanceMenuExists()
-            verifyIncreaseFontSizeButton()
-            verifyDecreaseFontSizeButton()
-            verifyAppearanceFontSize(3)
-            clickIncreaseFontSizeButton()
-            verifyAppearanceFontSize(4)
-            clickDecreaseFontSizeButton()
-            verifyAppearanceFontSize(3)
         }
+            .clickReaderViewButton {
+                verifyAppearanceButtonExists()
+                clickAppearanceButton()
+                verifyAppearanceMenuExists()
+                verifyIncreaseFontSizeButton()
+                verifyDecreaseFontSizeButton()
+                verifyAppearanceFontSize(3)
+                clickIncreaseFontSizeButton()
+                verifyAppearanceFontSize(4)
+                clickDecreaseFontSizeButton()
+                verifyAppearanceFontSize(3)
+            }
     }
 
     @Test
     fun readerViewColorSchemeChangeTest() {
         val readerViewPage = TestAssetHelper.getLoremIpsumAsset(mockWebServer)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(readerViewPage.url) {
-        }
+        navigationToolbar {}.enterUrlAndEnterToBrowser(readerViewPage.url) {}
         navigationToolbar {
             verifyReaderViewButton()
-        }.clickReaderViewButton {
-            verifyAppearanceButtonExists()
-            clickAppearanceButton()
-            verifyAppearanceMenuExists()
-            verifyColorSchemeGroupButtons()
-            clickSepiaColorButton()
-            verifyAppearanceColorScheme("SEPIA")
-            clickDarkColorButton()
-            verifyAppearanceColorScheme("DARK")
-            clickLightColorButton()
-            verifyAppearanceColorScheme("LIGHT")
         }
+            .clickReaderViewButton {
+                verifyAppearanceButtonExists()
+                clickAppearanceButton()
+                verifyAppearanceMenuExists()
+                verifyColorSchemeGroupButtons()
+                clickSepiaColorButton()
+                verifyAppearanceColorScheme("SEPIA")
+                clickDarkColorButton()
+                verifyAppearanceColorScheme("DARK")
+                clickLightColorButton()
+                verifyAppearanceColorScheme("LIGHT")
+            }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/SearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/SearchTest.kt
@@ -18,19 +18,17 @@ import org.mozilla.reference.browser.ui.robots.navigationToolbar
 class SearchTest {
     private lateinit var mockWebServer: MockWebServer
 
-    @get:Rule
-    val activityTestRule = BrowserActivityTestRule()
+    @get:Rule val activityTestRule = BrowserActivityTestRule()
 
-    @Rule
-    @JvmField
-    val retryTestRule = RetryTestRule(3)
+    @Rule @JvmField val retryTestRule = RetryTestRule(3)
 
     @Before
     fun setUp() {
-        mockWebServer = MockWebServer().apply {
-            dispatcher = AndroidAssetDispatcher()
-            start()
-        }
+        mockWebServer =
+            MockWebServer().apply {
+                dispatcher = AndroidAssetDispatcher()
+                start()
+            }
     }
 
     @After
@@ -42,17 +40,16 @@ class SearchTest {
     fun siteSearchSuggestionTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
-        }
-        navigationToolbar {
-        }.openTabTrayMenu {
-        }.openNewTab {
-        }.clickToolbar {
-            typeText("generic1.html")
-            verifySearchSuggestion(defaultWebPage.title)
-        }.clickSearchSuggestion(defaultWebPage.title) {
-            verifyUrl(defaultWebPage.url.toString())
-        }
+        navigationToolbar {}.enterUrlAndEnterToBrowser(defaultWebPage.url) {}
+        navigationToolbar {}
+            .openTabTrayMenu {}
+            .openNewTab {}
+            .clickToolbar {
+                typeText("generic1.html")
+                verifySearchSuggestion(defaultWebPage.title)
+            }
+            .clickSearchSuggestion(defaultWebPage.title) {
+                verifyUrl(defaultWebPage.url.toString())
+            }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/SettingsViewTest.kt
@@ -15,57 +15,55 @@ import org.mozilla.reference.browser.ui.robots.mDevice
 import org.mozilla.reference.browser.ui.robots.navigationToolbar
 
 /**
- *   Tests for verifying the settings view options exist as expected:
+ * Tests for verifying the settings view options exist as expected:
  * - Appears when the settings submenu is tapped
  * - Expected options are displayed as listed below
  */
-
 class SettingsViewTest {
     // Grant the app access to the camera so that we can test the Firefox Accounts QR code reader
-    @Rule @JvmField
+    @Rule
+    @JvmField
     val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(android.Manifest.permission.CAMERA)
 
     @get:Rule val browserActivityTestRule = BrowserActivityTestRule()
 
-    @Rule
-    @JvmField
-    val retryTestRule = RetryTestRule(3)
+    @Rule @JvmField val retryTestRule = RetryTestRule(3)
 
     // This test verifies settings view items are all in place
     @Test
     fun settingsItemsTest() {
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openSettings {
-            verifySettingsRecyclerViewToExist()
-            verifyNavigateUp()
-            verifySyncSigninButton()
-            verifySyncHistorySummary()
-            verifySyncQrCodeButton()
-            verifySyncQrSummary()
-            verifyPrivacyButton()
-            verifyPrivacySummary()
-            verifyOpenLinksInApps()
-            verifyMakeDefaultBrowserButton()
-            verifyAutofillAppsButton()
-            varifyAutofillAppsSummary()
-            verifyJetpackComposeButton()
-            verifyDeveloperToolsHeading()
-            verifyRemoteDebugging()
-            verifyCustomAddonCollectionButton()
-            verifyMozillaHeading()
-            verifyAboutReferenceBrowserButton()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openSettings {
+                verifySettingsRecyclerViewToExist()
+                verifyNavigateUp()
+                verifySyncSigninButton()
+                verifySyncHistorySummary()
+                verifySyncQrCodeButton()
+                verifySyncQrSummary()
+                verifyPrivacyButton()
+                verifyPrivacySummary()
+                verifyOpenLinksInApps()
+                verifyMakeDefaultBrowserButton()
+                verifyAutofillAppsButton()
+                varifyAutofillAppsSummary()
+                verifyJetpackComposeButton()
+                verifyDeveloperToolsHeading()
+                verifyRemoteDebugging()
+                verifyCustomAddonCollectionButton()
+                verifyMozillaHeading()
+                verifyAboutReferenceBrowserButton()
+            }
     }
 
     @Test
     fun openFXATest() {
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openSettings {
-        }.openFXASignin {
-            verifyFXAUrl()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openSettings {}
+            .openFXASignin {
+                verifyFXAUrl()
+            }
     }
 
     // openFXAQrCodeTest tests that we get to the camera
@@ -73,72 +71,72 @@ class SettingsViewTest {
     @Ignore("Test instrumentation process crash, see: https://github.com/mozilla-mobile/reference-browser/issues/1502")
     @Test
     fun openFXAQrCodeTest() {
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openSettings {
-        }.openFXAQrCode {
-            mDevice.waitForIdle()
-            verifyFxAQrCode()
-            mDevice.pressBack()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openSettings {}
+            .openFXAQrCode {
+                mDevice.waitForIdle()
+                verifyFxAQrCode()
+                mDevice.pressBack()
+            }
     }
 
     @Test
     fun privacySettingsItemsTest() {
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openSettings {
-        }.openSettingsViewPrivacy {
-            verifyPrivacyUpButton()
-            verifyPrivacySettings()
-            verifyTrackingProtectionHeading()
-            verifyTPEnableInNormalBrowsing()
-            verifyTPEnableinPrivateBrowsing()
-            verifyDataChoicesHeading()
-            verifyUseTelemetryToggle()
-            verifyTelemetrySummary()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openSettings {}
+            .openSettingsViewPrivacy {
+                verifyPrivacyUpButton()
+                verifyPrivacySettings()
+                verifyTrackingProtectionHeading()
+                verifyTPEnableInNormalBrowsing()
+                verifyTPEnableinPrivateBrowsing()
+                verifyDataChoicesHeading()
+                verifyUseTelemetryToggle()
+                verifyTelemetrySummary()
+            }
     }
 
     @Test
     fun setDefaultBrowserTest() {
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openSettings {
-        }.makeDefaultBrowser {
-            verifyAndroidDefaultApps()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openSettings {}
+            .makeDefaultBrowser {
+                verifyAndroidDefaultApps()
+            }
     }
 
     @Test
     fun autofillAppsTest() {
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openSettings {
-        }.clickAutofillAppsButton {
-            verifyAndroidAutofillServices()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openSettings {}
+            .clickAutofillAppsButton {
+                verifyAndroidAutofillServices()
+            }
     }
 
     @Test
     fun remoteDebuggingViaUSB() {
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openSettings {
-            toggleRemoteDebuggingOn()
-            toggleRemoteDebuggingOff()
-            toggleRemoteDebuggingOn()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openSettings {
+                toggleRemoteDebuggingOn()
+                toggleRemoteDebuggingOff()
+                toggleRemoteDebuggingOn()
+            }
     }
 
     @Test
     fun aboutReferenceBrowserTest() {
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openSettings {
-        }.openAboutReferenceBrowser {
-            verifyAboutBrowser()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openSettings {}
+            .openAboutReferenceBrowser {
+                verifyAboutBrowser()
+            }
     }
 
     /* Can't check further because after creating the custom add-on collection
@@ -148,29 +146,31 @@ class SettingsViewTest {
     will cause the test instrumentation process to crash */
     @Test
     fun customAddonsCollectionTest() {
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openSettings {
-            verifyCustomAddonCollectionButton()
-            clickCustomAddonCollectionButton()
-            verifyCustomAddonCollectionPanelExist()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openSettings {
+                verifyCustomAddonCollectionButton()
+                clickCustomAddonCollectionButton()
+                verifyCustomAddonCollectionPanelExist()
+            }
     }
 
     @Ignore("Failing, see: https://github.com/mozilla-mobile/reference-browser/issues/2260")
     @Test
     fun openLinksInAppsTest() {
         val url = "m.youtube.com"
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openSettings {
-            verifyOpenLinksInApps()
-            clickOpenLinksInApps()
-        }.goBack {
-        }.enterUrlAndEnterToBrowser(url.toUri()) {
-            clickOpenInAppPromptButton()
-        }.checkExternalApps {
-            verifyYouTubeApp()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openSettings {
+                verifyOpenLinksInApps()
+                clickOpenLinksInApps()
+            }
+            .goBack {}
+            .enterUrlAndEnterToBrowser(url.toUri()) {
+                clickOpenInAppPromptButton()
+            }
+            .checkExternalApps {
+                verifyYouTubeApp()
+            }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/TabTrayMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/TabTrayMenuTest.kt
@@ -11,6 +11,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import mockwebserver3.MockWebServer
+import mozilla.components.ui.tabcounter.R as tabcounterR
 import org.junit.After
 import org.junit.Before
 import org.junit.Ignore
@@ -23,33 +24,30 @@ import org.mozilla.reference.browser.helpers.TestAssetHelper
 import org.mozilla.reference.browser.helpers.click
 import org.mozilla.reference.browser.ui.robots.mDevice
 import org.mozilla.reference.browser.ui.robots.navigationToolbar
-import mozilla.components.ui.tabcounter.R as tabcounterR
 
 /**
- *  Tests for verifying tab tray menu:
+ * Tests for verifying tab tray menu:
  * - Appears when counter tabs is clicked
  * - Expected options are displayed as listed below
  * - Options/Buttons in this menu work as expected
  */
-
 class TabTrayMenuTest {
     private lateinit var mockWebServer: MockWebServer
 
     @get:Rule val activityTestRule = BrowserActivityTestRule()
 
-    @Rule
-    @JvmField
-    val retryTestRule = RetryTestRule(3)
+    @Rule @JvmField val retryTestRule = RetryTestRule(3)
 
     // SetUp to close all tabs before starting each test
     @Before
     fun setUp() {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
-        mockWebServer = MockWebServer().apply {
-            dispatcher = AndroidAssetDispatcher()
-            start()
-        }
+        mockWebServer =
+            MockWebServer().apply {
+                dispatcher = AndroidAssetDispatcher()
+                start()
+            }
 
         fun optionsButton() = onView(ViewMatchers.withContentDescription("More options"))
 
@@ -79,80 +77,87 @@ class TabTrayMenuTest {
     // This test verifies the tab tray menu items are all in place
     @Test
     fun tabTrayUITest() {
-        navigationToolbar {
-        }.openTabTrayMenu {
-            verifyRegularBrowsingTab()
-            verifyPrivateBrowsingTab()
-            verifyGoBackButton()
-            verifyNewTabButton()
-        }.openMoreOptionsMenu(activityTestRule.activity) {
-            verifyCloseAllTabsButton()
-        }
+        navigationToolbar {}
+            .openTabTrayMenu {
+                verifyRegularBrowsingTab()
+                verifyPrivateBrowsingTab()
+                verifyGoBackButton()
+                verifyNewTabButton()
+            }
+            .openMoreOptionsMenu(activityTestRule.activity) {
+                verifyCloseAllTabsButton()
+            }
     }
 
     // This test verifies that close all tabs option works as expected
     @Test
     fun closeAllTabsTest() {
-        navigationToolbar {
-        }.openTabTrayMenu {
-        }.openNewTab {
-        }.openTabTrayMenu {
-            verifyThereIsOneTabOpen()
-        }.openMoreOptionsMenu(activityTestRule.activity) {
-            mDevice.waitForIdle()
-            verifyCloseAllTabsButton()
-        }.closeAllTabs {
-            verifyNoTabAddressView()
-            checkNumberOfTabsTabCounter("0")
-        }
+        navigationToolbar {}
+            .openTabTrayMenu {}
+            .openNewTab {}
+            .openTabTrayMenu {
+                verifyThereIsOneTabOpen()
+            }
+            .openMoreOptionsMenu(activityTestRule.activity) {
+                mDevice.waitForIdle()
+                verifyCloseAllTabsButton()
+            }
+            .closeAllTabs {
+                verifyNoTabAddressView()
+                checkNumberOfTabsTabCounter("0")
+            }
     }
 
     // This test verifies that close all tabs option works as expected
     @Test
     fun closeAllPrivateTabsTest() {
-        navigationToolbar {
-        }.openTabTrayMenu {
-            openPrivateBrowsing()
-        }.openNewTab {
-        }.openTabTrayMenu {
-            openPrivateBrowsing()
-            verifyThereIsOnePrivateTabOpen()
-        }.openMoreOptionsMenu(activityTestRule.activity) {
-            mDevice.waitForIdle()
-            verifyCloseAllPrivateTabsButton()
-        }.closeAllPrivateTabs {
-        }.openTabTrayMenu {
-            openPrivateBrowsing()
-            verifyThereAreNotPrivateTabsOpen()
-            goBackFromTabTrayTest()
-        }
+        navigationToolbar {}
+            .openTabTrayMenu {
+                openPrivateBrowsing()
+            }
+            .openNewTab {}
+            .openTabTrayMenu {
+                openPrivateBrowsing()
+                verifyThereIsOnePrivateTabOpen()
+            }
+            .openMoreOptionsMenu(activityTestRule.activity) {
+                mDevice.waitForIdle()
+                verifyCloseAllPrivateTabsButton()
+            }
+            .closeAllPrivateTabs {}
+            .openTabTrayMenu {
+                openPrivateBrowsing()
+                verifyThereAreNotPrivateTabsOpen()
+                goBackFromTabTrayTest()
+            }
     }
 
     @Test
     fun closeOneTabXButtonTest() {
-        navigationToolbar {
-        }.openTabTrayMenu {
-        }.openNewTab {
-            checkNumberOfTabsTabCounter("1")
-        }.openTabTrayMenu {
-        }.closeTabXButton {
-            checkNumberOfTabsTabCounter("0")
-        }
+        navigationToolbar {}
+            .openTabTrayMenu {}
+            .openNewTab {
+                checkNumberOfTabsTabCounter("1")
+            }
+            .openTabTrayMenu {}
+            .closeTabXButton {
+                checkNumberOfTabsTabCounter("0")
+            }
     }
 
     // This test verifies the change between regular-private browsing works
     @Test
     fun privateRegularModeChangeTest() {
-        navigationToolbar {
-        }.openTabTrayMenu {
-            openPrivateBrowsing()
-            verifyPrivateBrowsingTab(true)
-            verifyRegularBrowsingTab(false)
-            openRegularBrowsing()
-            verifyPrivateBrowsingTab(false)
-            verifyRegularBrowsingTab(true)
-            goBackFromTabTrayTest()
-        }
+        navigationToolbar {}
+            .openTabTrayMenu {
+                openPrivateBrowsing()
+                verifyPrivateBrowsingTab(true)
+                verifyRegularBrowsingTab(false)
+                openRegularBrowsing()
+                verifyPrivateBrowsingTab(false)
+                verifyRegularBrowsingTab(true)
+                goBackFromTabTrayTest()
+            }
     }
 
     // This test verifies the new tab is open and that its items are all in place
@@ -161,24 +166,27 @@ class TabTrayMenuTest {
     fun openNewTabTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
+        navigationToolbar {}
+            .openTabTrayMenu {}
+            .openNewTab {
+                verifyNewTabAddressView("about:blank")
+                checkNumberOfTabsTabCounter("1")
+            }
+            .openTabTrayMenu {}
+            .openNewTab {}
+            .enterUrlAndEnterToBrowser(genericURL.url) {
+                verifyUrl(genericURL.url.toString())
+            }
         navigationToolbar {
-        }.openTabTrayMenu {
-        }.openNewTab {
-            verifyNewTabAddressView("about:blank")
-            checkNumberOfTabsTabCounter("1")
-        }.openTabTrayMenu {
-        }.openNewTab {
-        }.enterUrlAndEnterToBrowser(genericURL.url) {
-            verifyUrl(genericURL.url.toString())
-        }
-        navigationToolbar {
-            checkNumberOfTabsTabCounter("2")
-        }.openTabTrayMenu {
-            verifyExistingOpenTabs("about:blank")
-            verifyExistingOpenTabs(genericURL.title)
-        }.clickOpenTab("about:blank") {
-            verifyUrl("about:blank")
-        }
+                checkNumberOfTabsTabCounter("2")
+            }
+            .openTabTrayMenu {
+                verifyExistingOpenTabs("about:blank")
+                verifyExistingOpenTabs(genericURL.title)
+            }
+            .clickOpenTab("about:blank") {
+                verifyUrl("about:blank")
+            }
     }
 
     // This test verifies the new tab is open and that its items are all in place
@@ -188,28 +196,33 @@ class TabTrayMenuTest {
         val firstGenericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val secondGenericURL = TestAssetHelper.getGenericAsset(mockWebServer, 2)
 
+        navigationToolbar {}
+            .openTabTrayMenu {
+                openPrivateBrowsing()
+            }
+            .openNewTab {
+                verifyNewTabAddressView("data:text/html")
+                checkNumberOfTabsTabCounter("1")
+            }
+            .openTabTrayMenu {
+                openPrivateBrowsing()
+            }
+            .openNewTab {}
+            .enterUrlAndEnterToBrowser(firstGenericURL.url) {
+                verifyPageContent("Page content: 1")
+            }
         navigationToolbar {
-        }.openTabTrayMenu {
-            openPrivateBrowsing()
-        }.openNewTab {
-            verifyNewTabAddressView("data:text/html")
-            checkNumberOfTabsTabCounter("1")
-        }.openTabTrayMenu {
-            openPrivateBrowsing()
-        }.openNewTab {
-        }.enterUrlAndEnterToBrowser(firstGenericURL.url) {
-            verifyPageContent("Page content: 1")
-        }
-        navigationToolbar {
-            checkNumberOfTabsTabCounter("2")
-        }.openTabTrayMenu {
-            openPrivateBrowsing()
-            verifyExistingOpenTabs("Private Browsing")
-            verifyExistingOpenTabs(firstGenericURL.title)
-        }.openNewTab {
-        }.enterUrlAndEnterToBrowser(secondGenericURL.url) {
-            verifyPageContent("Page content: 2")
-        }
+                checkNumberOfTabsTabCounter("2")
+            }
+            .openTabTrayMenu {
+                openPrivateBrowsing()
+                verifyExistingOpenTabs("Private Browsing")
+                verifyExistingOpenTabs(firstGenericURL.title)
+            }
+            .openNewTab {}
+            .enterUrlAndEnterToBrowser(secondGenericURL.url) {
+                verifyPageContent("Page content: 2")
+            }
         navigationToolbar {
             checkNumberOfTabsTabCounter("3")
         }
@@ -218,11 +231,11 @@ class TabTrayMenuTest {
     // This test verifies the back button functionality
     @Test
     fun goBackFromTabTrayTest() {
-        navigationToolbar {
-        }.openTabTrayMenu {
-        }.goBackFromTabTray {
-            // For now checking new tab is valid, this will change when browsing to/from different places
-            verifyNoTabAddressView()
-        }
+        navigationToolbar {}
+            .openTabTrayMenu {}
+            .goBackFromTabTray {
+                // For now checking new tab is valid, this will change when browsing to/from different places
+                verifyNoTabAddressView()
+            }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ThreeDotMenuTest.kt
@@ -21,9 +21,9 @@ import org.mozilla.reference.browser.helpers.TestAssetHelper
 import org.mozilla.reference.browser.ui.robots.navigationToolbar
 
 /**
- *  Tests for verifying the main three dot menu options
+ * Tests for verifying the main three dot menu options
  *
- *  Including:
+ * Including:
  * - Verify all menu items present
  * - Forward button navigates forward to a page
  * - Refresh button refreshes page content
@@ -37,24 +37,21 @@ import org.mozilla.reference.browser.ui.robots.navigationToolbar
  * - TODO: Request desktop site (user mockWebServer to parse request headers)
  * - Stop button stops page loading (covered by smoke tests)
  */
-
 class ThreeDotMenuTest {
     private val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
     private lateinit var mockWebServer: MockWebServer
 
-    @get:Rule
-    val activityTestRule = BrowserActivityTestRule()
+    @get:Rule val activityTestRule = BrowserActivityTestRule()
 
-    @Rule
-    @JvmField
-    val retryTestRule = RetryTestRule(3)
+    @Rule @JvmField val retryTestRule = RetryTestRule(3)
 
     @Before
     fun setUp() {
-        mockWebServer = MockWebServer().apply {
-            dispatcher = AndroidAssetDispatcher()
-            start()
-        }
+        mockWebServer =
+            MockWebServer().apply {
+                dispatcher = AndroidAssetDispatcher()
+                start()
+            }
     }
 
     @After
@@ -64,48 +61,49 @@ class ThreeDotMenuTest {
 
     @Test
     fun homeScreenMenuTest() {
-        navigationToolbar {
-        }.openThreeDotMenu {
-            verifyThreeDotMenuExists()
-            // These items should not exist in the home screen menu
-            verifyForwardButtonDoesntExist()
-            verifyReloadButtonDoesntExist()
-            verifyStopButtonDoesntExist()
-            verifyShareButtonDoesntExist()
-            verifyRequestDesktopSiteToggleDoesntExist()
-            verifyAddToHomescreenButtonDoesntExist()
-            verifyFindInPageButtonDoesntExist()
-            // Only these items should exist in the home screen menu
-            verifyAddOnsButtonExists()
-            verifySyncedTabsButtonExists()
-            verifyReportIssueExists()
-            verifyOpenSettingsExists()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {
+                verifyThreeDotMenuExists()
+                // These items should not exist in the home screen menu
+                verifyForwardButtonDoesntExist()
+                verifyReloadButtonDoesntExist()
+                verifyStopButtonDoesntExist()
+                verifyShareButtonDoesntExist()
+                verifyRequestDesktopSiteToggleDoesntExist()
+                verifyAddToHomescreenButtonDoesntExist()
+                verifyFindInPageButtonDoesntExist()
+                // Only these items should exist in the home screen menu
+                verifyAddOnsButtonExists()
+                verifySyncedTabsButtonExists()
+                verifyReportIssueExists()
+                verifyOpenSettingsExists()
+            }
     }
 
     @Test
     fun threeDotMenuItemsTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         navigationToolbar {
-            // pull up URL to ensure this is not a first-user 3 dot menu
-        }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
-            mDevice.waitForIdle()
-        }
-        navigationToolbar {
-        }.openThreeDotMenu {
-            verifyThreeDotMenuExists()
-            verifyForwardButtonExists()
-            verifyReloadButtonExists()
-            verifyStopButtonExists()
-            verifyShareButtonExists()
-            verifyRequestDesktopSiteToggleExists()
-            verifyAddToHomescreenButtonExists()
-            verifyFindInPageButtonExists()
-            verifyAddOnsButtonExists()
-            verifySyncedTabsButtonExists()
-            verifyReportIssueExists()
-            verifyOpenSettingsExists()
-        }
+                // pull up URL to ensure this is not a first-user 3 dot menu
+            }
+            .enterUrlAndEnterToBrowser(defaultWebPage.url) {
+                mDevice.waitForIdle()
+            }
+        navigationToolbar {}
+            .openThreeDotMenu {
+                verifyThreeDotMenuExists()
+                verifyForwardButtonExists()
+                verifyReloadButtonExists()
+                verifyStopButtonExists()
+                verifyShareButtonExists()
+                verifyRequestDesktopSiteToggleExists()
+                verifyAddToHomescreenButtonExists()
+                verifyFindInPageButtonExists()
+                verifyAddOnsButtonExists()
+                verifySyncedTabsButtonExists()
+                verifyReportIssueExists()
+                verifyOpenSettingsExists()
+            }
     }
 
     @Test
@@ -113,21 +111,22 @@ class ThreeDotMenuTest {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val nextWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent("Page content: 1")
-        }
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(nextWebPage.url) {
-            verifyPageContent("Page content: 2")
-        }.goBack {
-            verifyPageContent("Page content: 1")
-        }
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.goForward {
-            verifyPageContent("Page content: 2")
-        }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(defaultWebPage.url) {
+                verifyPageContent("Page content: 1")
+            }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(nextWebPage.url) {
+                verifyPageContent("Page content: 2")
+            }
+            .goBack {
+                verifyPageContent("Page content: 1")
+            }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .goForward {
+                verifyPageContent("Page content: 2")
+            }
     }
 
     @Ignore("Failing, see: https://github.com/mozilla-mobile/reference-browser/issues/2085")
@@ -136,24 +135,26 @@ class ThreeDotMenuTest {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val nextWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
 
-        navigationToolbar {
-        }.openTabTrayMenu {
-            openPrivateBrowsing()
-        }.openNewTab {
-        }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
-            verifyUrl(defaultWebPage.url.toString())
-        }
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(nextWebPage.url) {
-            verifyUrl(nextWebPage.url.toString())
-        }.goBack {
-            verifyUrl(defaultWebPage.url.toString())
-        }
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.goForward {
-            verifyUrl(nextWebPage.url.toString())
-        }
+        navigationToolbar {}
+            .openTabTrayMenu {
+                openPrivateBrowsing()
+            }
+            .openNewTab {}
+            .enterUrlAndEnterToBrowser(defaultWebPage.url) {
+                verifyUrl(defaultWebPage.url.toString())
+            }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(nextWebPage.url) {
+                verifyUrl(nextWebPage.url.toString())
+            }
+            .goBack {
+                verifyUrl(defaultWebPage.url.toString())
+            }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .goForward {
+                verifyUrl(nextWebPage.url.toString())
+            }
     }
 
     // need to add clear cache setup to ensure correct starting page
@@ -164,54 +165,54 @@ class ThreeDotMenuTest {
         val refreshWebPage = TestAssetHelper.getRefreshAsset(mockWebServer)
 
         navigationToolbar {
-            // load the default page, to be refreshed
-            // (test assumes no cookies cached at test start)
-        }.enterUrlAndEnterToBrowser(refreshWebPage.url) {
-            verifyPageContent("DEFAULT")
-        }
-        navigationToolbar {
-        }.openThreeDotMenu {
-            // refresh page and verify
-        }.refreshPage {
-            verifyPageContent("REFRESHED")
-        }
+                // load the default page, to be refreshed
+                // (test assumes no cookies cached at test start)
+            }
+            .enterUrlAndEnterToBrowser(refreshWebPage.url) {
+                verifyPageContent("DEFAULT")
+            }
+        navigationToolbar {}
+            .openThreeDotMenu {
+                // refresh page and verify
+            }
+            .refreshPage {
+                verifyPageContent("REFRESHED")
+            }
     }
 
     @Test
     fun doShareTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(genericURL.url) {
-        }
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openShare {
-            verifyShareContentPanel()
-        }
+        navigationToolbar {}.enterUrlAndEnterToBrowser(genericURL.url) {}
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openShare {
+                verifyShareContentPanel()
+            }
     }
 
     @Test
     fun findInPageTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent("Page content: 1")
-        }
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openFindInPage {
-            verifyFindInPageBar()
-            enterFindInPageQuery("e")
-            verifyFindInPageResult("1/2")
-            clickFindInPageNextButton()
-            verifyFindInPageResult("2/2")
-            clickFindInPagePreviousButton()
-            verifyFindInPageResult("1/2")
-            clickFindInPageCloseButton()
-            verifyFindInPageBarIsDismissed()
-        }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(defaultWebPage.url) {
+                verifyPageContent("Page content: 1")
+            }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openFindInPage {
+                verifyFindInPageBar()
+                enterFindInPageQuery("e")
+                verifyFindInPageResult("1/2")
+                clickFindInPageNextButton()
+                verifyFindInPageResult("2/2")
+                clickFindInPagePreviousButton()
+                verifyFindInPageResult("1/2")
+                clickFindInPageCloseButton()
+                verifyFindInPageBarIsDismissed()
+            }
     }
 
     // so less flaky, we only test redirect to github login
@@ -220,25 +221,25 @@ class ThreeDotMenuTest {
     fun reportIssueTest() {
         val loremIpsumWebPage = TestAssetHelper.getLoremIpsumAsset(mockWebServer)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(loremIpsumWebPage.url) {
-            mDevice.waitForIdle()
-        }
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.reportIssue {
-            mDevice.waitForIdle()
-            verifyGithubUrl()
-        }
+        navigationToolbar {}
+            .enterUrlAndEnterToBrowser(loremIpsumWebPage.url) {
+                mDevice.waitForIdle()
+            }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .reportIssue {
+                mDevice.waitForIdle()
+                verifyGithubUrl()
+            }
     }
 
     @Test
     fun openSettingsTest() {
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openSettings {
-            verifySettingsViewExists()
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openSettings {
+                verifySettingsViewExists()
+            }
     }
 
     // Verifies the Synced tabs menu opens from a tab's 3 dot menu and
@@ -247,14 +248,12 @@ class ThreeDotMenuTest {
     fun openSyncedTabsTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
-        }
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openSyncedTabs {
-            verifyNotSignedInSyncTabsView()
-        }
+        navigationToolbar {}.enterUrlAndEnterToBrowser(defaultWebPage.url) {}
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openSyncedTabs {
+                verifyNotSignedInSyncTabsView()
+            }
     }
 
     @Ignore("Failing with frequent ANR: https://bugzilla.mozilla.org/show_bug.cgi?id=1764605")
@@ -262,41 +261,39 @@ class ThreeDotMenuTest {
     fun requestDesktopSiteTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
-        }
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.switchRequestDesktopSiteToggle {
-        }.openThreeDotMenu {
-            verifyRequestDesktopSiteIsTurnedOn()
-        }.goBack {
-        }.openThreeDotMenu {
-        }.switchRequestDesktopSiteToggle {
-        }.openThreeDotMenu {
-            verifyRequestDesktopSiteIsTurnedOff()
-        }
+        navigationToolbar {}.enterUrlAndEnterToBrowser(defaultWebPage.url) {}
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .switchRequestDesktopSiteToggle {}
+            .openThreeDotMenu {
+                verifyRequestDesktopSiteIsTurnedOn()
+            }
+            .goBack {}
+            .openThreeDotMenu {}
+            .switchRequestDesktopSiteToggle {}
+            .openThreeDotMenu {
+                verifyRequestDesktopSiteIsTurnedOff()
+            }
     }
 
     @Test
     fun addToHomeScreenTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        navigationToolbar {
-        }.enterUrlAndEnterToBrowser(defaultWebPage.url) {
-        }
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openAddToHomeScreen {
-            clickCancelAddToHomeScreenButton()
-        }
+        navigationToolbar {}.enterUrlAndEnterToBrowser(defaultWebPage.url) {}
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openAddToHomeScreen {
+                clickCancelAddToHomeScreenButton()
+            }
 
-        navigationToolbar {
-        }.openThreeDotMenu {
-        }.openAddToHomeScreen {
-            clickSystemHomeScreenShortcutAddButton()
-        }.openHomeScreenShortcut(defaultWebPage.title) {
-            verifyUrl(defaultWebPage.url.toString())
-        }
+        navigationToolbar {}
+            .openThreeDotMenu {}
+            .openAddToHomeScreen {
+                clickSystemHomeScreenShortcutAddButton()
+            }
+            .openHomeScreenShortcut(defaultWebPage.title) {
+                verifyUrl(defaultWebPage.url.toString())
+            }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddToHomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddToHomeScreenRobot.kt
@@ -9,9 +9,7 @@ import androidx.test.uiautomator.UiSelector
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTimeShort
 
-/**
- * Implementation of Robot Pattern for the Add to homescreen feature.
- */
+/** Implementation of Robot Pattern for the Add to homescreen feature. */
 class AddToHomeScreenRobot {
     fun clickCancelAddToHomeScreenButton() {
         cancelAddToHomeScreenButton().waitForExists(waitingTime)

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddonsManagerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AddonsManagerRobot.kt
@@ -19,6 +19,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
+import mozilla.components.feature.addons.R as addonsR
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertTrue
@@ -32,11 +33,8 @@ import org.mozilla.reference.browser.helpers.TestHelper.itemWithResId
 import org.mozilla.reference.browser.helpers.TestHelper.itemWithResIdContainingText
 import org.mozilla.reference.browser.helpers.TestHelper.packageName
 import org.mozilla.reference.browser.helpers.click
-import mozilla.components.feature.addons.R as addonsR
 
-/**
- * Implementation of Robot Pattern for the addons manager.
- */
+/** Implementation of Robot Pattern for the addons manager. */
 class AddonsManagerRobot {
     fun verifyAddonsRecommendedView() {
         assertTrue(mDevice.findObject(UiSelector().text("Recommended")).waitForExists(waitingTime))
@@ -70,11 +68,10 @@ class AddonsManagerRobot {
     fun waitForAddonDownloadComplete() = waitForDownloadProgressUntilGone()
 
     fun openAddon(addonName: String) =
-        itemWithResIdContainingText("$packageName:id/add_on_name", addonName)
-            .also {
-                it.waitForExists(waitingTimeShort)
-                it.clickAndWaitForNewWindow()
-            }
+        itemWithResIdContainingText("$packageName:id/add_on_name", addonName).also {
+            it.waitForExists(waitingTimeShort)
+            it.clickAndWaitForNewWindow()
+        }
 
     fun dismissAddonDownloadCompletedPrompt(addonName: String) {
         mDevice.waitForWindowUpdate(packageName, waitingTime)
@@ -83,17 +80,15 @@ class AddonsManagerRobot {
             .waitForExists(waitingTime)
         mDevice.waitAndInteract(
             Until.findObject(
-                By.text(
-                    getStringResource(addonsR.string.mozac_feature_addons_installed_dialog_okay_button_2),
-                ),
-            ),
+                By.text(getStringResource(addonsR.string.mozac_feature_addons_installed_dialog_okay_button_2))
+            )
         ) {}
         mDevice
             .findObject(
-            UiSelector().textContains(
-                getStringResource(addonsR.string.mozac_feature_addons_installed_dialog_okay_button_2),
-            ),
-        ).click()
+                UiSelector()
+                    .textContains(getStringResource(addonsR.string.mozac_feature_addons_installed_dialog_okay_button_2))
+            )
+            .click()
     }
 
     fun clickRemoveAddonButton() {
@@ -114,95 +109,80 @@ class AddonsManagerRobot {
                 withContentDescription("Install $addonName"),
                 isDescendantOfA(withId(R.id.add_on_item)),
                 hasSibling(hasDescendant(withText(addonName))),
-            ),
+            )
         )
 
     private fun removeAddonButton() = onView(withId(R.id.remove_add_on))
 
     private fun selectInstallAddonButton(addonName: String) {
         mDevice.waitForIdle()
-        mDevice
-            .findObject(UiSelector().textContains(addonName))
-            .waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().textContains(addonName)).waitForExists(waitingTime)
 
-        installAddonButton(addonName)
-            .check(matches(isCompletelyDisplayed()))
-            .perform(click())
+        installAddonButton(addonName).check(matches(isCompletelyDisplayed())).perform(click())
     }
 
     private fun assertAddonPrompt(addonName: String) {
         mDevice.waitForIdle()
-        mDevice
-            .findObject(
-            UiSelector()
-                .resourceId("$packageName:id/title"),
-        ).waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/title")).waitForExists(waitingTime)
 
-        assertTrue(
-            mDevice
-                .findObject(UiSelector().textContains("Add $addonName"))
-                .waitForExists(waitingTime),
-        )
+        assertTrue(mDevice.findObject(UiSelector().textContains("Add $addonName")).waitForExists(waitingTime))
 
         onView(
-            allOf(
-                withId(addonsR.id.optional_or_required_text),
-                withText(containsString("Required permissions:")),
-            ),
-        ).check(matches(isCompletelyDisplayed()))
+                allOf(
+                    withId(addonsR.id.optional_or_required_text),
+                    withText(containsString("Required permissions:")),
+                )
+            )
+            .check(matches(isCompletelyDisplayed()))
 
         onView(
-            allOf(
-                withId(addonsR.id.allow_button),
-                withText(addonsR.string.mozac_feature_addons_permissions_dialog_add),
-            ),
-        ).check(matches(isCompletelyDisplayed()))
+                allOf(
+                    withId(addonsR.id.allow_button),
+                    withText(addonsR.string.mozac_feature_addons_permissions_dialog_add),
+                )
+            )
+            .check(matches(isCompletelyDisplayed()))
 
         onView(
-            allOf(
-                withId(addonsR.id.deny_button),
-                withText(addonsR.string.mozac_feature_addons_permissions_dialog_cancel),
-            ),
-        ).check(matches(isCompletelyDisplayed()))
+                allOf(
+                    withId(addonsR.id.deny_button),
+                    withText(addonsR.string.mozac_feature_addons_permissions_dialog_cancel),
+                )
+            )
+            .check(matches(isCompletelyDisplayed()))
     }
 
     private fun cancelInstallButton() {
         onView(
-            allOf(
-                withId(addonsR.id.deny_button),
-                withText(addonsR.string.mozac_feature_addons_permissions_dialog_cancel),
-            ),
-        ).check(matches(isCompletelyDisplayed()))
+                allOf(
+                    withId(addonsR.id.deny_button),
+                    withText(addonsR.string.mozac_feature_addons_permissions_dialog_cancel),
+                )
+            )
+            .check(matches(isCompletelyDisplayed()))
             .perform(click())
     }
 
     private fun allowInstallAddonButton() {
         // The permissions dialog disables the "Add" button for ~1s as
         // clickjacking protection. Wait until it becomes enabled.
-        val allowButton = mDevice.wait(
-            Until.findObject(By.res("$packageName:id/allow_button").enabled(true)),
-            waitingTime,
-        )
+        val allowButton =
+            mDevice.wait(
+                Until.findObject(By.res("$packageName:id/allow_button").enabled(true)),
+                waitingTime,
+            )
         assertTrue("Allow button did not become enabled", allowButton != null)
         allowButton.click()
     }
 
     private fun assertAddonDownloadCompletedPrompt(addonName: String) {
         mDevice.waitForIdle()
-        assertTrue(
-            mDevice
-                .findObject(
-                UiSelector()
-                    .textContains("$addonName was added"),
-            ).waitForExists(waitingTime),
-        )
+        assertTrue(mDevice.findObject(UiSelector().textContains("$addonName was added")).waitForExists(waitingTime))
     }
 
     private fun waitForDownloadProgressUntilGone() {
         mDevice.waitForIdle()
-        mDevice
-            .findObject(UiSelector().resourceId("$packageName:id/addonProgressOverlay"))
-            .waitUntilGone(waitingTime)
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/addonProgressOverlay")).waitUntilGone(waitingTime)
     }
 
     private fun assertAddonElementsView(addonName: String) {
@@ -210,14 +190,15 @@ class AddonsManagerRobot {
         mDevice.findObject(UiSelector().textContains(addonName)).waitForExists(waitingTime)
 
         onView(
-            allOf(
-                withId(R.id.remove_add_on),
-                hasSibling(withId(R.id.enable_switch)),
-                hasSibling(withId(R.id.settings)),
-                hasSibling(withId(R.id.details)),
-                hasSibling(withId(R.id.permissions)),
-                hasSibling(withId(R.id.allow_in_private_browsing_switch)),
-            ),
-        ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+                allOf(
+                    withId(R.id.remove_add_on),
+                    hasSibling(withId(R.id.enable_switch)),
+                    hasSibling(withId(R.id.settings)),
+                    hasSibling(withId(R.id.details)),
+                    hasSibling(withId(R.id.permissions)),
+                    hasSibling(withId(R.id.allow_in_private_browsing_switch)),
+                )
+            )
+            .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AwesomeBarRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/AwesomeBarRobot.kt
@@ -14,17 +14,15 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withSubstring
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
+import mozilla.components.browser.toolbar.R as toolbarR
 import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestHelper.packageName
 import org.mozilla.reference.browser.helpers.click
-import mozilla.components.browser.toolbar.R as toolbarR
 
-/**
- * Implementation of Robot Pattern for awesomebar.
- */
+/** Implementation of Robot Pattern for awesomebar. */
 class AwesomeBarRobot {
     fun verifySearchSuggestion(searchSuggestionTitle: String) = assertSearchSuggestion(searchSuggestionTitle)
 
@@ -45,12 +43,8 @@ class AwesomeBarRobot {
 
     fun longClickToolbar() {
         mDevice.waitForWindowUpdate(packageName, waitingTime)
-        mDevice
-            .findObject(UiSelector().resourceId("$packageName:id/awesomeBar"))
-            .waitForExists(waitingTime)
-        mDevice
-            .findObject(UiSelector().resourceId("$packageName:id/toolbar"))
-            .waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/awesomeBar")).waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/toolbar")).waitForExists(waitingTime)
         val toolbar = mDevice.findObject(By.res("$packageName:id/toolbar"))
         toolbar.click(LONG_CLICK_DURATION)
     }
@@ -98,7 +92,7 @@ private fun awesomeBar() =
         allOf(
             withId(toolbarR.id.mozac_browser_toolbar_edit_url_view),
             isDescendantOfA(withId(toolbarR.id.mozac_browser_toolbar_container)),
-        ),
+        )
     )
 
 private fun clearToolbarButton() =
@@ -106,39 +100,28 @@ private fun clearToolbarButton() =
 
 private fun assertSearchSuggestion(searchSuggestionTitle: String) {
     mDevice.waitForIdle()
-    assertTrue(
-        mDevice
-            .findObject(UiSelector().textContains(searchSuggestionTitle))
-            .waitForExists(waitingTime),
-    )
+    assertTrue(mDevice.findObject(UiSelector().textContains(searchSuggestionTitle)).waitForExists(waitingTime))
 }
 
 private fun assertLinkFromClipboard(clipboardLink: String) {
     mDevice.waitForIdle()
-    mDevice
-        .findObject(UiSelector().resourceId("$packageName:id/awesomeBar"))
-        .waitForExists(waitingTime)
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/awesomeBar")).waitForExists(waitingTime)
     mDevice
         .findObject(UiSelector().resourceId("$packageName:id/mozac_browser_awesomebar_title"))
         .waitForExists(waitingTime)
-    assertTrue(
-        mDevice
-            .findObject(UiSelector().textContains(clipboardLink))
-            .waitForExists(waitingTime),
-    )
+    assertTrue(mDevice.findObject(UiSelector().textContains(clipboardLink)).waitForExists(waitingTime))
 }
 
 private fun assertPastedToolbarText(expectedText: String) {
-    mDevice
-        .findObject(UiSelector().resourceId("$packageName:id/toolbar"))
-        .waitForExists(waitingTime)
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/toolbar")).waitForExists(waitingTime)
     mDevice
         .findObject(UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_url_view"))
         .waitForExists(waitingTime)
     onView(
-        allOf(
-            withSubstring(expectedText),
-            withId(toolbarR.id.mozac_browser_toolbar_edit_url_view),
-        ),
-    ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+            allOf(
+                withSubstring(expectedText),
+                withId(toolbarR.id.mozac_browser_toolbar_edit_url_view),
+            )
+        )
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
@@ -13,30 +13,22 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withSubstring
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
+import mozilla.components.browser.toolbar.R as toolbarR
 import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestHelper.packageName
 import org.mozilla.reference.browser.helpers.TestHelper.waitForObjects
-import mozilla.components.browser.toolbar.R as toolbarR
 
-/**
- * Implementation of Robot Pattern for browser action.
- */
+/** Implementation of Robot Pattern for browser action. */
 class BrowserRobot {
     /* Asserts that the text within DOM element with ID="testContent" has the given text, i.e.
      * document.querySelector('#testContent').innerText == expectedText
      */
     fun verifyPageContent(expectedText: String) {
         mDevice.waitForObjects(mDevice.findObject(UiSelector().resourceId("android.webkit.WebView")))
-        assertTrue(
-            mDevice
-                .findObject(
-                UiSelector()
-                    .textContains(expectedText),
-            ).waitForExists(waitingTime),
-        )
+        assertTrue(mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime))
     }
 
     fun verifyFXAUrl() {
@@ -48,46 +40,33 @@ class BrowserRobot {
     }
 
     fun verifyUrl(expectedUrl: String) {
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/toolbar")).waitForExists(waitingTime)
         mDevice
-            .findObject(
-            UiSelector()
-                .resourceId("$packageName:id/toolbar"),
-        ).waitForExists(waitingTime)
-        mDevice
-            .findObject(
-            UiSelector()
-                .resourceId("$packageName:id/mozac_browser_toolbar_url_view"),
-        ).waitForExists(waitingTime)
-        mDevice
-            .findObject(UiSelector().textContains(expectedUrl))
+            .findObject(UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_url_view"))
             .waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().textContains(expectedUrl)).waitForExists(waitingTime)
         onView(
-            allOf(
-                withSubstring(expectedUrl),
-                withId(toolbarR.id.mozac_browser_toolbar_url_view),
-                isDescendantOfA(withId(toolbarR.id.mozac_browser_toolbar_origin_view)),
-            ),
-        ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+                allOf(
+                    withSubstring(expectedUrl),
+                    withId(toolbarR.id.mozac_browser_toolbar_url_view),
+                    isDescendantOfA(withId(toolbarR.id.mozac_browser_toolbar_origin_view)),
+                )
+            )
+            .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
     }
 
     fun verifyAboutBrowser() {
         assertTrue(
-            mDevice
-                .findObject(UiSelector().resourceId("$packageName:id/about_content"))
-                .waitForExists(waitingTime),
+            mDevice.findObject(UiSelector().resourceId("$packageName:id/about_content")).waitForExists(waitingTime)
         )
         assertTrue(
-            mDevice
-                .findObject(UiSelector().resourceId("$packageName:id/version_info"))
-                .waitForExists(waitingTime),
+            mDevice.findObject(UiSelector().resourceId("$packageName:id/version_info")).waitForExists(waitingTime)
         )
     }
 
     fun longClickMatchingText(expectedText: String) {
         mDevice.waitForWindowUpdate(packageName, waitingTime)
-        mDevice
-            .findObject(UiSelector().resourceId("$packageName:id/engineView"))
-            .waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView")).waitForExists(waitingTime)
         mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)
         val link = mDevice.findObject(By.textContains(expectedText))
         link.click(LONG_CLICK_DURATION)
@@ -100,9 +79,7 @@ class BrowserRobot {
         try {
             // Long click desired text
             mDevice.waitForWindowUpdate(packageName, waitingTime)
-            mDevice
-                .findObject(UiSelector().resourceId("$packageName:id/engineView"))
-                .waitForExists(waitingTime)
+            mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView")).waitForExists(waitingTime)
             mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)
             val link = mDevice.findObject(By.textContains(expectedText))
             link.click(LONG_CLICK_DURATION)
@@ -122,17 +99,15 @@ class BrowserRobot {
             println("Failed to long click desired text: ${e.localizedMessage}")
 
             // Refresh the page in case the first long click didn't succeed
-            navigationToolbar {
-            }.openThreeDotMenu {
-            }.refreshPage {
-                mDevice.waitForIdle()
-            }
+            navigationToolbar {}
+                .openThreeDotMenu {}
+                .refreshPage {
+                    mDevice.waitForIdle()
+                }
 
             // Long click again the desired text
             mDevice.waitForWindowUpdate(packageName, waitingTime)
-            mDevice
-                .findObject(UiSelector().resourceId("$packageName:id/engineView"))
-                .waitForExists(waitingTime)
+            mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView")).waitForExists(waitingTime)
             mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)
             val link = mDevice.findObject(By.textContains(expectedText))
             link.click(LONG_CLICK_DURATION)
@@ -153,94 +128,42 @@ class BrowserRobot {
 
     fun verifyLinkContextMenuItems() {
         mDevice.waitForWindowUpdate(packageName, waitingTime)
-        mDevice
-            .findObject(UiSelector().resourceId("$packageName:id/parentPanel"))
-            .waitForExists(waitingTime)
-        assertTrue(
-            mDevice
-                .findObject(UiSelector().resourceId("$packageName:id/titleView"))
-                .waitForExists(waitingTime),
-        )
-        assertTrue(
-            mDevice
-                .findObject(UiSelector().textContains("Open link in new tab"))
-                .waitForExists(waitingTime),
-        )
-        assertTrue(
-            mDevice
-                .findObject(UiSelector().textContains("Open link in private tab"))
-                .waitForExists(waitingTime),
-        )
-        assertTrue(
-            mDevice
-                .findObject(UiSelector().textContains("Copy link"))
-                .waitForExists(waitingTime),
-        )
-        assertTrue(
-            mDevice
-                .findObject(UiSelector().textContains("Share link"))
-                .waitForExists(waitingTime),
-        )
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/parentPanel")).waitForExists(waitingTime)
+        assertTrue(mDevice.findObject(UiSelector().resourceId("$packageName:id/titleView")).waitForExists(waitingTime))
+        assertTrue(mDevice.findObject(UiSelector().textContains("Open link in new tab")).waitForExists(waitingTime))
+        assertTrue(mDevice.findObject(UiSelector().textContains("Open link in private tab")).waitForExists(waitingTime))
+        assertTrue(mDevice.findObject(UiSelector().textContains("Copy link")).waitForExists(waitingTime))
+        assertTrue(mDevice.findObject(UiSelector().textContains("Share link")).waitForExists(waitingTime))
     }
 
     fun verifyNoControlsVideoContextMenuItems() {
         mDevice.waitForWindowUpdate(packageName, waitingTime)
-        mDevice
-            .findObject(UiSelector().resourceId("$packageName:id/parentPanel"))
-            .waitForExists(waitingTime)
-        assertTrue(
-            mDevice
-                .findObject(UiSelector().resourceId("$packageName:id/titleView"))
-                .waitForExists(waitingTime),
-        )
-        assertTrue(
-            mDevice
-                .findObject(UiSelector().textContains("Copy link"))
-                .waitForExists(waitingTime),
-        )
-        assertTrue(
-            mDevice
-                .findObject(UiSelector().textContains("Share link"))
-                .waitForExists(waitingTime),
-        )
-        assertTrue(
-            mDevice
-                .findObject(UiSelector().textContains("Save file to device"))
-                .waitForExists(waitingTime),
-        )
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/parentPanel")).waitForExists(waitingTime)
+        assertTrue(mDevice.findObject(UiSelector().resourceId("$packageName:id/titleView")).waitForExists(waitingTime))
+        assertTrue(mDevice.findObject(UiSelector().textContains("Copy link")).waitForExists(waitingTime))
+        assertTrue(mDevice.findObject(UiSelector().textContains("Share link")).waitForExists(waitingTime))
+        assertTrue(mDevice.findObject(UiSelector().textContains("Save file to device")).waitForExists(waitingTime))
     }
 
     fun clickContextOpenLinkInNewTab() {
-        mDevice
-            .findObject(UiSelector().resourceId("$packageName:id/parentPanel"))
-            .waitForExists(waitingTime)
-        mDevice
-            .findObject(UiSelector().textContains("Open link in new tab"))
-            .waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/parentPanel")).waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().textContains("Open link in new tab")).waitForExists(waitingTime)
 
         val contextMenuOpenInNewTab = mDevice.findObject(UiSelector().textContains("Open link in new tab"))
         contextMenuOpenInNewTab.click()
     }
 
     fun clickContextOpenLinkInPrivateTab() {
-        mDevice
-            .findObject(UiSelector().resourceId("$packageName:id/parentPanel"))
-            .waitForExists(waitingTime)
-        mDevice
-            .findObject(UiSelector().textContains("Open link in private tab"))
-            .waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/parentPanel")).waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().textContains("Open link in private tab")).waitForExists(waitingTime)
 
         val contextMenuOpenInNewPrivateTab = mDevice.findObject(UiSelector().textContains("Open link in private tab"))
         contextMenuOpenInNewPrivateTab.click()
     }
 
     fun clickContextCopyLink() {
-        mDevice
-            .findObject(UiSelector().resourceId("$packageName:id/parentPanel"))
-            .waitForExists(waitingTime)
-        mDevice
-            .findObject(UiSelector().textContains("Copy link"))
-            .waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/parentPanel")).waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().textContains("Copy link")).waitForExists(waitingTime)
 
         val contextCopyLink = mDevice.findObject(UiSelector().textContains("Copy link"))
         contextCopyLink.click()
@@ -249,10 +172,9 @@ class BrowserRobot {
     fun waitUntilCopyLinkSnackbarIsGone() =
         mDevice
             .findObject(
-            UiSelector()
-                .resourceId("$packageName:id/snackbar_text")
-                .textContains("Link copied to clipboard"),
-        ).waitUntilGone(waitingTime)
+                UiSelector().resourceId("$packageName:id/snackbar_text").textContains("Link copied to clipboard")
+            )
+            .waitUntilGone(waitingTime)
 
     fun verifyMediaPlayerControlButtonState(state: String) {
         mDevice.findObject(UiSelector().textContains("Audio_Test_Page")).waitForExists(waitingTime)
@@ -267,23 +189,13 @@ class BrowserRobot {
     }
 
     fun clickOpenInAppPromptButton() =
-        mDevice
-            .findObject(
-            UiSelector()
-                .resourceId("android:id/button1")
-                .textContains("OPEN"),
-        ).also {
+        mDevice.findObject(UiSelector().resourceId("android:id/button1").textContains("OPEN")).also {
             it.waitForExists(waitingTime)
             it.click()
         }
 
     fun clickSnackbarSwitchButton() =
-        mDevice
-            .findObject(
-            UiSelector()
-                .resourceId("$packageName:id/snackbar_action")
-                .textContains("SWITCH"),
-        ).also {
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/snackbar_action").textContains("SWITCH")).also {
             it.waitForExists(waitingTime)
             it.click()
         }
@@ -296,12 +208,8 @@ class BrowserRobot {
         }
 
         fun clickContextShareLink(interact: ContentPanelRobot.() -> Unit): ContentPanelRobot.Transition {
-            mDevice
-                .findObject(UiSelector().resourceId("$packageName:id/parentPanel"))
-                .waitForExists(waitingTime)
-            mDevice
-                .findObject(UiSelector().textContains("Share link"))
-                .waitForExists(waitingTime)
+            mDevice.findObject(UiSelector().resourceId("$packageName:id/parentPanel")).waitForExists(waitingTime)
+            mDevice.findObject(UiSelector().textContains("Share link")).waitForExists(waitingTime)
 
             val contextCopyLink = mDevice.findObject(UiSelector().textContains("Share link"))
             contextCopyLink.click()
@@ -313,10 +221,8 @@ class BrowserRobot {
         fun goBack(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
             mDevice.pressBack()
             mDevice
-                .findObject(
-                UiSelector()
-                    .resourceId("$packageName:id/mozac_browser_toolbar_progress"),
-            ).waitUntilGone(waitingTime)
+                .findObject(UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_progress"))
+                .waitUntilGone(waitingTime)
             BrowserRobot().interact()
             return BrowserRobot.Transition()
         }
@@ -329,8 +235,4 @@ fun browser(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
 }
 
 private fun mediaPlayerPlayButton(state: String) =
-    mDevice.findObject(
-        UiSelector()
-            .className("android.widget.Button")
-            .text(state),
-    )
+    mDevice.findObject(UiSelector().className("android.widget.Button").text(state))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ContentPanelRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ContentPanelRobot.kt
@@ -10,9 +10,7 @@ import androidx.test.uiautomator.UiSelector
 import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 
-/**
- * Implementation of Robot Pattern for the content panel.
- */
+/** Implementation of Robot Pattern for the content panel. */
 class ContentPanelRobot {
     fun verifyShareContentPanel() = assertShareContentPanel()
 

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/CustomTabRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/CustomTabRobot.kt
@@ -13,16 +13,14 @@ import androidx.test.espresso.matcher.ViewMatchers.withSubstring
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
+import mozilla.components.browser.toolbar.R as toolbarR
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestHelper.packageName
 import org.mozilla.reference.browser.helpers.click
-import mozilla.components.browser.toolbar.R as toolbarR
 
-/**
- *  Implementation of the robot pattern for Custom tabs
- */
+/** Implementation of the robot pattern for Custom tabs */
 class CustomTabRobot {
     fun verifyCloseButton() = assertCloseButton()
 
@@ -59,9 +57,7 @@ class CustomTabRobot {
     fun clickForwardButton() = forwardButton().click()
 
     fun clickGenericLink(expectedText: String) {
-        mDevice
-            .findObject(UiSelector().resourceId("$packageName:id/engineView"))
-            .waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView")).waitForExists(waitingTime)
         mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)
         val link = mDevice.findObject(By.textContains(expectedText))
         link.click()
@@ -70,29 +66,21 @@ class CustomTabRobot {
     fun switchRequestDesktopSiteToggle() {
         try {
             // Click the Request desktop site toggle
-            mDevice
-                .findObject(UiSelector().textContains("Request desktop site"))
-                .waitForExists(waitingTime)
+            mDevice.findObject(UiSelector().textContains("Request desktop site")).waitForExists(waitingTime)
             requestDesktopButton().click()
             mDevice.waitForIdle()
             assertTrue(
                 mDevice
-                    .findObject(
-                    UiSelector()
-                        .resourceId("$packageName:id/mozac_browser_menu_recyclerView"),
-                ).waitUntilGone(waitingTime),
+                    .findObject(UiSelector().resourceId("$packageName:id/mozac_browser_menu_recyclerView"))
+                    .waitUntilGone(waitingTime)
             )
         } catch (e: AssertionError) {
             println("Failed to click request desktop toggle")
             // If the click didn't succeed the main menu remains displayed and should be dismissed
             mDevice.pressBack()
-            customTabScreen {
-            }.openMainMenu {
-            }
+            customTabScreen {}.openMainMenu {}
             // Click again the Request desktop site toggle
-            mDevice
-                .findObject(UiSelector().textContains("Request desktop site"))
-                .waitForExists(waitingTime)
+            mDevice.findObject(UiSelector().textContains("Request desktop site")).waitForExists(waitingTime)
             requestDesktopButton().click()
             mDevice.waitForIdle()
         }
@@ -210,13 +198,9 @@ private fun assertOpenInBrowserButton() =
     openInBrowserButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertRequestDesktopSiteIsTurnedOff() {
-    assertFalse(
-        mDevice.findObject(UiSelector().textContains("Request desktop site")).isChecked,
-    )
+    assertFalse(mDevice.findObject(UiSelector().textContains("Request desktop site")).isChecked)
 }
 
 private fun assertRequestDesktopSiteIsTurnedOn() {
-    assertTrue(
-        mDevice.findObject(UiSelector().textContains("Request desktop site")).isChecked,
-    )
+    assertTrue(mDevice.findObject(UiSelector().textContains("Request desktop site")).isChecked)
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ExternalAppsRobot.kt
@@ -18,9 +18,7 @@ import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.reference.browser.helpers.TestHelper.packageName
 
-/**
- * Implementation of Robot Pattern for any non-Reference Browser (external) apps.
- */
+/** Implementation of Robot Pattern for any non-Reference Browser (external) apps. */
 class ExternalAppsRobot {
     fun verifyAndroidDefaultApps() = assertDefaultAppsLayout()
 
@@ -48,30 +46,19 @@ private fun assertYouTubeApp() {
     try {
         // Check youtube's home buttons
         mDevice.waitForIdle()
-        assertTrue(
-            mDevice
-                .findObject(UiSelector().text("Home"))
-                .waitForExists(waitingTime),
-        )
-        assertTrue(
-            mDevice
-                .findObject(UiSelector().text("Subscriptions"))
-                .waitForExists(waitingTime),
-        )
+        assertTrue(mDevice.findObject(UiSelector().text("Home")).waitForExists(waitingTime))
+        assertTrue(mDevice.findObject(UiSelector().text("Subscriptions")).waitForExists(waitingTime))
     } catch (e: AssertionError) {
         println("The native youtube app opens but needs to be updated")
         // In case the app isn't up to date on the emulator an update message will be displayed
         assertTrue(
-            mDevice
-                .findObject(UiSelector().text("Update for a faster, better YouTube"))
-                .waitForExists(waitingTime),
+            mDevice.findObject(UiSelector().text("Update for a faster, better YouTube")).waitForExists(waitingTime)
         )
     }
 }
 
 private fun assertFXAQrCode() {
-    onView(withText(R.string.pair_preferences))
-        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    onView(withText(R.string.pair_preferences)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
     onView(withText(R.string.pair_instructions))
         .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/FindInPagePanelRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/FindInPagePanelRobot.kt
@@ -10,6 +10,7 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.uiautomator.UiSelector
+import mozilla.components.feature.findinpage.R as findinpageR
 import org.hamcrest.Matchers.not
 import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.R
@@ -17,11 +18,8 @@ import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestHelper.packageName
 import org.mozilla.reference.browser.helpers.TestHelper.waitForObjects
 import org.mozilla.reference.browser.helpers.click
-import mozilla.components.feature.findinpage.R as findinpageR
 
-/**
- * Implementation of Robot Pattern for the FindInPage Panel.
- */
+/** Implementation of Robot Pattern for the FindInPage Panel. */
 class FindInPagePanelRobot {
     fun verifyFindInPageBar() = assertFindInPageBarExists()
 

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NavigationToolbarRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NavigationToolbarRobot.kt
@@ -16,17 +16,15 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
+import mozilla.components.browser.toolbar.R as toolbarR
+import mozilla.components.ui.tabcounter.R as tabcounterR
 import org.mozilla.fenix.ui.robots.ReaderViewRobot
 import org.mozilla.reference.browser.ext.waitAndInteract
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestHelper.packageName
 import org.mozilla.reference.browser.helpers.click
-import mozilla.components.browser.toolbar.R as toolbarR
-import mozilla.components.ui.tabcounter.R as tabcounterR
 
-/**
- * Implementation of Robot Pattern for the navigation toolbar menu.
- */
+/** Implementation of Robot Pattern for the navigation toolbar menu. */
 class NavigationToolbarRobot {
     fun verifyNoTabAddressView() = assertNoTabAddressText()
 
@@ -48,10 +46,8 @@ class NavigationToolbarRobot {
             mDevice.pressEnter()
 
             mDevice
-                .findObject(
-                UiSelector()
-                    .resourceId("$packageName:id/mozac_browser_toolbar_progress"),
-            ).waitUntilGone(waitingTime)
+                .findObject(UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_progress"))
+                .waitUntilGone(waitingTime)
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()
@@ -59,10 +55,8 @@ class NavigationToolbarRobot {
 
         fun openThreeDotMenu(interact: ThreeDotMenuRobot.() -> Unit): ThreeDotMenuRobot.Transition {
             mDevice
-                .findObject(
-                UiSelector()
-                    .resourceId("$packageName:id/mozac_browser_toolbar_menu"),
-            ).waitForExists(waitingTime)
+                .findObject(UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_menu"))
+                .waitForExists(waitingTime)
             threeDotMenuButton().click()
 
             ThreeDotMenuRobot().interact()
@@ -78,9 +72,7 @@ class NavigationToolbarRobot {
         fun clickToolbar(interact: AwesomeBarRobot.() -> Unit): AwesomeBarRobot.Transition {
             urlBar().click()
             mDevice.waitForIdle()
-            mDevice
-                .findObject(UiSelector().textContains("Search or enter address"))
-                .waitForExists(waitingTime)
+            mDevice.findObject(UiSelector().textContains("Search or enter address")).waitForExists(waitingTime)
             AwesomeBarRobot().interact()
             return AwesomeBarRobot.Transition()
         }
@@ -123,9 +115,8 @@ private fun assertNewTabAddressText(url: String) {
 private fun assertReaderViewButton() {
     mDevice.waitForWindowUpdate(packageName, waitingTime)
     mDevice
-        .findObject(
-        UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_page_actions"),
-    ).waitForExists(waitingTime)
+        .findObject(UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_page_actions"))
+        .waitForExists(waitingTime)
 
     readerViewButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NotificationRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/NotificationRobot.kt
@@ -77,6 +77,5 @@ private fun systemMediaNotificationControlButton(state: String) =
 
 private fun systemMediaNotificationTitle(title: String) = mDevice.findObject(UiSelector().textContains(title))
 
-private val notificationTray = UiScrollable(
-    UiSelector().resourceId("com.android.systemui:id/notification_stack_scroller"),
-).setAsVerticalList()
+private val notificationTray =
+    UiScrollable(UiSelector().resourceId("com.android.systemui:id/notification_stack_scroller")).setAsVerticalList()

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ReaderViewRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ReaderViewRobot.kt
@@ -15,6 +15,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withParent
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiSelector
+import mozilla.components.feature.readerview.R as readerviewR
 import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert.assertEquals
 import org.mozilla.reference.browser.R
@@ -22,11 +23,8 @@ import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestHelper.packageName
 import org.mozilla.reference.browser.helpers.click
 import org.mozilla.reference.browser.ui.robots.mDevice
-import mozilla.components.feature.readerview.R as readerviewR
 
-/**
- * Implementation of Robot Pattern for Reader View UI.
- */
+/** Implementation of Robot Pattern for Reader View UI. */
 class ReaderViewRobot {
     fun verifyAppearanceButtonExists() = assertAppearanceButtonExists()
 
@@ -61,13 +59,13 @@ class ReaderViewRobot {
     fun verifyActiveAppearanceFont(fontType: String) {
         val fontTypeKey: String = "mozac-readerview-fonttype"
 
-        val prefs = InstrumentationRegistry
-            .getInstrumentation()
-            .targetContext
-            .getSharedPreferences(
-                "mozac_feature_reader_view",
-                Context.MODE_PRIVATE,
-            )
+        val prefs =
+            InstrumentationRegistry.getInstrumentation()
+                .targetContext
+                .getSharedPreferences(
+                    "mozac_feature_reader_view",
+                    Context.MODE_PRIVATE,
+                )
 
         assertEquals(fontType, prefs.getString(fontTypeKey, ""))
     }
@@ -75,13 +73,13 @@ class ReaderViewRobot {
     fun verifyAppearanceFontSize(expectedFontSize: Int) {
         val fontSizeKey: String = "mozac-readerview-fontsize"
 
-        val prefs = InstrumentationRegistry
-            .getInstrumentation()
-            .targetContext
-            .getSharedPreferences(
-                "mozac_feature_reader_view",
-                Context.MODE_PRIVATE,
-            )
+        val prefs =
+            InstrumentationRegistry.getInstrumentation()
+                .targetContext
+                .getSharedPreferences(
+                    "mozac_feature_reader_view",
+                    Context.MODE_PRIVATE,
+                )
 
         val fontSizeKeyValue = prefs.getInt(fontSizeKey, 3)
 
@@ -91,13 +89,13 @@ class ReaderViewRobot {
     fun verifyAppearanceColorScheme(expectedColorScheme: String) {
         val colorSchemeKey: String = "mozac-readerview-colorscheme"
 
-        val prefs = InstrumentationRegistry
-            .getInstrumentation()
-            .targetContext
-            .getSharedPreferences(
-                "mozac_feature_reader_view",
-                Context.MODE_PRIVATE,
-            )
+        val prefs =
+            InstrumentationRegistry.getInstrumentation()
+                .targetContext
+                .getSharedPreferences(
+                    "mozac_feature_reader_view",
+                    Context.MODE_PRIVATE,
+                )
 
         assertEquals(expectedColorScheme, prefs.getString(colorSchemeKey, ""))
     }
@@ -117,7 +115,7 @@ private fun appearanceButton() =
         allOf(
             withId(R.id.readerViewAppearanceButton),
             hasSibling(withId(R.id.toolbar)),
-        ),
+        )
     )
 
 private fun appearanceMenu() =
@@ -125,7 +123,7 @@ private fun appearanceMenu() =
         allOf(
             withId(R.id.readerViewAppearanceButton),
             hasSibling(withId(R.id.swipeRefresh)),
-        ),
+        )
     )
 
 private fun fontGroupButtons() =
@@ -133,7 +131,7 @@ private fun fontGroupButtons() =
         allOf(
             withId(readerviewR.id.mozac_feature_readerview_font_group),
             withParent(withId(R.id.readerViewBar)),
-        ),
+        )
     )
 
 private fun sansSerifButton() =
@@ -141,7 +139,7 @@ private fun sansSerifButton() =
         allOf(
             withId(readerviewR.id.mozac_feature_readerview_font_sans_serif),
             withParent(withId(readerviewR.id.mozac_feature_readerview_font_group)),
-        ),
+        )
     )
 
 private fun serifButton() =
@@ -149,7 +147,7 @@ private fun serifButton() =
         allOf(
             withId(readerviewR.id.mozac_feature_readerview_font_serif),
             withParent(withId(readerviewR.id.mozac_feature_readerview_font_group)),
-        ),
+        )
     )
 
 private fun increaseFontSizeButton() =
@@ -157,7 +155,7 @@ private fun increaseFontSizeButton() =
         allOf(
             withText("+"),
             withParent(withId(R.id.readerViewBar)),
-        ),
+        )
     )
 
 private fun decreaseFontSizeButton() =
@@ -165,7 +163,7 @@ private fun decreaseFontSizeButton() =
         allOf(
             withText("−"),
             withParent(withId(R.id.readerViewBar)),
-        ),
+        )
     )
 
 private fun colorSchemeGroupButtons() =
@@ -173,7 +171,7 @@ private fun colorSchemeGroupButtons() =
         allOf(
             withId(readerviewR.id.mozac_feature_readerview_color_scheme_group),
             withParent(withId(R.id.readerViewBar)),
-        ),
+        )
     )
 
 private fun lightColorButton() =
@@ -181,7 +179,7 @@ private fun lightColorButton() =
         allOf(
             withText("Light"),
             withParent(withId(readerviewR.id.mozac_feature_readerview_color_scheme_group)),
-        ),
+        )
     )
 
 private fun sepiaColorButton() =
@@ -189,7 +187,7 @@ private fun sepiaColorButton() =
         allOf(
             withText("Sepia"),
             withParent(withId(readerviewR.id.mozac_feature_readerview_color_scheme_group)),
-        ),
+        )
     )
 
 private fun darkColorButton() =
@@ -197,20 +195,16 @@ private fun darkColorButton() =
         allOf(
             withText("Dark"),
             withParent(withId(readerviewR.id.mozac_feature_readerview_color_scheme_group)),
-        ),
+        )
     )
 
 private fun assertAppearanceButtonExists() {
-    mDevice
-        .findObject(UiSelector().resourceId("$packageName:id/readerViewAppearanceButton"))
-        .waitForExists(waitingTime)
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/readerViewAppearanceButton")).waitForExists(waitingTime)
     appearanceButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 }
 
 private fun assertAppearanceButtonDoesntExists() {
-    mDevice
-        .findObject(UiSelector().resourceId("$packageName:id/readerViewAppearanceButton"))
-        .waitUntilGone(waitingTime)
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/readerViewAppearanceButton")).waitUntilGone(waitingTime)
     appearanceButton().check((matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE))))
 }
 
@@ -222,32 +216,28 @@ private fun assertAppearanceMenu() {
 
 private fun assertFontGroupButtons() {
     mDevice
-        .findObject(
-        UiSelector().resourceId("$packageName:id/:id/mozac_feature_readerview_font_group"),
-    ).waitForExists(waitingTime)
+        .findObject(UiSelector().resourceId("$packageName:id/:id/mozac_feature_readerview_font_group"))
+        .waitForExists(waitingTime)
     fontGroupButtons().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 }
 
 private fun assertIncreaseFontSizeButton() {
     mDevice
-        .findObject(
-        UiSelector().resourceId("$packageName:id/mozac_feature_readerview_font_size_increase"),
-    ).waitForExists(waitingTime)
+        .findObject(UiSelector().resourceId("$packageName:id/mozac_feature_readerview_font_size_increase"))
+        .waitForExists(waitingTime)
     increaseFontSizeButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 }
 
 private fun assertDecreaseFontSizeButton() {
     mDevice
-        .findObject(
-        UiSelector().resourceId("$packageName:id/mozac_feature_readerview_font_size_decrease"),
-    ).waitForExists(waitingTime)
+        .findObject(UiSelector().resourceId("$packageName:id/mozac_feature_readerview_font_size_decrease"))
+        .waitForExists(waitingTime)
     decreaseFontSizeButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 }
 
 private fun assertColorSchemeGroupButtons() {
     mDevice
-        .findObject(
-        UiSelector().resourceId("$packageName:id/mozac_feature_readerview_color_scheme_group"),
-    ).waitForExists(waitingTime)
+        .findObject(UiSelector().resourceId("$packageName:id/mozac_feature_readerview_color_scheme_group"))
+        .waitForExists(waitingTime)
     colorSchemeGroupButtons().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewPrivacyRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewPrivacyRobot.kt
@@ -11,9 +11,7 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.Until
 import org.mozilla.reference.browser.helpers.TestAssetHelper
 
-/**
- * Implementation of Robot Pattern for the settings privacy menu.
- */
+/** Implementation of Robot Pattern for the settings privacy menu. */
 class SettingsViewPrivacyRobot {
     fun verifyPrivacyUpButton() = assertPrivacyUpButton()
 
@@ -57,28 +55,28 @@ private fun assertPrivacyUpButton() {
 
 private fun assertPrivacySettingsView() =
     privacySettingsView()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertTrackingProtectionHeading() =
     trackingProtectionHeading()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertTpEnableInNormalBrowsing() =
     tpEnableInNormalBrowsing()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertTpEnableInPrivateBrowsing() =
     tpEnableInPrivateBrowsing()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertDataChoicesHeading() =
     dataChoicesHeading()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertUseTelemetryToggle() =
     useTelemetryToggle()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertTelemetrySummary() =
     telemetrySummary()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SettingsViewRobot.kt
@@ -30,9 +30,7 @@ import org.mozilla.reference.browser.helpers.TestHelper.packageName
 import org.mozilla.reference.browser.helpers.click
 import org.mozilla.reference.browser.helpers.hasCousin
 
-/**
- * Implementation of Robot Pattern for the settings menu.
- */
+/** Implementation of Robot Pattern for the settings menu. */
 class SettingsViewRobot {
     fun verifySettingsViewExists() = assertSettingsView()
 
@@ -80,15 +78,13 @@ class SettingsViewRobot {
 
     // toggleRemoteDebugging does not yet verify that the debug service is started
     // server runs on port 6000
-    fun toggleRemoteDebuggingOn() =
-        {
+    fun toggleRemoteDebuggingOn() = {
         Espresso.onView(withText("OFF")).check(matches(isDisplayed()))
         remoteDebuggingToggle().click()
         Espresso.onView(withText("ON")).check(matches(isDisplayed()))
     }
 
-    fun toggleRemoteDebuggingOff() =
-        {
+    fun toggleRemoteDebuggingOff() = {
         Espresso.onView(withText("ON")).check(matches(isDisplayed()))
         remoteDebuggingToggle().click()
         Espresso.onView(withText("OFF")).check(matches(isDisplayed()))
@@ -96,7 +92,7 @@ class SettingsViewRobot {
 
     class Transition {
         fun openSettingsViewPrivacy(
-            interact: SettingsViewPrivacyRobot.() -> Unit,
+            interact: SettingsViewPrivacyRobot.() -> Unit
         ): SettingsViewPrivacyRobot.Transition {
             privacyButton().click()
             SettingsViewPrivacyRobot().interact()
@@ -144,11 +140,7 @@ class SettingsViewRobot {
 }
 
 private fun waitForSettingsRecyclerViewToExist() {
-    mDevice
-        .findObject(UiSelector().resourceId("$packageName:id/recycler_view"))
-        .waitForExists(
-            waitingTime,
-        )
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/recycler_view")).waitForExists(waitingTime)
 }
 
 private fun assertSettingsView() {
@@ -156,15 +148,11 @@ private fun assertSettingsView() {
     assertTrue(
         mDevice
             .findObject(
-            UiSelector()
-                .resourceId("$packageName:id/action_bar")
-                .childSelector(
-                    UiSelector()
-                        .textContains(
-                            getStringResource(R.string.settings),
-                        ),
-                ),
-        ).waitForExists(waitingTime),
+                UiSelector()
+                    .resourceId("$packageName:id/action_bar")
+                    .childSelector(UiSelector().textContains(getStringResource(R.string.settings)))
+            )
+            .waitForExists(waitingTime)
     )
 }
 
@@ -182,11 +170,11 @@ private fun privacySummary() = Espresso.onView(withText(R.string.preferences_pri
 
 private fun openLinksInAppsToggle() =
     Espresso.onView(
-    allOf(
-        withId(androidx.preference.R.id.switchWidget),
-        hasCousin(withText(R.string.open_links_in_apps)),
-    ),
-)
+        allOf(
+            withId(androidx.preference.R.id.switchWidget),
+            hasCousin(withText(R.string.open_links_in_apps)),
+        )
+    )
 
 private fun makeDefaultBrowserButton() = Espresso.onView(withText(R.string.preferences_make_default_browser))
 
@@ -200,11 +188,11 @@ private fun developerToolsHeading() = Espresso.onView(withText(R.string.develope
 
 private fun remoteDebuggingToggle() =
     Espresso.onView(
-    allOf(
-        withId(androidx.preference.R.id.switchWidget),
-        hasCousin(withText(R.string.preferences_remote_debugging)),
-    ),
-)
+        allOf(
+            withId(androidx.preference.R.id.switchWidget),
+            hasCousin(withText(R.string.preferences_remote_debugging)),
+        )
+    )
 
 private fun customAddonCollectionButton() = onView(withText("Custom Add-on collection"))
 
@@ -219,76 +207,62 @@ private fun assertNavigateUpButton() {
 private fun assertSyncSigninButton() = assertUIObjectExists(syncSignInButton())
 
 private fun assertSyncHistorySummary() =
-    syncHistorySummary()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    syncHistorySummary().check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertSyncQrCodeButton() =
-    syncQrCodeButton()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    syncQrCodeButton().check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertSyncQrSummary() =
-    syncQrSummary()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    syncQrSummary().check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertPrivacyButton() =
-    privacyButton()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    privacyButton().check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertPrivacySummary() =
-    privacySummary()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    privacySummary().check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertOpenLinksInApps() =
-    openLinksInAppsToggle()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    openLinksInAppsToggle().check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertMakeDefaultBrowserButton() =
-    makeDefaultBrowserButton()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    makeDefaultBrowserButton().check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertAutofillAppsButton() =
-    autofillAppsButton()
-    .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    autofillAppsButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertAutofillAppsSummary() =
-    autofillAppsSummary()
-    .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    autofillAppsSummary().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertJetpackComposeButton() =
-    jetpackComposeButton()
-    .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    jetpackComposeButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertDeveloperToolsHeading() =
-    developerToolsHeading()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    developerToolsHeading().check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertRemoteDebugging() =
-    remoteDebuggingToggle()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    remoteDebuggingToggle().check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertCustomAddonCollectionButton() =
-    customAddonCollectionButton()
-    .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    customAddonCollectionButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertMozillaHeading() =
     mozillaHeading().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertAboutReferenceBrowserButton() =
-    aboutReferenceBrowserButton()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    aboutReferenceBrowserButton().check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertCustomAddonCollectionPanel() {
     mDevice.waitForIdle()
-    mDevice
-        .findObject(UiSelector().resourceId("$packageName:id/parentPanel"))
-        .waitForExists(waitingTime)
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/parentPanel")).waitForExists(waitingTime)
     onView(
-        allOf(
-            withText(R.string.preferences_customize_amo_collection),
-            anyOf(
-                withId(androidx.appcompat.R.id.alertTitle),
-                withId(android.R.id.title),
-            ),
-        ),
-    ).inRoot(isDialog()).check(matches(isCompletelyDisplayed()))
+            allOf(
+                withText(R.string.preferences_customize_amo_collection),
+                anyOf(
+                    withId(androidx.appcompat.R.id.alertTitle),
+                    withId(android.R.id.title),
+                ),
+            )
+        )
+        .inRoot(isDialog())
+        .check(matches(isCompletelyDisplayed()))
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SyncedTabsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/SyncedTabsRobot.kt
@@ -11,9 +11,7 @@ import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestHelper.getStringResource
 import org.mozilla.reference.browser.helpers.TestHelper.packageName
 
-/**
- * Implementation of Robot Pattern for Synced Tabs sub menu.
- */
+/** Implementation of Robot Pattern for Synced Tabs sub menu. */
 class SyncedTabsRobot {
     fun verifyNotSignedInSyncTabsView() = assertNotSignedInSyncTabsView()
 
@@ -28,10 +26,11 @@ class SyncedTabsRobot {
         assertTrue(
             mDevice
                 .findObject(
-                UiSelector()
-                    .resourceId("$packageName:id/synced_tabs_status")
-                    .textContains(getStringResource(R.string.synced_tabs_connect_to_sync_account)),
-            ).waitForExists(waitingTime),
+                    UiSelector()
+                        .resourceId("$packageName:id/synced_tabs_status")
+                        .textContains(getStringResource(R.string.synced_tabs_connect_to_sync_account))
+                )
+                .waitForExists(waitingTime)
         )
     }
 }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMenuRobot.kt
@@ -28,10 +28,7 @@ import org.mozilla.reference.browser.helpers.assertIsSelected
 import org.mozilla.reference.browser.helpers.click
 import org.mozilla.reference.browser.helpers.matchers.TabMatcher
 
-/**
- * Implementation of Robot Pattern for the tab tray menu.
- */
-
+/** Implementation of Robot Pattern for the tab tray menu. */
 val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
 class TabTrayMenuRobot {
@@ -125,20 +122,16 @@ private fun closeTabButtonTabTray() = onView(withId(R.id.mozac_browser_tabstray_
 private fun tab() = onView(TabMatcher.withText("about:blank"))
 
 private fun assertRegularBrowsingTabs() =
-    regularTabs()
-    .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    regularTabs().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertPrivateBrowsingTabs() =
-    privateTabs()
-    .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    privateTabs().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertGoBackButton() =
-    goBackButton()
-    .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    goBackButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertNewTabButton() =
-    newTabButton()
-    .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    newTabButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertPrivateTabs() {
     mDevice.wait(Until.findObject(By.text("Private Browsing")), waitingTime)
@@ -155,12 +148,8 @@ private fun assertThereAreNoPrivateTabsOpen() {
 
 private fun assertExistingOpenTabs(title: String) {
     mDevice.waitForIdle()
-    mDevice
-        .findObject(UiSelector().resourceId("${TestHelper.packageName}:id/tabsTray"))
-        .waitForExists(waitingTime)
-    Assert.assertTrue(
-        mDevice.findObject(UiSelector().textContains(title)).waitForExists(waitingTime),
-    )
+    mDevice.findObject(UiSelector().resourceId("${TestHelper.packageName}:id/tabsTray")).waitForExists(waitingTime)
+    Assert.assertTrue(mDevice.findObject(UiSelector().textContains(title)).waitForExists(waitingTime))
 }
 
 private fun openTab(title: String) = mDevice.findObject(UiSelector().textContains(title))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMoreOptionsMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/TabTrayMoreOptionsMenuRobot.kt
@@ -15,10 +15,9 @@ import org.mozilla.reference.browser.ext.waitAndInteract
 import org.mozilla.reference.browser.helpers.click
 
 /**
- * Implementation of Robot Pattern for menu in tab tray that shows more options.
- * So far only Close All Tabs is implemented.
+ * Implementation of Robot Pattern for menu in tab tray that shows more options. So far only Close All Tabs is
+ * implemented.
  */
-
 class TabTrayMoreOptionsMenuRobot {
     fun verifyCloseAllTabsButton() = assertCloseAllTabsButton()
 
@@ -54,4 +53,4 @@ private fun assertCloseAllTabsButton() {
 
 private fun assertCloseAllPrivateTabsButton() =
     closeAllPrivateTabsButton()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/ThreeDotMenuRobot.kt
@@ -12,17 +12,15 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.uiautomator.UiSelector
 import junit.framework.AssertionFailedError
+import mozilla.components.browser.menu.R as menuR
+import mozilla.components.browser.toolbar.R as toolbarR
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestHelper.packageName
 import org.mozilla.reference.browser.helpers.click
-import mozilla.components.browser.menu.R as menuR
-import mozilla.components.browser.toolbar.R as toolbarR
 
-/**
- * Implementation of Robot Pattern for three dot menu.
- */
+/** Implementation of Robot Pattern for three dot menu. */
 class ThreeDotMenuRobot {
     fun verifyThreeDotMenuExists() = threeDotMenuRecyclerViewExists()
 
@@ -70,10 +68,8 @@ class ThreeDotMenuRobot {
         fun goForward(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
             forwardButton().click()
             mDevice
-                .findObject(
-                UiSelector()
-                    .resourceId("$packageName:id/mozac_browser_toolbar_progress"),
-            ).waitUntilGone(waitingTime)
+                .findObject(UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_progress"))
+                .waitUntilGone(waitingTime)
             mDevice.waitForIdle()
 
             BrowserRobot().interact()
@@ -100,38 +96,30 @@ class ThreeDotMenuRobot {
         }
 
         fun switchRequestDesktopSiteToggle(
-            interact: NavigationToolbarRobot.() -> Unit,
+            interact: NavigationToolbarRobot.() -> Unit
         ): NavigationToolbarRobot.Transition {
             try {
-                mDevice
-                    .findObject(UiSelector().textContains("Request desktop site"))
-                    .waitForExists(waitingTime)
+                mDevice.findObject(UiSelector().textContains("Request desktop site")).waitForExists(waitingTime)
                 requestDesktopSiteToggle().click()
                 mDevice.waitForIdle()
                 assertTrue(
                     mDevice
-                        .findObject(
-                        UiSelector()
-                            .resourceId("$packageName:id/mozac_browser_menu_recyclerView"),
-                    ).waitUntilGone(waitingTime),
+                        .findObject(UiSelector().resourceId("$packageName:id/mozac_browser_menu_recyclerView"))
+                        .waitUntilGone(waitingTime)
                 )
             } catch (e: AssertionFailedError) {
                 println("Failed to click request desktop toggle")
                 // If the click didn't succeed the main menu remains displayed and should be dismissed
                 mDevice.pressBack()
                 threeDotMenuButton().click()
-                mDevice
-                    .findObject(UiSelector().textContains("Request desktop site"))
-                    .waitForExists(waitingTime)
+                mDevice.findObject(UiSelector().textContains("Request desktop site")).waitForExists(waitingTime)
                 // Click again the Request desktop site toggle
                 requestDesktopSiteToggle().click()
                 mDevice.waitForIdle()
                 assertTrue(
                     mDevice
-                        .findObject(
-                        UiSelector()
-                            .resourceId("$packageName:id/mozac_browser_menu_recyclerView"),
-                    ).waitUntilGone(waitingTime),
+                        .findObject(UiSelector().resourceId("$packageName:id/mozac_browser_menu_recyclerView"))
+                        .waitUntilGone(waitingTime)
                 )
             }
             NavigationToolbarRobot().interact()
@@ -230,62 +218,49 @@ private fun assertRefreshButtonDoesntExist() = refreshButton().check(ViewAsserti
 
 private fun assertStopButtonDoesntExist() = stopButton().check(ViewAssertions.doesNotExist())
 
-private fun assertAddToHomescreenButtonDoesntExist() =
-    addToHomescreenButton()
-    .check(ViewAssertions.doesNotExist())
+private fun assertAddToHomescreenButtonDoesntExist() = addToHomescreenButton().check(ViewAssertions.doesNotExist())
 
 private fun assertForwardButton() =
-    forwardButton()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    forwardButton().check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertRefreshButton() =
-    refreshButton()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    refreshButton().check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertStopButton() =
-    stopButton()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    stopButton().check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertShareButton() =
-    shareButton()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    shareButton().check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertRequestDesktopSiteToggle() =
     requestDesktopSiteToggle()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertAddToHomescreenButton() =
-    addToHomescreenButton()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    addToHomescreenButton().check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertFindInPageButton() =
     findInPageButton()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertAddOnsButton() =
-    addOnsButton()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    addOnsButton().check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertSyncedTabsButton() =
-    syncedTabsButton()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    syncedTabsButton().check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertReportIssueButton() =
     reportIssueButton()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertSettingsButton() =
     settingsButton()
-    .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertRequestDesktopSiteIsTurnedOff() {
-    assertFalse(
-        mDevice.findObject(UiSelector().textContains("Request desktop site")).isChecked,
-    )
+    assertFalse(mDevice.findObject(UiSelector().textContains("Request desktop site")).isChecked)
 }
 
 private fun assertRequestDesktopSiteIsTurnedOn() {
-    assertTrue(
-        mDevice.findObject(UiSelector().textContains("Request desktop site")).isChecked,
-    )
+    assertTrue(mDevice.findObject(UiSelector().textContains("Request desktop site")).isChecked)
 }

--- a/app/src/main/java/mozilla/components/compose/browser/toolbar/BrowserToolbar.kt
+++ b/app/src/main/java/mozilla/components/compose/browser/toolbar/BrowserToolbar.kt
@@ -68,8 +68,6 @@ fun BrowserEditToolbar(
         onValueChange = { value -> input = value },
         singleLine = true,
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri, imeAction = ImeAction.Go),
-        keyboardActions = KeyboardActions(
-            onGo = { onUrlCommitted(input) },
-        ),
+        keyboardActions = KeyboardActions(onGo = { onUrlCommitted(input) }),
     )
 }

--- a/app/src/main/java/mozilla/components/lib/state/Store.kt
+++ b/app/src/main/java/mozilla/components/lib/state/Store.kt
@@ -5,21 +5,21 @@
 package mozilla.components.lib.state
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State as ComposeState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import mozilla.components.lib.state.ext.observe
-import androidx.compose.runtime.State as ComposeState
 
 /**
- * Starts observing this [Store] and represents the mapped state (using [map]) via [ComposeState].
- * Every time the [Store] state changes the returned [ComposeState] will be updated causing
- * recomposition of every [ComposeState.value] usage.
+ * Starts observing this [Store] and represents the mapped state (using [map]) via [ComposeState]. Every time the
+ * [Store] state changes the returned [ComposeState] will be updated causing recomposition of every [ComposeState.value]
+ * usage.
  *
- * The [Store] observer will automatically be removed when this composable disposes or the current
- * [LifecycleOwner] moves to the [Lifecycle.State.DESTROYED] state.
+ * The [Store] observer will automatically be removed when this composable disposes or the current [LifecycleOwner]
+ * moves to the [Lifecycle.State.DESTROYED] state.
  */
 @Composable
 fun <S : State, A : Action, R> Store<S, A>.observeAsState(map: (S) -> R): ComposeState<R?> {

--- a/app/src/main/java/org/mozilla/reference/browser/AppRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/AppRequestInterceptor.kt
@@ -18,12 +18,10 @@ import org.mozilla.reference.browser.tabs.PrivatePage
 
 /**
  * NB, and FIXME: this class is consumed by a 'Core' component group, but itself relies on 'firefoxAccountsFeature'
- * component; this creates a circular dependency, since firefoxAccountsFeature relies on tabsUseCases
- * which in turn needs 'core' itself.
+ * component; this creates a circular dependency, since firefoxAccountsFeature relies on tabsUseCases which in turn
+ * needs 'core' itself.
  */
-class AppRequestInterceptor(
-    private val context: Context,
-) : RequestInterceptor {
+class AppRequestInterceptor(private val context: Context) : RequestInterceptor {
     override fun onLoadRequest(
         engineSession: EngineSession,
         uri: String,
@@ -58,16 +56,17 @@ class AppRequestInterceptor(
                     isRedirect,
                     isDirectNavigation,
                     isSubframeRequest,
-                ) ?: context.components.services.appLinksInterceptor.onLoadRequest(
-                    engineSession,
-                    uri,
-                    lastUri,
-                    hasUserGesture,
-                    isSameDomain,
-                    isRedirect,
-                    isDirectNavigation,
-                    isSubframeRequest,
                 )
+                    ?: context.components.services.appLinksInterceptor.onLoadRequest(
+                        engineSession,
+                        uri,
+                        lastUri,
+                        hasUserGesture,
+                        isSameDomain,
+                        isRedirect,
+                        isDirectNavigation,
+                        isSubframeRequest,
+                    )
             }
         }
 

--- a/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
@@ -32,9 +32,7 @@ import org.mozilla.reference.browser.browser.BrowserFragment
 import org.mozilla.reference.browser.browser.CrashIntegration
 import org.mozilla.reference.browser.ext.components
 
-/**
- * Activity that holds the [BrowserFragment].
- */
+/** Activity that holds the [BrowserFragment]. */
 open class BrowserActivity : AppCompatActivity() {
     private lateinit var crashIntegration: CrashIntegration
 
@@ -45,9 +43,7 @@ open class BrowserActivity : AppCompatActivity() {
         WebExtensionPopupObserver(components.core.store, ::openPopup)
     }
 
-    /**
-     * Returns a new instance of [BrowserFragment] to display.
-     */
+    /** Returns a new instance of [BrowserFragment] to display. */
     open fun createBrowserFragment(sessionId: String?): Fragment = BrowserFragment.create(sessionId)
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -65,9 +61,10 @@ open class BrowserActivity : AppCompatActivity() {
             }
         }
 
-        crashIntegration = CrashIntegration(this, components.analytics.crashReporter) { crash ->
-            onNonFatalCrash(crash)
-        }
+        crashIntegration =
+            CrashIntegration(this, components.analytics.crashReporter) { crash ->
+                onNonFatalCrash(crash)
+            }
         lifecycle.addObserver(crashIntegration)
 
         NotificationManager.checkAndNotifyPolicy(this)
@@ -91,7 +88,7 @@ open class BrowserActivity : AppCompatActivity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         Logger.info(
             "Activity onActivityResult received with " +
-                "requestCode: $requestCode, resultCode: $resultCode, data: $data",
+                "requestCode: $requestCode, resultCode: $resultCode, data: $data"
         )
 
         supportFragmentManager.fragments.forEach {
@@ -126,9 +123,7 @@ open class BrowserActivity : AppCompatActivity() {
     ): View? =
         when (name) {
             EngineView::class.java.name -> {
-                components.core.engine
-                .createView(context, attrs)
-                .asView()
+                components.core.engine.createView(context, attrs).asView()
             }
 
             else -> {
@@ -137,11 +132,11 @@ open class BrowserActivity : AppCompatActivity() {
         }
 
     private fun onNonFatalCrash(crash: Crash) {
-        Snackbar
-            .make(findViewById(android.R.id.content), R.string.crash_report_non_fatal_message, LENGTH_LONG)
+        Snackbar.make(findViewById(android.R.id.content), R.string.crash_report_non_fatal_message, LENGTH_LONG)
             .setAction(R.string.crash_report_non_fatal_action) {
                 crashIntegration.sendCrashReport(crash)
-            }.show()
+            }
+            .show()
     }
 
     private fun openPopup(webExtensionState: WebExtensionState) {

--- a/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserApplication.kt
@@ -5,6 +5,7 @@
 package org.mozilla.reference.browser
 
 import android.app.Application
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -14,6 +15,7 @@ import mozilla.components.concept.engine.webextension.isUnsupported
 import mozilla.components.concept.push.PushProcessor
 import mozilla.components.feature.addons.update.GlobalAddonDependencyProvider
 import mozilla.components.support.AppServicesInitializer
+import mozilla.components.support.AppServicesInitializer.Config as AppServicesConfig
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.log.sink.AndroidLogSink
@@ -23,8 +25,6 @@ import mozilla.components.support.rusthttp.RustHttpConfig
 import mozilla.components.support.webextensions.WebExtensionSupport
 import org.mozilla.reference.browser.push.PushFxaIntegration
 import org.mozilla.reference.browser.push.WebPushEngineIntegration
-import java.util.concurrent.TimeUnit
-import mozilla.components.support.AppServicesInitializer.Config as AppServicesConfig
 
 open class BrowserApplication : Application() {
     val components by lazy { Components(this) }
@@ -34,9 +34,7 @@ open class BrowserApplication : Application() {
 
         setupCrashReporting(this)
 
-        AppServicesInitializer.init(
-            AppServicesConfig(components.analytics.crashReporter),
-        )
+        AppServicesInitializer.init(AppServicesConfig(components.analytics.crashReporter))
         RustHttpConfig.setClient(lazy { components.core.client })
 
         Log.addSink(AndroidLogSink())
@@ -61,12 +59,13 @@ open class BrowserApplication : Application() {
             runtime = components.core.engine,
             store = components.core.store,
             onNewTabOverride = { _, engineSession, url, selected, isPrivate ->
-                val tabId = components.useCases.tabsUseCases.addTab(
-                    url = url,
-                    selectTab = selected,
-                    engineSession = engineSession,
-                    private = isPrivate,
-                )
+                val tabId =
+                    components.useCases.tabsUseCases.addTab(
+                        url = url,
+                        selectTab = selected,
+                        engineSession = engineSession,
+                        private = isPrivate,
+                    )
                 tabId
             },
             onCloseTabOverride = { _, sessionId ->
@@ -122,19 +121,19 @@ open class BrowserApplication : Application() {
     @OptIn(DelicateCoroutinesApi::class)
     private fun restoreBrowserState() =
         GlobalScope.launch(Dispatchers.Main) {
-        val store = components.core.store
-        val sessionStorage = components.core.sessionStorage
+            val store = components.core.store
+            val sessionStorage = components.core.sessionStorage
 
-        components.useCases.tabsUseCases.restore(sessionStorage)
+            components.useCases.tabsUseCases.restore(sessionStorage)
 
-        // Now that we have restored our previous state (if there's one) let's setup auto saving the state while
-        // the app is used.
-        sessionStorage
-            .autoSave(store)
-            .periodicallyInForeground(interval = 30, unit = TimeUnit.SECONDS)
-            .whenGoingToBackground()
-            .whenSessionsChange()
-    }
+            // Now that we have restored our previous state (if there's one) let's setup auto saving the state while
+            // the app is used.
+            sessionStorage
+                .autoSave(store)
+                .periodicallyInForeground(interval = 30, unit = TimeUnit.SECONDS)
+                .whenGoingToBackground()
+                .whenSessionsChange()
+        }
 
     companion object {
         const val NON_FATAL_CRASH_BROADCAST = "org.mozilla.reference.browser"
@@ -142,9 +141,5 @@ open class BrowserApplication : Application() {
 }
 
 private fun setupCrashReporting(application: BrowserApplication) {
-    application
-        .components
-        .analytics
-        .crashReporter
-        .install(application)
+    application.components.analytics.crashReporter.install(application)
 }

--- a/app/src/main/java/org/mozilla/reference/browser/Components.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/Components.kt
@@ -25,12 +25,8 @@ import org.mozilla.reference.browser.components.Services
 import org.mozilla.reference.browser.components.UseCases
 import org.mozilla.reference.browser.components.Utilities
 
-/**
- * Provides access to all components.
- */
-class Components(
-    private val context: Context,
-) {
+/** Provides access to all components. */
+class Components(private val context: Context) {
     val core by lazy { Core(context, analytics.crashReporter) }
     val useCases by lazy {
         UseCases(
@@ -81,9 +77,7 @@ class Components(
     private val notificationManagerCompat = NotificationManagerCompat.from(context)
 
     val notificationsDelegate: NotificationsDelegate by lazy {
-        NotificationsDelegate(
-            notificationManagerCompat,
-        )
+        NotificationsDelegate(notificationManagerCompat)
     }
 
     val fileSizeFormatter: FileSizeFormatter by lazy { DefaultFileSizeFormatter(context.applicationContext) }

--- a/app/src/main/java/org/mozilla/reference/browser/CrashListActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/CrashListActivity.kt
@@ -16,33 +16,27 @@ import mozilla.components.lib.crash.ui.AbstractCrashListFragment
 import mozilla.components.support.ktx.android.view.setupPersistentInsets
 import org.mozilla.reference.browser.ext.requireComponents
 
-/**
- * A simple activity whose only purpose is to load the [CrashListFragment].
- */
+/** A simple activity whose only purpose is to load the [CrashListFragment]. */
 class CrashListActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge(SystemBarStyle.dark(Color.TRANSPARENT))
         super.onCreate(savedInstanceState)
         window.setupPersistentInsets()
 
-        supportFragmentManager
-            .beginTransaction()
-            .add(android.R.id.content, CrashListFragment())
-            .commit()
+        supportFragmentManager.beginTransaction().add(android.R.id.content, CrashListFragment()).commit()
     }
 }
 
-/**
- * An [AbstractCrashListFragment] implementor that uses the application [CrashReporter].
- */
+/** An [AbstractCrashListFragment] implementor that uses the application [CrashReporter]. */
 class CrashListFragment : AbstractCrashListFragment() {
     override val reporter: CrashReporter by lazy { requireComponents.analytics.crashReporter }
 
     override fun onCrashServiceSelected(url: String) {
-        val intent = Intent(Intent.ACTION_VIEW).apply {
-            data = url.toUri()
-            `package` = context?.packageName
-        }
+        val intent =
+            Intent(Intent.ACTION_VIEW).apply {
+                data = url.toUri()
+                `package` = context?.packageName
+            }
         startActivity(intent)
         activity?.finish()
     }

--- a/app/src/main/java/org/mozilla/reference/browser/ExternalAppBrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/ExternalAppBrowserActivity.kt
@@ -11,24 +11,23 @@ import mozilla.components.feature.pwa.ext.getWebAppManifest
 import org.mozilla.reference.browser.browser.ExternalAppBrowserFragment
 
 /**
- * Activity that holds the BrowserFragment that is launched within an external app,
- * such as custom tabs and progressive web apps.
+ * Activity that holds the BrowserFragment that is launched within an external app, such as custom tabs and progressive
+ * web apps.
  */
 class ExternalAppBrowserActivity : BrowserActivity() {
     override fun createBrowserFragment(sessionId: String?): Fragment =
         if (sessionId != null) {
             val manifest = intent.getWebAppManifest()
-            val scope = when (manifest?.display) {
-                WebAppManifest.DisplayMode.FULLSCREEN,
-                WebAppManifest.DisplayMode.STANDALONE,
-                -> (manifest.scope ?: manifest.startUrl).toUri()
+            val scope =
+                when (manifest?.display) {
+                    WebAppManifest.DisplayMode.FULLSCREEN,
+                    WebAppManifest.DisplayMode.STANDALONE -> (manifest.scope ?: manifest.startUrl).toUri()
 
-                WebAppManifest.DisplayMode.MINIMAL_UI,
-                WebAppManifest.DisplayMode.BROWSER,
-                -> null
+                    WebAppManifest.DisplayMode.MINIMAL_UI,
+                    WebAppManifest.DisplayMode.BROWSER -> null
 
-                else -> null
-            }
+                    else -> null
+                }
 
             ExternalAppBrowserFragment.create(
                 sessionId,

--- a/app/src/main/java/org/mozilla/reference/browser/IntentReceiverActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/IntentReceiverActivity.kt
@@ -30,11 +30,12 @@ class IntentReceiverActivity : Activity() {
         MainScope().launch {
             val processor = utils.intentProcessors.firstOrNull { it.process(intent) }
 
-            val className = if (processor in utils.externalIntentProcessors) {
-                ExternalAppBrowserActivity::class
-            } else {
-                BrowserActivity::class
-            }
+            val className =
+                if (processor in utils.externalIntentProcessors) {
+                    ExternalAppBrowserActivity::class
+                } else {
+                    BrowserActivity::class
+                }
 
             intent.setClassName(applicationContext, className.java.name)
 

--- a/app/src/main/java/org/mozilla/reference/browser/NotificationManager.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/NotificationManager.kt
@@ -7,6 +7,7 @@ package org.mozilla.reference.browser
 import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
+import android.app.NotificationManager as AndroidNotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -23,11 +24,8 @@ import mozilla.components.concept.sync.TabData
 import mozilla.components.support.base.ids.SharedIdsHelper
 import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.reference.browser.IntentRequestCodes.REQUEST_CODE_DATA_REPORTING
-import android.app.NotificationManager as AndroidNotificationManager
 
-/**
- * Manages notification channels and allows displaying different supported types of notifications.
- */
+/** Manages notification channels and allows displaying different supported types of notifications. */
 object NotificationManager {
     // Send Tab
     private const val RECEIVE_TABS_TAG = "org.mozilla.reference.browser.receivedTabs"
@@ -39,8 +37,7 @@ object NotificationManager {
     private const val DATA_REPORTING_TAG = "org.mozilla.reference.browser.DataReporting"
     private const val DATA_REPORTING_NOTIFICATION_ID = 1
     private const val PREFS_POLICY_VERSION = "datareporting.policy.dataSubmissionPolicyVersion"
-    private const val PREFS_POLICY_NOTIFIED_TIME =
-        "datareporting.policy.dataSubmissionPolicyNotifiedTime"
+    private const val PREFS_POLICY_NOTIFIED_TIME = "datareporting.policy.dataSubmissionPolicyNotifiedTime"
 
     // Default
     private const val NOTIFICATION_CHANNEL_ID = "default-notification-channel"
@@ -65,50 +62,55 @@ object NotificationManager {
         logger.debug("Showing ${tabs.size} tab(s) received from deviceID=${device?.id}")
 
         tabs.forEach { tab ->
-            val intent = Intent(Intent.ACTION_VIEW, tab.url.toUri()).apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK
-            }
-            val flags = if (SDK_INT >= Build.VERSION_CODES.S) {
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_ONE_SHOT
-            } else {
-                PendingIntent.FLAG_ONE_SHOT
-            }
+            val intent =
+                Intent(Intent.ACTION_VIEW, tab.url.toUri()).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                }
+            val flags =
+                if (SDK_INT >= Build.VERSION_CODES.S) {
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_ONE_SHOT
+                } else {
+                    PendingIntent.FLAG_ONE_SHOT
+                }
             val notificationId = SharedIdsHelper.getNextIdForTag(context, RECEIVE_TABS_TAG)
-            val pendingIntent: PendingIntent = PendingIntent.getActivity(
-                context,
-                notificationId,
-                intent,
-                flags,
-            )
+            val pendingIntent: PendingIntent =
+                PendingIntent.getActivity(
+                    context,
+                    notificationId,
+                    intent,
+                    flags,
+                )
             // We pick 'IMPORTANCE_HIGH' priority because this is a user-triggered action that is
             // expected to be part of a continuity flow. That is, user is expected to be waiting for
             // this notification on their device; make it obvious.
             val importance = AndroidNotificationManager.IMPORTANCE_HIGH
-            val channelId = getNotificationChannelId(
-                context,
-                RECEIVE_TABS_CHANNEL_ID,
-                context.getString(R.string.fxa_received_tab_channel_name),
-                context.getString(R.string.fxa_received_tab_channel_description),
-                importance,
-            )
+            val channelId =
+                getNotificationChannelId(
+                    context,
+                    RECEIVE_TABS_CHANNEL_ID,
+                    context.getString(R.string.fxa_received_tab_channel_name),
+                    context.getString(R.string.fxa_received_tab_channel_description),
+                    importance,
+                )
 
-            val builder = NotificationCompat
-                .Builder(context, channelId)
-                .setSmallIcon(R.drawable.ic_notification)
-                .setSendTabTitle(context, device, tab)
-                .setWhen(System.currentTimeMillis())
-                .setContentText(tab.url)
-                .setContentIntent(pendingIntent)
-                .setAutoCancel(true)
-                .setPriority(NotificationCompat.PRIORITY_HIGH)
-                .setDefaults(Notification.DEFAULT_VIBRATE or Notification.DEFAULT_SOUND)
-                .setCategory(NotificationCompat.CATEGORY_REMINDER)
+            val builder =
+                NotificationCompat.Builder(context, channelId)
+                    .setSmallIcon(R.drawable.ic_notification)
+                    .setSendTabTitle(context, device, tab)
+                    .setWhen(System.currentTimeMillis())
+                    .setContentText(tab.url)
+                    .setContentIntent(pendingIntent)
+                    .setAutoCancel(true)
+                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+                    .setDefaults(Notification.DEFAULT_VIBRATE or Notification.DEFAULT_SOUND)
+                    .setCategory(NotificationCompat.CATEGORY_REMINDER)
 
-            NotificationManagerCompat.from(context).notify(
-                RECEIVE_TABS_TAG,
-                notificationId,
-                builder.build(),
-            )
+            NotificationManagerCompat.from(context)
+                .notify(
+                    RECEIVE_TABS_TAG,
+                    notificationId,
+                    builder.build(),
+                )
         }
     }
 
@@ -122,9 +124,7 @@ object NotificationManager {
         }
     }
 
-    /**
-     * Launch a notification of the data policy, and record notification time and version.
-     */
+    /** Launch a notification of the data policy, and record notification time and version. */
     @SuppressLint("MissingPermission", "NotifyUsage")
     private fun notifyDataPolicy(
         context: Context,
@@ -135,35 +135,36 @@ object NotificationManager {
         val notificationTitle = resources.getString(R.string.datareporting_notification_title)
         val notificationSummary = resources.getString(R.string.datareporting_notification_summary)
 
-        val intent = Intent(Intent.ACTION_VIEW).apply {
-            data = PRIVACY_NOTICE_URL.toUri()
-            setPackage(context.packageName)
-        }
+        val intent =
+            Intent(Intent.ACTION_VIEW).apply {
+                data = PRIVACY_NOTICE_URL.toUri()
+                setPackage(context.packageName)
+            }
 
-        val flags = if (SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_IMMUTABLE
-        } else {
-            0
-        }
+        val flags =
+            if (SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_IMMUTABLE
+            } else {
+                0
+            }
 
-        val pendingIntent =
-            PendingIntent.getActivity(context, REQUEST_CODE_DATA_REPORTING, intent, flags)
+        val pendingIntent = PendingIntent.getActivity(context, REQUEST_CODE_DATA_REPORTING, intent, flags)
 
-        val notificationBuilder = NotificationCompat
-            .Builder(
-            context,
-            getNotificationChannelId(context),
-        ).apply {
-            setContentTitle(notificationTitle)
-            setContentText(notificationSummary)
-            setSmallIcon(R.drawable.ic_notification)
-            setAutoCancel(true)
-            setContentIntent(pendingIntent)
-            setStyle(NotificationCompat.BigTextStyle().bigText(notificationSummary))
-        }
+        val notificationBuilder =
+            NotificationCompat.Builder(
+                    context,
+                    getNotificationChannelId(context),
+                )
+                .apply {
+                    setContentTitle(notificationTitle)
+                    setContentText(notificationSummary)
+                    setSmallIcon(R.drawable.ic_notification)
+                    setAutoCancel(true)
+                    setContentIntent(pendingIntent)
+                    setStyle(NotificationCompat.BigTextStyle().bigText(notificationSummary))
+                }
 
-        NotificationManagerCompat
-            .from(context)
+        NotificationManagerCompat.from(context)
             .notify(DATA_REPORTING_TAG, DATA_REPORTING_NOTIFICATION_ID, notificationBuilder.build())
 
         preferences.edit {
@@ -198,20 +199,21 @@ object NotificationManager {
         channelDescription: String?,
         importance: Int = AndroidNotificationManager.IMPORTANCE_DEFAULT,
     ) {
-        val notificationManager =
-            context.getSystemService(Context.NOTIFICATION_SERVICE) as AndroidNotificationManager
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as AndroidNotificationManager
 
         if (null != notificationManager.getNotificationChannel(channelId)) {
             return
         }
 
-        val channel = NotificationChannel(
-            channelId,
-            channelName,
-            importance,
-        ).apply {
-            description = channelDescription
-        }
+        val channel =
+            NotificationChannel(
+                    channelId,
+                    channelName,
+                    importance,
+                )
+                .apply {
+                    description = channelDescription
+                }
 
         notificationManager.createNotificationChannel(channel)
     }
@@ -226,7 +228,7 @@ object NotificationManager {
                 context.getString(
                     R.string.fxa_tab_received_from_notification_name,
                     it.displayName,
-                ),
+                )
             )
             return this
         }

--- a/app/src/main/java/org/mozilla/reference/browser/addons/AddonDetailsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/AddonDetailsActivity.kt
@@ -16,20 +16,18 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import androidx.core.text.HtmlCompat
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.util.Locale
 import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.R as addonsR
 import mozilla.components.feature.addons.ui.translateDescription
 import mozilla.components.feature.addons.ui.translateName
 import mozilla.components.support.ktx.android.view.setupPersistentInsets
 import mozilla.components.support.utils.ext.getParcelableExtraCompat
 import org.mozilla.reference.browser.R
-import java.text.DateFormat
-import java.text.SimpleDateFormat
-import java.util.Locale
-import mozilla.components.feature.addons.R as addonsR
 
-/**
- * An activity to show the details of an add-on.
- */
+/** An activity to show the details of an add-on. */
 class AddonDetailsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge(SystemBarStyle.dark(Color.TRANSPARENT))
@@ -37,9 +35,7 @@ class AddonDetailsActivity : AppCompatActivity() {
         setContentView(R.layout.activity_add_on_details)
         window.setupPersistentInsets()
 
-        val addon = requireNotNull(
-            intent.getParcelableExtraCompat("add_on", Addon::class.java),
-        )
+        val addon = requireNotNull(intent.getParcelableExtraCompat("add_on", Addon::class.java))
         bind(addon)
     }
 

--- a/app/src/main/java/org/mozilla/reference/browser/addons/AddonSettingsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/AddonSettingsActivity.kt
@@ -25,9 +25,7 @@ import mozilla.components.support.utils.ext.getParcelableExtraCompat
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.components
 
-/**
- * An activity to show the settings of an add-on.
- */
+/** An activity to show the settings of an add-on. */
 class AddonSettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         setContentView(R.layout.activity_add_on_settings)
@@ -35,9 +33,7 @@ class AddonSettingsActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         window.setupPersistentInsets(true)
 
-        val addon = requireNotNull(
-            intent.getParcelableExtraCompat("add_on", Addon::class.java),
-        )
+        val addon = requireNotNull(intent.getParcelableExtraCompat("add_on", Addon::class.java))
 
         title = addon.translateName(this)
 
@@ -55,9 +51,7 @@ class AddonSettingsActivity : AppCompatActivity() {
     ): View? =
         when (name) {
             EngineView::class.java.name -> {
-                components.core.engine
-                .createView(context, attrs)
-                .asView()
+                components.core.engine.createView(context, attrs).asView()
             }
 
             else -> {
@@ -65,9 +59,7 @@ class AddonSettingsActivity : AppCompatActivity() {
             }
         }
 
-    /**
-     * A fragment to show the settings of an add-on with [EngineView].
-     */
+    /** A fragment to show the settings of an add-on with [EngineView]. */
     class AddonSettingsFragment : Fragment() {
         private lateinit var optionsPageUrl: String
         private lateinit var engineSession: EngineSession
@@ -77,18 +69,18 @@ class AddonSettingsActivity : AppCompatActivity() {
             container: ViewGroup?,
             savedInstanceState: Bundle?,
         ): View? {
-            optionsPageUrl = requireNotNull(
-                arguments
-                    ?.getParcelableCompat(
-                    "add_on",
-                    Addon::class.java,
-                )?.installedState
-                    ?.optionsPageUrl,
-            )
+            optionsPageUrl =
+                requireNotNull(
+                    arguments
+                        ?.getParcelableCompat(
+                            "add_on",
+                            Addon::class.java,
+                        )
+                        ?.installedState
+                        ?.optionsPageUrl
+                )
 
-            engineSession = requireContext()
-                .components.core.engine
-                .createSession()
+            engineSession = requireContext().components.core.engine.createSession()
 
             return inflater.inflate(R.layout.fragment_add_on_settings, container, false)
         }
@@ -110,15 +102,14 @@ class AddonSettingsActivity : AppCompatActivity() {
         }
 
         companion object {
-            /**
-             * Create an [AddonSettingsFragment] with add_on as a required parameter.
-             */
+            /** Create an [AddonSettingsFragment] with add_on as a required parameter. */
             fun create(addon: Addon) =
                 AddonSettingsFragment().apply {
-                arguments = Bundle().apply {
-                    putParcelable("add_on", addon)
+                    arguments =
+                        Bundle().apply {
+                            putParcelable("add_on", addon)
+                        }
                 }
-            }
         }
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/addons/AddonsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/AddonsActivity.kt
@@ -12,9 +12,7 @@ import androidx.appcompat.app.AppCompatActivity
 import mozilla.components.support.ktx.android.view.setupPersistentInsets
 import org.mozilla.reference.browser.R
 
-/**
- * An activity to manage add-ons.
- */
+/** An activity to manage add-ons. */
 class AddonsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         setContentView(R.layout.activity_main)

--- a/app/src/main/java/org/mozilla/reference/browser/addons/AddonsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/AddonsFragment.kt
@@ -18,19 +18,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.AddonManagerException
+import mozilla.components.feature.addons.R as addonsR
 import mozilla.components.feature.addons.ui.AddonsManagerAdapter
 import mozilla.components.feature.addons.ui.AddonsManagerAdapterDelegate
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.components
-import mozilla.components.feature.addons.R as addonsR
 
-/**
- * Fragment use for managing add-ons.
- */
-class AddonsFragment :
-    Fragment(),
-    AddonsManagerAdapterDelegate {
+/** Fragment use for managing add-ons. */
+class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
     private val webExtensionPromptFeature = ViewBoundFeatureWrapper<WebExtensionPromptFeature>()
     private lateinit var recyclerView: RecyclerView
     private val scope = CoroutineScope(Dispatchers.IO)
@@ -53,11 +49,12 @@ class AddonsFragment :
         super.onViewCreated(rootView, savedInstanceState)
         bindRecyclerView(rootView)
         webExtensionPromptFeature.set(
-            feature = WebExtensionPromptFeature(
-                store = requireContext().components.core.store,
-                context = requireContext(),
-                fragmentManager = parentFragmentManager,
-            ),
+            feature =
+                WebExtensionPromptFeature(
+                    store = requireContext().components.core.store,
+                    context = requireContext(),
+                    fragmentManager = parentFragmentManager,
+                ),
             owner = this,
             view = rootView,
         )
@@ -78,26 +75,25 @@ class AddonsFragment :
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         scope.launch {
             try {
-                addons = requireContext()
-                    .components.core.addonManager
-                    .getAddons()
+                addons = requireContext().components.core.addonManager.getAddons()
 
                 scope.launch(Dispatchers.Main) {
-                    adapter = AddonsManagerAdapter(
-                        this@AddonsFragment,
-                        addons,
-                        store = requireContext().components.core.store,
-                    )
+                    adapter =
+                        AddonsManagerAdapter(
+                            this@AddonsFragment,
+                            addons,
+                            store = requireContext().components.core.store,
+                        )
                     recyclerView.adapter = adapter
                 }
             } catch (e: AddonManagerException) {
                 scope.launch(Dispatchers.Main) {
-                    Toast
-                        .makeText(
-                        activity,
-                        addonsR.string.mozac_feature_addons_failed_to_load_extensions,
-                        Toast.LENGTH_SHORT,
-                    ).show()
+                    Toast.makeText(
+                            activity,
+                            addonsR.string.mozac_feature_addons_failed_to_load_extensions,
+                            Toast.LENGTH_SHORT,
+                        )
+                        .show()
                 }
             }
         }
@@ -125,28 +121,30 @@ class AddonsFragment :
     private val installAddon: ((Addon) -> Unit) = { addon ->
         addonProgressOverlay.visibility = View.VISIBLE
         isInstallationInProgress = true
-        requireContext().components.core.addonManager.installAddon(
-            url = addon.downloadUrl,
-            onSuccess = {
-                runIfFragmentIsAttached {
-                    isInstallationInProgress = false
-                    this@AddonsFragment.view?.let { view ->
-                        bindRecyclerView(view)
+        requireContext()
+            .components
+            .core
+            .addonManager
+            .installAddon(
+                url = addon.downloadUrl,
+                onSuccess = {
+                    runIfFragmentIsAttached {
+                        isInstallationInProgress = false
+                        this@AddonsFragment.view?.let { view ->
+                            bindRecyclerView(view)
+                        }
+                        addonProgressOverlay.visibility = View.GONE
                     }
-                    addonProgressOverlay.visibility = View.GONE
-                }
-            },
-            onError = { _ ->
-                runIfFragmentIsAttached {
-                    addonProgressOverlay.visibility = View.GONE
-                    isInstallationInProgress = false
-                }
-            },
-        )
+                },
+                onError = { _ ->
+                    runIfFragmentIsAttached {
+                        addonProgressOverlay.visibility = View.GONE
+                        isInstallationInProgress = false
+                    }
+                },
+            )
     }
 
-    /**
-     * Whether or not an add-on installation is in progress.
-     */
+    /** Whether or not an add-on installation is in progress. */
     private var isInstallationInProgress = false
 }

--- a/app/src/main/java/org/mozilla/reference/browser/addons/InstalledAddonDetailsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/InstalledAddonDetailsActivity.kt
@@ -19,16 +19,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.AddonManagerException
+import mozilla.components.feature.addons.R as addonsR
 import mozilla.components.feature.addons.ui.translateName
 import mozilla.components.support.ktx.android.view.setupPersistentInsets
 import mozilla.components.support.utils.ext.getParcelableExtraCompat
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.components
-import mozilla.components.feature.addons.R as addonsR
 
-/**
- * An activity to show the details of a installed add-on.
- */
+/** An activity to show the details of a installed add-on. */
 class InstalledAddonDetailsActivity : AppCompatActivity() {
     private val scope = CoroutineScope(Dispatchers.IO)
 
@@ -38,11 +36,10 @@ class InstalledAddonDetailsActivity : AppCompatActivity() {
         setContentView(R.layout.activity_installed_add_on_details)
         window.setupPersistentInsets(true)
 
-        val addon = requireNotNull(
-            intent.getParcelableExtraCompat("add_on", Addon::class.java),
-        ).also {
-            bindUI(it)
-        }
+        val addon =
+            requireNotNull(intent.getParcelableExtraCompat("add_on", Addon::class.java)).also {
+                bindUI(it)
+            }
 
         bindAddon(addon)
     }
@@ -50,25 +47,26 @@ class InstalledAddonDetailsActivity : AppCompatActivity() {
     private fun bindAddon(addon: Addon) {
         scope.launch {
             try {
-                val addons = baseContext.components.core.addonManager
-                    .getAddons()
+                val addons = baseContext.components.core.addonManager.getAddons()
                 scope.launch(Dispatchers.Main) {
-                    addons.find { addon.id == it.id }.let {
-                        if (it == null) {
-                            throw AddonManagerException(Exception("Addon ${addon.id} not found"))
-                        } else {
-                            bindUI(it)
+                    addons
+                        .find { addon.id == it.id }
+                        .let {
+                            if (it == null) {
+                                throw AddonManagerException(Exception("Addon ${addon.id} not found"))
+                            } else {
+                                bindUI(it)
+                            }
                         }
-                    }
                 }
             } catch (e: AddonManagerException) {
                 scope.launch(Dispatchers.Main) {
-                    Toast
-                        .makeText(
-                        baseContext,
-                        addonsR.string.mozac_feature_addons_failed_to_load_extensions,
-                        Toast.LENGTH_SHORT,
-                    ).show()
+                    Toast.makeText(
+                            baseContext,
+                            addonsR.string.mozac_feature_addons_failed_to_load_extensions,
+                            Toast.LENGTH_SHORT,
+                        )
+                        .show()
                 }
             }
         }

--- a/app/src/main/java/org/mozilla/reference/browser/addons/PermissionsDetailsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/PermissionsDetailsActivity.kt
@@ -23,24 +23,17 @@ import mozilla.components.support.ktx.android.view.setupPersistentInsets
 import mozilla.components.support.utils.ext.getParcelableExtraCompat
 import org.mozilla.reference.browser.R
 
-private const val LEARN_MORE_URL =
-    "https://support.mozilla.org/kb/permission-request-messages-firefox-extensions"
+private const val LEARN_MORE_URL = "https://support.mozilla.org/kb/permission-request-messages-firefox-extensions"
 
-/**
- * An activity to show the permissions of an add-on.
- */
-class PermissionsDetailsActivity :
-    AppCompatActivity(),
-    View.OnClickListener {
+/** An activity to show the permissions of an add-on. */
+class PermissionsDetailsActivity : AppCompatActivity(), View.OnClickListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge(SystemBarStyle.dark(Color.TRANSPARENT))
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_add_on_permissions)
         window.setupPersistentInsets()
 
-        val addon = requireNotNull(
-            intent.getParcelableExtraCompat("add_on", Addon::class.java),
-        )
+        val addon = requireNotNull(intent.getParcelableExtraCompat("add_on", Addon::class.java))
 
         title = addon.translateName(this)
 
@@ -60,12 +53,8 @@ class PermissionsDetailsActivity :
         findViewById<View>(R.id.learn_more_label).setOnClickListener(this)
     }
 
-    /**
-     * An adapter for displaying the permissions of an add-on.
-     */
-    class PermissionsAdapter(
-        private val permissions: List<String>,
-    ) : RecyclerView.Adapter<PermissionViewHolder>() {
+    /** An adapter for displaying the permissions of an add-on. */
+    class PermissionsAdapter(private val permissions: List<String>) : RecyclerView.Adapter<PermissionViewHolder>() {
         override fun onCreateViewHolder(
             parent: ViewGroup,
             viewType: Int,
@@ -91,9 +80,7 @@ class PermissionsDetailsActivity :
         }
     }
 
-    /**
-     * A view holder for displaying the permissions of an add-on.
-     */
+    /** A view holder for displaying the permissions of an add-on. */
     class PermissionViewHolder(
         val view: View,
         val textView: TextView,

--- a/app/src/main/java/org/mozilla/reference/browser/addons/WebExtensionActionPopupActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/WebExtensionActionPopupActivity.kt
@@ -24,9 +24,7 @@ import mozilla.components.support.ktx.android.view.setupPersistentInsets
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.components
 
-/**
- * An activity to show the pop up action of a web extension.
- */
+/** An activity to show the pop up action of a web extension. */
 class WebExtensionActionPopupActivity : AppCompatActivity() {
     private lateinit var webExtensionId: String
 
@@ -55,9 +53,7 @@ class WebExtensionActionPopupActivity : AppCompatActivity() {
     ): View? =
         when (name) {
             EngineView::class.java.name -> {
-                components.core.engine
-                .createView(context, attrs)
-                .asView()
+                components.core.engine.createView(context, attrs).asView()
             }
 
             else -> {
@@ -65,12 +61,8 @@ class WebExtensionActionPopupActivity : AppCompatActivity() {
             }
         }
 
-    /**
-     * A fragment to show the web extension action popup with [EngineView].
-     */
-    class WebExtensionActionPopupFragment :
-        Fragment(),
-        EngineSession.Observer {
+    /** A fragment to show the web extension action popup with [EngineView]. */
+    class WebExtensionActionPopupFragment : Fragment(), EngineSession.Observer {
         private var engineSession: EngineSession? = null
         private lateinit var webExtensionId: String
 
@@ -83,9 +75,7 @@ class WebExtensionActionPopupActivity : AppCompatActivity() {
             savedInstanceState: Bundle?,
         ): View? {
             webExtensionId = requireNotNull(arguments?.getString("web_extension_id"))
-            engineSession = requireContext()
-                .components.core.store.state.extensions[webExtensionId]
-                ?.popupSession
+            engineSession = requireContext().components.core.store.state.extensions[webExtensionId]?.popupSession
 
             return inflater.inflate(R.layout.fragment_add_on_settings, container, false)
         }
@@ -132,21 +122,22 @@ class WebExtensionActionPopupActivity : AppCompatActivity() {
         }
 
         private fun consumePopupSession() {
-            requireContext().components.core.store.dispatch(
-                WebExtensionAction.UpdatePopupSessionAction(webExtensionId, popupSession = null),
-            )
+            requireContext()
+                .components
+                .core
+                .store
+                .dispatch(WebExtensionAction.UpdatePopupSessionAction(webExtensionId, popupSession = null))
         }
 
         companion object {
-            /**
-             * Create an [WebExtensionActionPopupFragment] with webExtensionId as a required parameter.
-             */
+            /** Create an [WebExtensionActionPopupFragment] with webExtensionId as a required parameter. */
             fun create(webExtensionId: String) =
                 WebExtensionActionPopupFragment().apply {
-                arguments = Bundle().apply {
-                    putString("web_extension_id", webExtensionId)
+                    arguments =
+                        Bundle().apply {
+                            putString("web_extension_id", webExtensionId)
+                        }
                 }
-            }
         }
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/addons/WebExtensionPromptFeature.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/addons/WebExtensionPromptFeature.kt
@@ -20,6 +20,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.webextension.PermissionPromptResponse
 import mozilla.components.concept.engine.webextension.WebExtensionInstallException
 import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.R as addonsR
 import mozilla.components.feature.addons.ui.AddonInstallationDialogFragment
 import mozilla.components.feature.addons.ui.PermissionsDialogFragment
 import mozilla.components.lib.state.ext.flowScoped
@@ -27,44 +28,38 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.ktx.android.content.appVersionName
 import mozilla.components.ui.widgets.withCenterAlignedButtons
 import org.mozilla.reference.browser.R
-import mozilla.components.feature.addons.R as addonsR
 
-/**
- * Feature implementation for handling [WebExtensionPromptRequest] and showing the respective UI.
- */
+/** Feature implementation for handling [WebExtensionPromptRequest] and showing the respective UI. */
 class WebExtensionPromptFeature(
     private val store: BrowserStore,
     private val context: Context,
     private val fragmentManager: FragmentManager,
     private val mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : LifecycleAwareFeature {
-    /**
-     * Whether or not an add-on installation is in progress.
-     */
+    /** Whether or not an add-on installation is in progress. */
     private var isInstallationInProgress = false
     private var scope: CoroutineScope? = null
 
-    /**
-     * Starts observing the selected session to listen for window requests
-     * and opens / closes tabs as needed.
-     */
+    /** Starts observing the selected session to listen for window requests and opens / closes tabs as needed. */
     override fun start() {
-        scope = store.flowScoped(dispatcher = mainDispatcher) { flow ->
-            flow
-                .mapNotNull { state ->
-                    state.webExtensionPromptRequest
-                }.distinctUntilChanged()
-                .collect { promptRequest ->
-                    if (promptRequest is WebExtensionPromptRequest.AfterInstallation) {
-                        handleAfterInstallationRequest(promptRequest)
+        scope =
+            store.flowScoped(dispatcher = mainDispatcher) { flow ->
+                flow
+                    .mapNotNull { state ->
+                        state.webExtensionPromptRequest
                     }
+                    .distinctUntilChanged()
+                    .collect { promptRequest ->
+                        if (promptRequest is WebExtensionPromptRequest.AfterInstallation) {
+                            handleAfterInstallationRequest(promptRequest)
+                        }
 
-                    if (promptRequest is WebExtensionPromptRequest.BeforeInstallation.InstallationFailed) {
-                        handleBeforeInstallationRequest(promptRequest)
-                        consumePromptRequest()
+                        if (promptRequest is WebExtensionPromptRequest.BeforeInstallation.InstallationFailed) {
+                            handleBeforeInstallationRequest(promptRequest)
+                            consumePromptRequest()
+                        }
                     }
-                }
-        }
+            }
         tryToReAttachButtonHandlersToPreviousDialog()
     }
 
@@ -74,19 +69,19 @@ class WebExtensionPromptFeature(
         // opens the add-ons manager.
         val addon = Addon.newFromWebExtension(promptRequest.extension)
         when (promptRequest) {
-            is WebExtensionPromptRequest.AfterInstallation.Permissions.Required -> handlePermissionRequest(
-                addon,
-                promptRequest,
-            )
+            is WebExtensionPromptRequest.AfterInstallation.Permissions.Required ->
+                handlePermissionRequest(
+                    addon,
+                    promptRequest,
+                )
 
-            is WebExtensionPromptRequest.AfterInstallation.PostInstallation -> handlePostInstallationRequest(
-                addon,
-            )
+            is WebExtensionPromptRequest.AfterInstallation.PostInstallation -> handlePostInstallationRequest(addon)
 
-            is WebExtensionPromptRequest.AfterInstallation.Permissions.Optional -> handleOptionalPermissionsRequest(
-                addon,
-                promptRequest,
-            )
+            is WebExtensionPromptRequest.AfterInstallation.Permissions.Optional ->
+                handleOptionalPermissionsRequest(
+                    addon,
+                    promptRequest,
+                )
         }
     }
 
@@ -132,22 +127,21 @@ class WebExtensionPromptFeature(
 
     private fun showPostInstallationDialog(addon: Addon) {
         if (!isInstallationInProgress && !hasExistingAddonPostInstallationDialogFragment()) {
-            val dialog = AddonInstallationDialogFragment.newInstance(
-                addon = addon,
-                onDismissed = {
-                    consumePromptRequest()
-                },
-                onConfirmButtonClicked = { _ ->
-                    consumePromptRequest()
-                },
-            )
+            val dialog =
+                AddonInstallationDialogFragment.newInstance(
+                    addon = addon,
+                    onDismissed = {
+                        consumePromptRequest()
+                    },
+                    onConfirmButtonClicked = { _ ->
+                        consumePromptRequest()
+                    },
+                )
             dialog.show(fragmentManager, POST_INSTALLATION_DIALOG_FRAGMENT_TAG)
         }
     }
 
-    /**
-     * Stops observing the selected session for incoming window requests.
-     */
+    /** Stops observing the selected session for incoming window requests. */
     override fun stop() {
         scope?.cancel()
     }
@@ -161,32 +155,33 @@ class WebExtensionPromptFeature(
         forOptionalPermissions: Boolean = false,
     ) {
         if (!isInstallationInProgress && !hasExistingPermissionDialogFragment()) {
-            val dialog = PermissionsDialogFragment.newInstance(
-                addon = addon,
-                permissions = permissions,
-                origins = origins,
-                dataCollectionPermissions = emptyList(),
-                forOptionalPermissions = forOptionalPermissions,
-                onPositiveButtonClicked = { _, privateBrowsingAllowed, _ ->
-                    handlePermissions(
-                        promptRequest,
-                        granted = true,
-                        privateBrowsingAllowed = privateBrowsingAllowed,
-                    )
-                },
-                onNegativeButtonClicked = {
-                    when (promptRequest) {
-                        is WebExtensionPromptRequest.AfterInstallation.Permissions.Optional -> {
-                            promptRequest.onConfirm(false)
-                        }
+            val dialog =
+                PermissionsDialogFragment.newInstance(
+                    addon = addon,
+                    permissions = permissions,
+                    origins = origins,
+                    dataCollectionPermissions = emptyList(),
+                    forOptionalPermissions = forOptionalPermissions,
+                    onPositiveButtonClicked = { _, privateBrowsingAllowed, _ ->
+                        handlePermissions(
+                            promptRequest,
+                            granted = true,
+                            privateBrowsingAllowed = privateBrowsingAllowed,
+                        )
+                    },
+                    onNegativeButtonClicked = {
+                        when (promptRequest) {
+                            is WebExtensionPromptRequest.AfterInstallation.Permissions.Optional -> {
+                                promptRequest.onConfirm(false)
+                            }
 
-                        is WebExtensionPromptRequest.AfterInstallation.Permissions.Required -> {
-                            promptRequest.onConfirm(PermissionPromptResponse(isPermissionsGranted = false))
+                            is WebExtensionPromptRequest.AfterInstallation.Permissions.Required -> {
+                                promptRequest.onConfirm(PermissionPromptResponse(isPermissionsGranted = false))
+                            }
                         }
-                    }
-                    consumePromptRequest()
-                },
-            )
+                        consumePromptRequest()
+                    },
+                )
             dialog.show(
                 fragmentManager,
                 PERMISSIONS_DIALOG_FRAGMENT_TAG,
@@ -198,8 +193,9 @@ class WebExtensionPromptFeature(
         findPreviousDialogFragment()?.let { dialog ->
             dialog.onPositiveButtonClicked = { addon, privateBrowsingAllowed, _ ->
                 store.state.webExtensionPromptRequest?.let { promptRequest ->
-                    if (promptRequest is WebExtensionPromptRequest.AfterInstallation.Permissions &&
-                        addon.id == promptRequest.extension.id
+                    if (
+                        promptRequest is WebExtensionPromptRequest.AfterInstallation.Permissions &&
+                            addon.id == promptRequest.extension.id
                     ) {
                         handlePermissions(
                             promptRequest,
@@ -232,10 +228,11 @@ class WebExtensionPromptFeature(
             }
 
             is WebExtensionPromptRequest.AfterInstallation.Permissions.Required -> {
-                val response = PermissionPromptResponse(
-                    isPermissionsGranted = granted,
-                    isPrivateModeGranted = privateBrowsingAllowed,
-                )
+                val response =
+                    PermissionPromptResponse(
+                        isPermissionsGranted = granted,
+                        isPrivateModeGranted = privateBrowsingAllowed,
+                    )
                 promptRequest.onConfirm(response)
             }
 
@@ -264,15 +261,13 @@ class WebExtensionPromptFeature(
         fragmentManager.findFragmentByTag(PERMISSIONS_DIALOG_FRAGMENT_TAG) as? PermissionsDialogFragment
 
     private fun hasExistingAddonPostInstallationDialogFragment(): Boolean =
-        fragmentManager.findFragmentByTag(POST_INSTALLATION_DIALOG_FRAGMENT_TAG)
-            as? AddonInstallationDialogFragment != null
+        fragmentManager.findFragmentByTag(POST_INSTALLATION_DIALOG_FRAGMENT_TAG) as? AddonInstallationDialogFragment !=
+            null
 
     private fun handleBeforeInstallationRequest(promptRequest: WebExtensionPromptRequest.BeforeInstallation) {
         when (promptRequest) {
             is WebExtensionPromptRequest.BeforeInstallation.InstallationFailed -> {
-                handleInstallationFailedRequest(
-                    exception = promptRequest.exception,
-                )
+                handleInstallationFailedRequest(exception = promptRequest.exception)
                 consumePromptRequest()
             }
         }
@@ -282,63 +277,61 @@ class WebExtensionPromptFeature(
     internal fun handleInstallationFailedRequest(exception: WebExtensionInstallException) {
         val addonName = exception.extensionName ?: ""
         var title = context.getString(addonsR.string.mozac_feature_addons_cant_install_extension, "")
-        val message = when (exception) {
-            is WebExtensionInstallException.Blocklisted -> {
-                context.getString(addonsR.string.mozac_feature_addons_blocklisted_2, addonName, R.string.app_name)
-            }
+        val message =
+            when (exception) {
+                is WebExtensionInstallException.Blocklisted -> {
+                    context.getString(addonsR.string.mozac_feature_addons_blocklisted_2, addonName, R.string.app_name)
+                }
 
-            is WebExtensionInstallException.SoftBlocked -> {
-                context.getString(addonsR.string.mozac_feature_addons_soft_blocked_2, addonName, R.string.app_name)
-            }
+                is WebExtensionInstallException.SoftBlocked -> {
+                    context.getString(addonsR.string.mozac_feature_addons_soft_blocked_2, addonName, R.string.app_name)
+                }
 
-            is WebExtensionInstallException.UserCancelled -> {
-                // We don't want to show an error message when users cancel installation.
-                return
-            }
+                is WebExtensionInstallException.UserCancelled -> {
+                    // We don't want to show an error message when users cancel installation.
+                    return
+                }
 
-            is WebExtensionInstallException.UnsupportedAddonType,
-            is WebExtensionInstallException.Unknown,
-            -> {
-                // Making sure we don't have a
-                // Title = Can't install extension
-                // Message = Failed to install $addonName
-                title = ""
-                if (addonName.isNotEmpty()) {
-                    context.getString(addonsR.string.mozac_feature_addons_failed_to_install, addonName)
-                } else {
-                    context.getString(addonsR.string.mozac_feature_addons_extension_failed_to_install)
+                is WebExtensionInstallException.UnsupportedAddonType,
+                is WebExtensionInstallException.Unknown -> {
+                    // Making sure we don't have a
+                    // Title = Can't install extension
+                    // Message = Failed to install $addonName
+                    title = ""
+                    if (addonName.isNotEmpty()) {
+                        context.getString(addonsR.string.mozac_feature_addons_failed_to_install, addonName)
+                    } else {
+                        context.getString(addonsR.string.mozac_feature_addons_extension_failed_to_install)
+                    }
+                }
+
+                is WebExtensionInstallException.NetworkFailure -> {
+                    context.getString(addonsR.string.mozac_feature_addons_extension_failed_to_install_network_error)
+                }
+
+                is WebExtensionInstallException.CorruptFile -> {
+                    context.getString(addonsR.string.mozac_feature_addons_extension_failed_to_install_corrupt_error)
+                }
+
+                is WebExtensionInstallException.NotSigned -> {
+                    context.getString(addonsR.string.mozac_feature_addons_extension_failed_to_install_not_signed_error)
+                }
+
+                is WebExtensionInstallException.Incompatible -> {
+                    val appName = context.getString(R.string.app_name)
+                    val version = context.appVersionName
+                    context.getString(
+                        addonsR.string.mozac_feature_addons_failed_to_install_incompatible_error,
+                        addonName,
+                        appName,
+                        version,
+                    )
+                }
+
+                is WebExtensionInstallException.AdminInstallOnly -> {
+                    context.getString(addonsR.string.mozac_feature_addons_admin_install_only, addonName)
                 }
             }
-
-            is WebExtensionInstallException.NetworkFailure -> {
-                context.getString(addonsR.string.mozac_feature_addons_extension_failed_to_install_network_error)
-            }
-
-            is WebExtensionInstallException.CorruptFile -> {
-                context.getString(addonsR.string.mozac_feature_addons_extension_failed_to_install_corrupt_error)
-            }
-
-            is WebExtensionInstallException.NotSigned -> {
-                context.getString(
-                    addonsR.string.mozac_feature_addons_extension_failed_to_install_not_signed_error,
-                )
-            }
-
-            is WebExtensionInstallException.Incompatible -> {
-                val appName = context.getString(R.string.app_name)
-                val version = context.appVersionName
-                context.getString(
-                    addonsR.string.mozac_feature_addons_failed_to_install_incompatible_error,
-                    addonName,
-                    appName,
-                    version,
-                )
-            }
-
-            is WebExtensionInstallException.AdminInstallOnly -> {
-                context.getString(addonsR.string.mozac_feature_addons_admin_install_only, addonName)
-            }
-        }
 
         showDialog(
             title = title,
@@ -352,21 +345,18 @@ class WebExtensionPromptFeature(
         message: String,
     ) {
         context.let {
-            AlertDialog
-                .Builder(it)
+            AlertDialog.Builder(it)
                 .setTitle(title)
                 .setPositiveButton(android.R.string.ok) { _, _ -> }
                 .setCancelable(false)
-                .setMessage(
-                    message,
-                ).show()
+                .setMessage(message)
+                .show()
                 .withCenterAlignedButtons()
         }
     }
 
     companion object {
         private const val PERMISSIONS_DIALOG_FRAGMENT_TAG = "ADDONS_PERMISSIONS_DIALOG_FRAGMENT"
-        private const val POST_INSTALLATION_DIALOG_FRAGMENT_TAG =
-            "ADDONS_INSTALLATION_DIALOG_FRAGMENT"
+        private const val POST_INSTALLATION_DIALOG_FRAGMENT_TAG = "ADDONS_INSTALLATION_DIALOG_FRAGMENT"
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/autofill/AutofillPreference.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/autofill/AutofillPreference.kt
@@ -16,8 +16,8 @@ import androidx.preference.PreferenceViewHolder
 import org.mozilla.reference.browser.R
 
 class AutofillPreference
-    @JvmOverloads
-    constructor(
+@JvmOverloads
+constructor(
     context: Context,
     attrs: AttributeSet? = null,
 ) : Preference(context, attrs) {
@@ -40,9 +40,10 @@ class AutofillPreference
     }
 
     override fun onClick() {
-        val intent = Intent(Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE).apply {
-            data = "package:${context.packageName}".toUri()
-        }
+        val intent =
+            Intent(Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE).apply {
+                data = "package:${context.packageName}".toUri()
+            }
         context.startActivity(intent)
     }
 

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
@@ -61,14 +61,10 @@ import org.mozilla.reference.browser.tabs.LastTabFeature
 private const val BOTTOM_TOOLBAR_HEIGHT = 0
 
 /**
- * Base fragment extended by [BrowserFragment] and [ExternalAppBrowserFragment].
- * This class only contains shared code focused on the main browsing content.
- * UI code specific to the app or to custom tabs can be found in the subclasses.
+ * Base fragment extended by [BrowserFragment] and [ExternalAppBrowserFragment]. This class only contains shared code
+ * focused on the main browsing content. UI code specific to the app or to custom tabs can be found in the subclasses.
  */
-abstract class BaseBrowserFragment :
-    Fragment(),
-    UserInteractionHandler,
-    ActivityResultHandler {
+abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, ActivityResultHandler {
     private val sessionFeature = ViewBoundFeatureWrapper<SessionFeature>()
     private val toolbarIntegration = ViewBoundFeatureWrapper<ToolbarIntegration>()
     private val contextMenuIntegration = ViewBoundFeatureWrapper<ContextMenuIntegration>()
@@ -90,25 +86,30 @@ abstract class BaseBrowserFragment :
 
     private val engineView: EngineView
         get() = requireView().findViewById<View>(R.id.engineView) as EngineView
+
     private val toolbar: BrowserToolbar
         get() = requireView().findViewById(R.id.toolbar)
+
     private val findInPageBar: FindInPageBar
         get() = requireView().findViewById(R.id.findInPageBar)
+
     private val swipeRefresh: SwipeRefreshLayout
         get() = requireView().findViewById(R.id.swipeRefresh)
 
-    private val backButtonHandler: List<ViewBoundFeatureWrapper<*>> = listOf(
-        fullScreenFeature,
-        findInPageIntegration,
-        toolbarIntegration,
-        sessionFeature,
-        lastTabFeature,
-    )
+    private val backButtonHandler: List<ViewBoundFeatureWrapper<*>> =
+        listOf(
+            fullScreenFeature,
+            findInPageIntegration,
+            toolbarIntegration,
+            sessionFeature,
+            lastTabFeature,
+        )
 
-    private val activityResultHandler: List<ViewBoundFeatureWrapper<*>> = listOf(
-        webAuthnFeature,
-        promptsFeature,
-    )
+    private val activityResultHandler: List<ViewBoundFeatureWrapper<*>> =
+        listOf(
+            webAuthnFeature,
+            promptsFeature,
+        )
 
     protected val sessionId: String?
         get() = arguments?.getString(SESSION_ID)
@@ -127,8 +128,9 @@ abstract class BaseBrowserFragment :
                 val grantResults =
                     results.values
                         .map {
-                        if (it) PackageManager.PERMISSION_GRANTED else PackageManager.PERMISSION_DENIED
-                    }.toIntArray()
+                            if (it) PackageManager.PERMISSION_GRANTED else PackageManager.PERMISSION_DENIED
+                        }
+                        .toIntArray()
                 downloadsFeature.withFeature {
                     it.onPermissionsResult(permissions, grantResults)
                 }
@@ -140,8 +142,9 @@ abstract class BaseBrowserFragment :
                 val grantResults =
                     results.values
                         .map {
-                        if (it) PackageManager.PERMISSION_GRANTED else PackageManager.PERMISSION_DENIED
-                    }.toIntArray()
+                            if (it) PackageManager.PERMISSION_GRANTED else PackageManager.PERMISSION_DENIED
+                        }
+                        .toIntArray()
                 sitePermissionFeature.withFeature {
                     it.onPermissionsResult(permissions, grantResults)
                 }
@@ -153,8 +156,9 @@ abstract class BaseBrowserFragment :
                 val grantResults =
                     results.values
                         .map {
-                        if (it) PackageManager.PERMISSION_GRANTED else PackageManager.PERMISSION_DENIED
-                    }.toIntArray()
+                            if (it) PackageManager.PERMISSION_GRANTED else PackageManager.PERMISSION_DENIED
+                        }
+                        .toIntArray()
                 promptsFeature.withFeature {
                     it.onPermissionsResult(permissions, grantResults)
                 }
@@ -178,52 +182,56 @@ abstract class BaseBrowserFragment :
         val prefs = PreferenceManager.getDefaultSharedPreferences(requireContext())
 
         sessionFeature.set(
-            feature = SessionFeature(
-                requireComponents.core.store,
-                requireComponents.useCases.sessionUseCases.goBack,
-                requireComponents.useCases.sessionUseCases.goForward,
-                engineView,
-                sessionId,
-            ),
+            feature =
+                SessionFeature(
+                    requireComponents.core.store,
+                    requireComponents.useCases.sessionUseCases.goBack,
+                    requireComponents.useCases.sessionUseCases.goForward,
+                    engineView,
+                    sessionId,
+                ),
             owner = this,
             view = view,
         )
 
         (toolbar.layoutParams as? CoordinatorLayout.LayoutParams)?.apply {
-            behavior = EngineViewScrollingGesturesBehavior(
-                engineView = engineView,
-                dependency = toolbar,
-                dependencyGravity = DependencyGravity.Bottom,
-            )
+            behavior =
+                EngineViewScrollingGesturesBehavior(
+                    engineView = engineView,
+                    dependency = toolbar,
+                    dependencyGravity = DependencyGravity.Bottom,
+                )
         }
 
         toolbarIntegration.set(
-            feature = ToolbarIntegration(
-                requireContext(),
-                toolbar,
-                view,
-                requireComponents.core.historyStorage,
-                requireComponents.core.store,
-                requireComponents.useCases.sessionUseCases,
-                requireComponents.useCases.tabsUseCases,
-                requireComponents.useCases.webAppUseCases,
-                sessionId,
-            ),
+            feature =
+                ToolbarIntegration(
+                    requireContext(),
+                    toolbar,
+                    view,
+                    requireComponents.core.historyStorage,
+                    requireComponents.core.store,
+                    requireComponents.useCases.sessionUseCases,
+                    requireComponents.useCases.tabsUseCases,
+                    requireComponents.useCases.webAppUseCases,
+                    sessionId,
+                ),
             owner = this,
             view = view,
         )
 
         contextMenuIntegration.set(
-            feature = ContextMenuIntegration(
-                requireContext(),
-                parentFragmentManager,
-                requireComponents.core.store,
-                requireComponents.useCases.tabsUseCases,
-                requireComponents.useCases.contextMenuUseCases,
-                engineView,
-                view,
-                sessionId,
-            ),
+            feature =
+                ContextMenuIntegration(
+                    requireContext(),
+                    parentFragmentManager,
+                    requireComponents.core.store,
+                    requireComponents.useCases.tabsUseCases,
+                    requireComponents.useCases.contextMenuUseCases,
+                    engineView,
+                    view,
+                    sessionId,
+                ),
             owner = this,
             view = view,
         )
@@ -239,67 +247,76 @@ abstract class BaseBrowserFragment :
         )
 
         downloadsFeature.set(
-            feature = DownloadsFeature(
-                requireContext(),
-                store = requireComponents.core.store,
-                useCases = requireComponents.useCases.downloadsUseCases,
-                fragmentManager = childFragmentManager,
-                downloadFileUtils = DefaultDownloadFileUtils(
-                    context = requireContext().applicationContext,
-                    downloadLocation = {
-                        Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path
+            feature =
+                DownloadsFeature(
+                    requireContext(),
+                    store = requireComponents.core.store,
+                    useCases = requireComponents.useCases.downloadsUseCases,
+                    fragmentManager = childFragmentManager,
+                    downloadFileUtils =
+                        DefaultDownloadFileUtils(
+                            context = requireContext().applicationContext,
+                            downloadLocation = {
+                                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path
+                            },
+                        ),
+                    downloadManager =
+                        FetchDownloadManager(
+                            requireContext().applicationContext,
+                            requireComponents.core.store,
+                            DownloadService::class,
+                            notificationsDelegate = requireComponents.notificationsDelegate,
+                        ),
+                    onNeedToRequestPermissions = { permissions ->
+                        requestDownloadPermissionsLauncher.launch(permissions)
                     },
                 ),
-                downloadManager = FetchDownloadManager(
-                    requireContext().applicationContext,
-                    requireComponents.core.store,
-                    DownloadService::class,
-                    notificationsDelegate = requireComponents.notificationsDelegate,
-                ),
-                onNeedToRequestPermissions = { permissions ->
-                    requestDownloadPermissionsLauncher.launch(permissions)
-                },
-            ),
             owner = this,
             view = view,
         )
 
         appLinksFeature.set(
-            feature = AppLinksFeature(
-                requireContext(),
-                store = requireComponents.core.store,
-                sessionId = sessionId,
-                fragmentManager = parentFragmentManager,
-                launchInApp = {
-                    prefs.getBoolean(requireContext().getPreferenceKey(R.string.pref_key_launch_external_app), false)
-                },
-            ),
+            feature =
+                AppLinksFeature(
+                    requireContext(),
+                    store = requireComponents.core.store,
+                    sessionId = sessionId,
+                    fragmentManager = parentFragmentManager,
+                    launchInApp = {
+                        prefs.getBoolean(
+                            requireContext().getPreferenceKey(R.string.pref_key_launch_external_app),
+                            false,
+                        )
+                    },
+                ),
             owner = this,
             view = view,
         )
 
         promptsFeature.set(
-            feature = PromptFeature(
-                fragment = this,
-                store = requireComponents.core.store,
-                tabsUseCases = requireComponents.useCases.tabsUseCases,
-                customTabId = sessionId,
-                fileUploadsDirCleaner = requireComponents.core.fileUploadsDirCleaner,
-                fragmentManager = parentFragmentManager,
-                onNeedToRequestPermissions = { permissions ->
-                    requestPromptsPermissionsLauncher.launch(permissions)
-                },
-            ),
+            feature =
+                PromptFeature(
+                    fragment = this,
+                    store = requireComponents.core.store,
+                    tabsUseCases = requireComponents.useCases.tabsUseCases,
+                    customTabId = sessionId,
+                    fileUploadsDirCleaner = requireComponents.core.fileUploadsDirCleaner,
+                    fragmentManager = parentFragmentManager,
+                    onNeedToRequestPermissions = { permissions ->
+                        requestPromptsPermissionsLauncher.launch(permissions)
+                    },
+                ),
             owner = this,
             view = view,
         )
 
         webExtensionPromptFeature.set(
-            feature = WebExtensionPromptFeature(
-                store = requireComponents.core.store,
-                context = requireContext(),
-                fragmentManager = parentFragmentManager,
-            ),
+            feature =
+                WebExtensionPromptFeature(
+                    store = requireComponents.core.store,
+                    context = requireContext(),
+                    fragmentManager = parentFragmentManager,
+                ),
             owner = this,
             view = view,
         )
@@ -311,110 +328,122 @@ abstract class BaseBrowserFragment :
         )
 
         fullScreenFeature.set(
-            feature = FullScreenFeature(
-                store = requireComponents.core.store,
-                sessionUseCases = requireComponents.useCases.sessionUseCases,
-                tabId = sessionId,
-                viewportFitChanged = ::viewportFitChanged,
-                fullScreenChanged = ::fullScreenChanged,
-            ),
+            feature =
+                FullScreenFeature(
+                    store = requireComponents.core.store,
+                    sessionUseCases = requireComponents.useCases.sessionUseCases,
+                    tabId = sessionId,
+                    viewportFitChanged = ::viewportFitChanged,
+                    fullScreenChanged = ::fullScreenChanged,
+                ),
             owner = this,
             view = view,
         )
 
         findInPageIntegration.set(
-            feature = FindInPageIntegration(
-                requireComponents.core.store,
-                sessionId,
-                findInPageBar as FindInPageView,
-                engineView,
-            ),
+            feature =
+                FindInPageIntegration(
+                    requireComponents.core.store,
+                    sessionId,
+                    findInPageBar as FindInPageView,
+                    engineView,
+                ),
             owner = this,
             view = view,
         )
 
         sitePermissionFeature.set(
-            feature = SitePermissionsFeature(
-                context = requireContext(),
-                fragmentManager = parentFragmentManager,
-                sessionId = sessionId,
-                storage = requireComponents.core.geckoSitePermissionsStorage,
-                onNeedToRequestPermissions = { permissions ->
-                    requestSitePermissionsLauncher.launch(permissions)
-                },
-                onShouldShowRequestPermissionRationale = { shouldShowRequestPermissionRationale(it) },
-                store = requireComponents.core.store,
-            ),
+            feature =
+                SitePermissionsFeature(
+                    context = requireContext(),
+                    fragmentManager = parentFragmentManager,
+                    sessionId = sessionId,
+                    storage = requireComponents.core.geckoSitePermissionsStorage,
+                    onNeedToRequestPermissions = { permissions ->
+                        requestSitePermissionsLauncher.launch(permissions)
+                    },
+                    onShouldShowRequestPermissionRationale = { shouldShowRequestPermissionRationale(it) },
+                    store = requireComponents.core.store,
+                ),
             owner = this,
             view = view,
         )
 
         pictureInPictureIntegration.set(
-            feature = PictureInPictureIntegration(
-                requireComponents.core.store,
-                requireActivity(),
-                sessionId,
-            ),
+            feature =
+                PictureInPictureIntegration(
+                    requireComponents.core.store,
+                    requireActivity(),
+                    sessionId,
+                ),
             owner = this,
             view = view,
         )
 
         fullScreenMediaSessionFeature.set(
-            feature = MediaSessionFullscreenFeature(
-                requireActivity(),
-                requireComponents.core.store,
-                sessionId,
-            ),
+            feature =
+                MediaSessionFullscreenFeature(
+                    requireActivity(),
+                    requireComponents.core.store,
+                    sessionId,
+                ),
             owner = this,
             view = view,
         )
 
         (swipeRefresh.layoutParams as? CoordinatorLayout.LayoutParams)?.apply {
-            behavior = EngineViewClippingBehavior(
-                context = requireContext(),
-                attrs = null,
-                engineViewParent = swipeRefresh,
-                topToolbarHeight = toolbar.height,
-                bottomToolbarHeight = BOTTOM_TOOLBAR_HEIGHT,
-            )
+            behavior =
+                EngineViewClippingBehavior(
+                    context = requireContext(),
+                    attrs = null,
+                    engineViewParent = swipeRefresh,
+                    topToolbarHeight = toolbar.height,
+                    bottomToolbarHeight = BOTTOM_TOOLBAR_HEIGHT,
+                )
         }
         swipeRefreshFeature.set(
-            feature = SwipeRefreshFeature(
-                requireComponents.core.store,
-                requireComponents.useCases.sessionUseCases.reload,
-                swipeRefresh,
-            ),
+            feature =
+                SwipeRefreshFeature(
+                    requireComponents.core.store,
+                    requireComponents.useCases.sessionUseCases.reload,
+                    swipeRefresh,
+                ),
             owner = this,
             view = view,
         )
 
         lastTabFeature.set(
-            feature = LastTabFeature(
-                requireComponents.core.store,
-                sessionId,
-                requireComponents.useCases.tabsUseCases.removeTab,
-                requireActivity(),
-            ),
+            feature =
+                LastTabFeature(
+                    requireComponents.core.store,
+                    sessionId,
+                    requireComponents.useCases.tabsUseCases.removeTab,
+                    requireActivity(),
+                ),
             owner = this,
             view = view,
         )
 
         screenOrientationFeature.set(
-            feature = ScreenOrientationFeature(
-                requireComponents.core.engine,
-                requireActivity(),
-            ),
+            feature =
+                ScreenOrientationFeature(
+                    requireComponents.core.engine,
+                    requireActivity(),
+                ),
             owner = this,
             view = view,
         )
 
         if (BuildConfig.MOZILLA_OFFICIAL) {
             webAuthnFeature.set(
-                feature = WebAuthnFeature(
-                    requireComponents.core.engine,
-                    requireActivity(),
-                    requireComponents.useCases.sessionUseCases.exitFullscreen::invoke,
-                ) { requireComponents.core.store.state.selectedTabId },
+                feature =
+                    WebAuthnFeature(
+                        requireComponents.core.engine,
+                        requireActivity(),
+                        requireComponents.useCases.sessionUseCases.exitFullscreen::invoke,
+                    ) {
+                        requireComponents.core.store.state.selectedTabId
+                    },
                 owner = this,
                 view = view,
             )
@@ -449,8 +478,7 @@ abstract class BaseBrowserFragment :
         }
     }
 
-    @CallSuper
-    override fun onBackPressed(): Boolean = backButtonHandler.any { it.onBackPressed() }
+    @CallSuper override fun onBackPressed(): Boolean = backButtonHandler.any { it.onBackPressed() }
 
     final override fun onHomePressed(): Boolean = pictureInPictureIntegration.get()?.onHomePressed() ?: false
 
@@ -480,7 +508,7 @@ abstract class BaseBrowserFragment :
     ): Boolean {
         Logger.info(
             "Fragment onActivityResult received with " +
-                "requestCode: $requestCode, resultCode: $resultCode, data: $data",
+                "requestCode: $requestCode, resultCode: $resultCode, data: $data"
         )
 
         return activityResultHandler.any { it.onActivityResult(requestCode, data, resultCode) }

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
@@ -31,12 +31,8 @@ import org.mozilla.reference.browser.ext.requireComponents
 import org.mozilla.reference.browser.search.AwesomeBarWrapper
 import org.mozilla.reference.browser.tabs.TabsTrayFragment
 
-/**
- * Fragment used for browsing the web within the main app.
- */
-class BrowserFragment :
-    BaseBrowserFragment(),
-    UserInteractionHandler {
+/** Fragment used for browsing the web within the main app. */
+class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     private val thumbnailsFeature = ViewBoundFeatureWrapper<BrowserThumbnails>()
     private val readerViewFeature = ViewBoundFeatureWrapper<ReaderViewIntegration>()
     private val webExtToolbarFeature = ViewBoundFeatureWrapper<WebExtensionToolbarFeature>()
@@ -44,20 +40,26 @@ class BrowserFragment :
 
     private val awesomeBar: AwesomeBarWrapper
         get() = requireView().findViewById(R.id.awesomeBar)
+
     private val toolbar: BrowserToolbar
         get() = requireView().findViewById(R.id.toolbar)
+
     private val engineView: EngineView
         get() = requireView().findViewById<View>(R.id.engineView) as EngineView
+
     private val readerViewBar: ReaderViewControlsBar
         get() = requireView().findViewById(R.id.readerViewBar)
+
     private val readerViewAppearanceButton: FloatingActionButton
         get() = requireView().findViewById(R.id.readerViewAppearanceButton)
 
     override val shouldUseComposeUI: Boolean
-        get() = PreferenceManager.getDefaultSharedPreferences(requireContext()).getBoolean(
-            getString(R.string.pref_key_compose_ui),
-            false,
-        )
+        get() =
+            PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getBoolean(
+                    getString(R.string.pref_key_compose_ui),
+                    false,
+                )
 
     @Suppress("LongMethod")
     override fun onViewCreated(
@@ -75,14 +77,17 @@ class BrowserFragment :
                 engine = requireComponents.core.engine,
                 limit = 5,
                 filterExactMatch = true,
-            ).addSessionProvider(
+            )
+            .addSessionProvider(
                 resources,
                 requireComponents.core.store,
                 requireComponents.useCases.tabsUseCases.selectTab,
-            ).addHistoryProvider(
+            )
+            .addHistoryProvider(
                 requireComponents.core.historyStorage,
                 requireComponents.useCases.sessionUseCases.loadUrl,
-            ).addClipboardProvider(requireContext(), requireComponents.useCases.sessionUseCases.loadUrl)
+            )
+            .addClipboardProvider(requireContext(), requireComponents.useCases.sessionUseCases.loadUrl)
 
         // We cannot really add a `addSyncedTabsProvider` to `AwesomeBarFeature` coz that would create
         // a dependency on feature-syncedtabs (which depends on Sync).
@@ -91,7 +96,7 @@ class BrowserFragment :
                 requireComponents.backgroundServices.syncedTabsStorage,
                 requireComponents.useCases.tabsUseCases.addTab,
                 requireComponents.core.icons,
-            ),
+            )
         )
         awesomeBar.setOnRemoveSuggestionButtonClicked {
             awesomeBar.addHiddenSuggestion(it)
@@ -107,42 +112,46 @@ class BrowserFragment :
         )
 
         thumbnailsFeature.set(
-            feature = BrowserThumbnails(
-                requireContext(),
-                engineView,
-                requireComponents.core.store,
-            ),
+            feature =
+                BrowserThumbnails(
+                    requireContext(),
+                    engineView,
+                    requireComponents.core.store,
+                ),
             owner = this,
             view = view,
         )
 
         readerViewFeature.set(
-            feature = ReaderViewIntegration(
-                requireContext(),
-                requireComponents.core.engine,
-                requireComponents.core.store,
-                toolbar,
-                readerViewBar,
-                readerViewAppearanceButton,
-            ),
+            feature =
+                ReaderViewIntegration(
+                    requireContext(),
+                    requireComponents.core.engine,
+                    requireComponents.core.store,
+                    toolbar,
+                    readerViewBar,
+                    readerViewAppearanceButton,
+                ),
             owner = this,
             view = view,
         )
 
         webExtToolbarFeature.set(
-            feature = WebExtensionToolbarFeature(
-                toolbar,
-                requireContext().components.core.store,
-            ),
+            feature =
+                WebExtensionToolbarFeature(
+                    toolbar,
+                    requireContext().components.core.store,
+                ),
             owner = this,
             view = view,
         )
 
         windowFeature.set(
-            feature = WindowFeature(
-                store = requireComponents.core.store,
-                tabsUseCases = requireComponents.useCases.tabsUseCases,
-            ),
+            feature =
+                WindowFeature(
+                    store = requireComponents.core.store,
+                    tabsUseCases = requireComponents.useCases.tabsUseCases,
+                ),
             owner = this,
             view = view,
         )
@@ -173,9 +182,10 @@ class BrowserFragment :
     companion object {
         fun create(sessionId: String? = null) =
             BrowserFragment().apply {
-            arguments = Bundle().apply {
-                putSessionId(sessionId)
+                arguments =
+                    Bundle().apply {
+                        putSessionId(sessionId)
+                    }
             }
-        }
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/browser/ContextMenuIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/ContextMenuIntegration.kt
@@ -62,13 +62,14 @@ class ContextMenuIntegration(
         }
     }
 
-    private val feature = ContextMenuFeature(
-        fragmentManager,
-        browserStore,
-        candidates,
-        engineView,
-        contextMenuUseCases,
-    )
+    private val feature =
+        ContextMenuFeature(
+            fragmentManager,
+            browserStore,
+            candidates,
+            engineView,
+            contextMenuUseCases,
+        )
 
     override fun start() {
         feature.start()

--- a/app/src/main/java/org/mozilla/reference/browser/browser/CrashIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/CrashIntegration.kt
@@ -24,19 +24,20 @@ class CrashIntegration(
     private val crashReporter: CrashReporter,
     private val onCrash: (Crash) -> Unit,
 ) : DefaultLifecycleObserver {
-    private val receiver = object : BroadcastReceiver() {
-        override fun onReceive(
-            context: Context,
-            intent: Intent,
-        ) {
-            if (!Crash.isCrashIntent(intent)) {
-                return
-            }
+    private val receiver =
+        object : BroadcastReceiver() {
+            override fun onReceive(
+                context: Context,
+                intent: Intent,
+            ) {
+                if (!Crash.isCrashIntent(intent)) {
+                    return
+                }
 
-            val crash = Crash.fromIntent(intent)
-            onCrash(crash)
+                val crash = Crash.fromIntent(intent)
+                onCrash(crash)
+            }
         }
-    }
 
     override fun onStart(owner: LifecycleOwner) {
         super.onStart(owner)

--- a/app/src/main/java/org/mozilla/reference/browser/browser/CustomTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/CustomTabsIntegration.kt
@@ -47,9 +47,8 @@ class CustomTabsIntegration(
     private val customTabsUseCases: CustomTabsUseCases,
     sessionId: String,
     private val activity: Activity?,
-) : LifecycleAwareFeature,
-    UserInteractionHandler {
-        private val session = store.state.findCustomTab(sessionId)
+) : LifecycleAwareFeature, UserInteractionHandler {
+    private val session = store.state.findCustomTab(sessionId)
     private val logger = Logger("CustomTabsIntegration")
 
     init {
@@ -64,38 +63,44 @@ class CustomTabsIntegration(
         val tint = ContextCompat.getColor(context, R.color.icons)
         val tabId = session?.id
 
-        val forward = SmallMenuCandidate(
-            contentDescription = "Forward",
-            icon = DrawableMenuIcon(
-                context,
-                mozilla.components.ui.icons.R.drawable.mozac_ic_forward_24,
-                tint = tint,
-            ),
-        ) {
-            sessionUseCases.goForward.invoke(tabId)
-        }
+        val forward =
+            SmallMenuCandidate(
+                contentDescription = "Forward",
+                icon =
+                    DrawableMenuIcon(
+                        context,
+                        mozilla.components.ui.icons.R.drawable.mozac_ic_forward_24,
+                        tint = tint,
+                    ),
+            ) {
+                sessionUseCases.goForward.invoke(tabId)
+            }
 
-        val refresh = SmallMenuCandidate(
-            contentDescription = "Refresh",
-            icon = DrawableMenuIcon(
-                context,
-                mozilla.components.ui.icons.R.drawable.mozac_ic_arrow_clockwise_24,
-                tint = tint,
-            ),
-        ) {
-            sessionUseCases.reload.invoke(tabId)
-        }
+        val refresh =
+            SmallMenuCandidate(
+                contentDescription = "Refresh",
+                icon =
+                    DrawableMenuIcon(
+                        context,
+                        mozilla.components.ui.icons.R.drawable.mozac_ic_arrow_clockwise_24,
+                        tint = tint,
+                    ),
+            ) {
+                sessionUseCases.reload.invoke(tabId)
+            }
 
-        val stop = SmallMenuCandidate(
-            contentDescription = "Stop",
-            icon = DrawableMenuIcon(
-                context,
-                mozilla.components.ui.icons.R.drawable.mozac_ic_cross_24,
-                tint = tint,
-            ),
-        ) {
-            sessionUseCases.stopLoading.invoke(tabId)
-        }
+        val stop =
+            SmallMenuCandidate(
+                contentDescription = "Stop",
+                icon =
+                    DrawableMenuIcon(
+                        context,
+                        mozilla.components.ui.icons.R.drawable.mozac_ic_cross_24,
+                        tint = tint,
+                    ),
+            ) {
+                sessionUseCases.stopLoading.invoke(tabId)
+            }
 
         return RowMenuCandidate(listOf(forward, refresh, stop))
     }
@@ -137,14 +142,15 @@ class CustomTabsIntegration(
 
     private val menuController: MenuController = BrowserMenuController()
 
-    private val feature = CustomTabsToolbarFeature(
-        store,
-        toolbar,
-        sessionId,
-        customTabsUseCases,
-        window = activity?.window,
-        closeListener = { activity?.finish() },
-    )
+    private val feature =
+        CustomTabsToolbarFeature(
+            store,
+            toolbar,
+            sessionId,
+            customTabsUseCases,
+            window = activity?.window,
+            closeListener = { activity?.finish() },
+        )
 
     init {
         toolbar.display.menuController = menuController

--- a/app/src/main/java/org/mozilla/reference/browser/browser/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/ExternalAppBrowserFragment.kt
@@ -25,12 +25,8 @@ import mozilla.components.support.utils.ext.getParcelableArrayListCompat
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.requireComponents
 
-/**
- * Fragment used for browsing within an external app, such as for custom tabs and PWAs.
- */
-class ExternalAppBrowserFragment :
-    BaseBrowserFragment(),
-    UserInteractionHandler {
+/** Fragment used for browsing within an external app, such as for custom tabs and PWAs. */
+class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     private val customTabsIntegration = ViewBoundFeatureWrapper<CustomTabsIntegration>()
     private val windowFeature = ViewBoundFeatureWrapper<CustomTabWindowFeature>()
     private val hideToolbarFeature = ViewBoundFeatureWrapper<WebAppHideToolbarFeature>()
@@ -39,11 +35,13 @@ class ExternalAppBrowserFragment :
 
     private val toolbar: BrowserToolbar
         get() = requireView().findViewById(R.id.toolbar)
+
     private val engineView: EngineView
         get() = requireView().findViewById<View>(R.id.engineView) as EngineView
 
     private val manifest: WebAppManifest?
         get() = arguments?.getWebAppManifest()
+
     private val trustedScopes: List<Uri>
         get() = arguments?.getParcelableArrayListCompat(ARG_TRUSTED_SCOPES, Uri::class.java).orEmpty()
 
@@ -57,42 +55,45 @@ class ExternalAppBrowserFragment :
         val sessionId = this.sessionId
 
         customTabsIntegration.set(
-            feature = CustomTabsIntegration(
-                requireContext(),
-                requireComponents.core.store,
-                toolbar,
-                engineView,
-                requireComponents.useCases.sessionUseCases,
-                requireComponents.useCases.customTabsUseCases,
-                sessionId!!,
-                activity,
-            ),
+            feature =
+                CustomTabsIntegration(
+                    requireContext(),
+                    requireComponents.core.store,
+                    toolbar,
+                    engineView,
+                    requireComponents.useCases.sessionUseCases,
+                    requireComponents.useCases.customTabsUseCases,
+                    sessionId!!,
+                    activity,
+                ),
             owner = this,
             view = view,
         )
 
         windowFeature.set(
-            feature = CustomTabWindowFeature(
-                requireActivity(),
-                requireComponents.core.store,
-                sessionId,
-            ),
+            feature =
+                CustomTabWindowFeature(
+                    requireActivity(),
+                    requireComponents.core.store,
+                    sessionId,
+                ),
             owner = this,
             view = view,
         )
 
         hideToolbarFeature.set(
-            feature = WebAppHideToolbarFeature(
-                requireComponents.core.store,
-                requireComponents.core.customTabsStore,
-                sessionId,
-                manifest,
-                scope = viewLifecycleOwner.lifecycleScope,
-            ) { toolbarVisible ->
-                toolbar.isVisible = toolbarVisible
-                webAppToolbarShouldBeVisible = toolbarVisible
-                if (!toolbarVisible) engineView.setDynamicToolbarMaxHeight(0)
-            },
+            feature =
+                WebAppHideToolbarFeature(
+                    requireComponents.core.store,
+                    requireComponents.core.customTabsStore,
+                    sessionId,
+                    manifest,
+                    scope = viewLifecycleOwner.lifecycleScope,
+                ) { toolbarVisible ->
+                    toolbar.isVisible = toolbarVisible
+                    webAppToolbarShouldBeVisible = toolbarVisible
+                    if (!toolbarVisible) engineView.setDynamicToolbarMaxHeight(0)
+                },
             owner = this,
             view = toolbar,
         )
@@ -119,8 +120,8 @@ class ExternalAppBrowserFragment :
     }
 
     /**
-     * Calls [onBackPressed] for features in the base class first,
-     * before trying to call the custom tab [UserInteractionHandler].
+     * Calls [onBackPressed] for features in the base class first, before trying to call the custom tab
+     * [UserInteractionHandler].
      */
     override fun onBackPressed(): Boolean = super.onBackPressed() || customTabsIntegration.onBackPressed()
 
@@ -131,12 +132,14 @@ class ExternalAppBrowserFragment :
             sessionId: String,
             manifest: WebAppManifest?,
             trustedScopes: List<Uri>,
-        ) = ExternalAppBrowserFragment().apply {
-            arguments = Bundle().apply {
-                putSessionId(sessionId)
-                putWebAppManifest(manifest)
-                putParcelableArrayList(ARG_TRUSTED_SCOPES, ArrayList(trustedScopes))
+        ) =
+            ExternalAppBrowserFragment().apply {
+                arguments =
+                    Bundle().apply {
+                        putSessionId(sessionId)
+                        putWebAppManifest(manifest)
+                        putParcelableArrayList(ARG_TRUSTED_SCOPES, ArrayList(trustedScopes))
+                    }
             }
-        }
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/browser/FindInPageIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/FindInPageIntegration.kt
@@ -23,8 +23,7 @@ class FindInPageIntegration(
     private val sessionId: String? = null,
     private val view: FindInPageView,
     engineView: EngineView,
-) : LifecycleAwareFeature,
-    UserInteractionHandler {
+) : LifecycleAwareFeature, UserInteractionHandler {
     private val feature = FindInPageFeature(store, view, engineView, ::onClose)
 
     override fun start() {
@@ -63,8 +62,8 @@ class FindInPageIntegration(
 }
 
 /**
- * [CoordinatorLayout.Behavior] that will always position the [FindInPageBar] above the [BrowserToolbar] (including
- * when the browser toolbar is scrolling or performing a snap animation).
+ * [CoordinatorLayout.Behavior] that will always position the [FindInPageBar] above the [BrowserToolbar] (including when
+ * the browser toolbar is scrolling or performing a snap animation).
  */
 @Suppress("unused") // Referenced from XML
 class FindInPageBarBehavior(

--- a/app/src/main/java/org/mozilla/reference/browser/browser/ReaderViewIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/ReaderViewIntegration.kt
@@ -29,44 +29,44 @@ class ReaderViewIntegration(
     toolbar: BrowserToolbar,
     view: ReaderViewControlsView,
     readerViewAppearanceButton: FloatingActionButton,
-) : LifecycleAwareFeature,
-    UserInteractionHandler {
-        private var readerViewButtonVisible = false
+) : LifecycleAwareFeature, UserInteractionHandler {
+    private var readerViewButtonVisible = false
 
-    private val readerViewButton: BrowserToolbar.ToggleButton = BrowserToolbar.ToggleButton(
-        image = ContextCompat.getDrawable(context, iconsR.drawable.mozac_ic_reader_view_24)!!,
-        imageSelected = ContextCompat.getDrawable(context, iconsR.drawable.mozac_ic_reader_view_24)!!.mutate().apply {
-            setTint(ContextCompat.getColor(context, colorsR.color.photonBlue40))
-        },
-        contentDescription = "Enable Reader View",
-        contentDescriptionSelected = "Disable Reader View",
-        selected = store.state.selectedTab
-            ?.readerState
-            ?.active ?: false,
-        visible = { readerViewButtonVisible },
-    ) { enabled ->
-        if (enabled) {
-            feature.showReaderView()
-            readerViewAppearanceButton.show()
-        } else {
-            feature.hideReaderView()
-            feature.hideControls()
-            readerViewAppearanceButton.hide()
+    private val readerViewButton: BrowserToolbar.ToggleButton =
+        BrowserToolbar.ToggleButton(
+            image = ContextCompat.getDrawable(context, iconsR.drawable.mozac_ic_reader_view_24)!!,
+            imageSelected =
+                ContextCompat.getDrawable(context, iconsR.drawable.mozac_ic_reader_view_24)!!.mutate().apply {
+                    setTint(ContextCompat.getColor(context, colorsR.color.photonBlue40))
+                },
+            contentDescription = "Enable Reader View",
+            contentDescriptionSelected = "Disable Reader View",
+            selected = store.state.selectedTab?.readerState?.active ?: false,
+            visible = { readerViewButtonVisible },
+        ) { enabled ->
+            if (enabled) {
+                feature.showReaderView()
+                readerViewAppearanceButton.show()
+            } else {
+                feature.hideReaderView()
+                feature.hideControls()
+                readerViewAppearanceButton.hide()
+            }
         }
-    }
 
     init {
         toolbar.addPageAction(readerViewButton)
         readerViewAppearanceButton.setOnClickListener { feature.showControls() }
     }
 
-    private val feature = ReaderViewFeature(context, engine, store, view) { available, active ->
-        readerViewButtonVisible = available
-        readerViewButton.setSelected(active)
+    private val feature =
+        ReaderViewFeature(context, engine, store, view) { available, active ->
+            readerViewButtonVisible = available
+            readerViewButton.setSelected(active)
 
-        if (active) readerViewAppearanceButton.show() else readerViewAppearanceButton.hide()
-        toolbar.invalidateActions()
-    }
+            if (active) readerViewAppearanceButton.show() else readerViewAppearanceButton.hide()
+            toolbar.invalidateActions()
+        }
 
     override fun start() {
         feature.start()
@@ -80,8 +80,8 @@ class ReaderViewIntegration(
 }
 
 /**
- * [CoordinatorLayout.Behavior] that will always position the reader view appearance button above
- * the [FindInPageBar] (including when the browser toolbar is scrolling or performing a snap animation).
+ * [CoordinatorLayout.Behavior] that will always position the reader view appearance button above the [FindInPageBar]
+ * (including when the browser toolbar is scrolling or performing a snap animation).
  */
 @Suppress("unused") // Referenced from XML
 class ReaderViewAppearanceButtonBehavior(

--- a/app/src/main/java/org/mozilla/reference/browser/browser/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/ToolbarIntegration.kt
@@ -57,52 +57,56 @@ class ToolbarIntegration(
     private val tabsUseCases: TabsUseCases,
     private val webAppUseCases: WebAppUseCases,
     sessionId: String? = null,
-) : LifecycleAwareFeature,
-    UserInteractionHandler {
-    private val shippedDomainsProvider = ShippedDomainsProvider().also {
-        it.initialize(context)
-    }
+) : LifecycleAwareFeature, UserInteractionHandler {
+    private val shippedDomainsProvider =
+        ShippedDomainsProvider().also {
+            it.initialize(context)
+        }
 
     private val scope = MainScope()
 
     private fun menuToolbar(session: SessionState?): RowMenuCandidate {
         val tint = ContextCompat.getColor(context, R.color.icons)
 
-        val forward = SmallMenuCandidate(
-            contentDescription = "Forward",
-            icon = DrawableMenuIcon(
-                context,
-                mozilla.components.ui.icons.R.drawable.mozac_ic_forward_24,
-                tint = tint,
-            ),
-            containerStyle = ContainerStyle(
-                isEnabled = session?.content?.canGoForward == true,
-            ),
-        ) {
-            sessionUseCases.goForward.invoke()
-        }
+        val forward =
+            SmallMenuCandidate(
+                contentDescription = "Forward",
+                icon =
+                    DrawableMenuIcon(
+                        context,
+                        mozilla.components.ui.icons.R.drawable.mozac_ic_forward_24,
+                        tint = tint,
+                    ),
+                containerStyle = ContainerStyle(isEnabled = session?.content?.canGoForward == true),
+            ) {
+                sessionUseCases.goForward.invoke()
+            }
 
-        val refresh = SmallMenuCandidate(
-            contentDescription = "Refresh",
-            icon = DrawableMenuIcon(
-                context,
-                mozilla.components.ui.icons.R.drawable.mozac_ic_arrow_clockwise_24,
-                tint = tint,
-            ),
-        ) {
-            sessionUseCases.reload.invoke()
-        }
+        val refresh =
+            SmallMenuCandidate(
+                contentDescription = "Refresh",
+                icon =
+                    DrawableMenuIcon(
+                        context,
+                        mozilla.components.ui.icons.R.drawable.mozac_ic_arrow_clockwise_24,
+                        tint = tint,
+                    ),
+            ) {
+                sessionUseCases.reload.invoke()
+            }
 
-        val stop = SmallMenuCandidate(
-            contentDescription = "Stop",
-            icon = DrawableMenuIcon(
-                context,
-                mozilla.components.ui.icons.R.drawable.mozac_ic_cross_24,
-                tint = tint,
-            ),
-        ) {
-            sessionUseCases.stopLoading.invoke()
-        }
+        val stop =
+            SmallMenuCandidate(
+                contentDescription = "Stop",
+                icon =
+                    DrawableMenuIcon(
+                        context,
+                        mozilla.components.ui.icons.R.drawable.mozac_ic_cross_24,
+                        tint = tint,
+                    ),
+            ) {
+                sessionUseCases.stopLoading.invoke()
+            }
 
         return RowMenuCandidate(listOf(forward, refresh, stop))
     }
@@ -124,68 +128,63 @@ class ToolbarIntegration(
             if (webAppUseCases.isPinningSupported()) {
                 TextMenuCandidate(
                     text = "Add to homescreen",
-                    containerStyle = ContainerStyle(
-                        isVisible = webAppUseCases.isPinningSupported(),
-                    ),
+                    containerStyle = ContainerStyle(isVisible = webAppUseCases.isPinningSupported()),
                 ) {
                     scope.launch { webAppUseCases.addToHomescreen() }
                 }
             } else {
                 null
             },
-            TextMenuCandidate(
-                text = "Find in Page",
-            ) {
+            TextMenuCandidate(text = "Find in Page") {
                 FindInPageIntegration.launch?.invoke()
             },
         )
 
     private fun menuItems(sessionState: SessionState?): List<MenuCandidate> {
-        val sessionMenuItems = if (sessionState != null) {
-            sessionMenuItems(sessionState)
-        } else {
-            emptyList()
-        }
+        val sessionMenuItems =
+            if (sessionState != null) {
+                sessionMenuItems(sessionState)
+            } else {
+                emptyList()
+            }
 
-        return sessionMenuItems + listOf(
-            TextMenuCandidate(text = "Add-ons") {
-                val intent = Intent(context, AddonsActivity::class.java)
-                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                context.startActivity(intent)
-            },
-            TextMenuCandidate(text = "Synced Tabs") {
-                val intent = Intent(context, SyncedTabsActivity::class.java)
-                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                context.startActivity(intent)
-            },
-            TextMenuCandidate(text = "Report issue") {
-                tabsUseCases.addTab(
-                    url = "https://github.com/mozilla-mobile/reference-browser/issues/new",
-                )
-            },
-            TextMenuCandidate(text = "Settings") {
-                val intent = Intent(context, SettingsActivity::class.java)
-                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                context.startActivity(intent)
-            },
-        )
+        return sessionMenuItems +
+            listOf(
+                TextMenuCandidate(text = "Add-ons") {
+                    val intent = Intent(context, AddonsActivity::class.java)
+                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    context.startActivity(intent)
+                },
+                TextMenuCandidate(text = "Synced Tabs") {
+                    val intent = Intent(context, SyncedTabsActivity::class.java)
+                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    context.startActivity(intent)
+                },
+                TextMenuCandidate(text = "Report issue") {
+                    tabsUseCases.addTab(url = "https://github.com/mozilla-mobile/reference-browser/issues/new")
+                },
+                TextMenuCandidate(text = "Settings") {
+                    val intent = Intent(context, SettingsActivity::class.java)
+                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    context.startActivity(intent)
+                },
+            )
     }
 
     private val browserMenuController: MenuController = BrowserMenuController()
 
     init {
         toolbar.display.apply {
-            indicators = listOf(
-                DisplayToolbar.Indicators.SECURITY,
-                DisplayToolbar.Indicators.TRACKING_PROTECTION,
-            )
+            indicators =
+                listOf(
+                    DisplayToolbar.Indicators.SECURITY,
+                    DisplayToolbar.Indicators.TRACKING_PROTECTION,
+                )
             displayIndicatorSeparator = true
             menuController = browserMenuController
             hint = context.getString(R.string.toolbar_hint)
 
-            setUrlBackground(
-                ResourcesCompat.getDrawable(context.resources, R.drawable.url_background, context.theme),
-            )
+            setUrlBackground(ResourcesCompat.getDrawable(context.resources, R.drawable.url_background, context.theme))
         }
 
         toolbar.edit.apply {
@@ -193,9 +192,7 @@ class ToolbarIntegration(
         }
 
         ToolbarAutocompleteFeature(toolbar).apply {
-            updateAutocompleteProviders(
-                listOf(historyStorage, shippedDomainsProvider),
-            )
+            updateAutocompleteProviders(listOf(historyStorage, shippedDomainsProvider))
         }
 
         ImeInsetsSynchronizer.setup(
@@ -232,19 +229,20 @@ class ToolbarIntegration(
         }
     }
 
-    private val toolbarFeature: ToolbarFeature = ToolbarFeature(
-        toolbar,
-        context.components.core.store,
-        context.components.useCases.sessionUseCases.loadUrl,
-        { searchTerms ->
-            context.components.useCases.searchUseCases.defaultSearch.invoke(
-                searchTerms = searchTerms,
-                searchEngine = null,
-                parentSessionId = null,
-            )
-        },
-        sessionId,
-    )
+    private val toolbarFeature: ToolbarFeature =
+        ToolbarFeature(
+            toolbar,
+            context.components.core.store,
+            context.components.useCases.sessionUseCases.loadUrl,
+            { searchTerms ->
+                context.components.useCases.searchUseCases.defaultSearch.invoke(
+                    searchTerms = searchTerms,
+                    searchEngine = null,
+                    parentSessionId = null,
+                )
+            },
+            sessionId,
+        )
 
     override fun start() {
         toolbarFeature.start()

--- a/app/src/main/java/org/mozilla/reference/browser/components/Analytics.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Analytics.kt
@@ -20,55 +20,52 @@ import org.mozilla.reference.browser.BrowserApplication
 import org.mozilla.reference.browser.BuildConfig
 import org.mozilla.reference.browser.R
 
-/**
- * Component group for all functionality related to analytics e.g. crash
- * reporting and telemetry.
- */
-class Analytics(
-    private val context: Context,
-) {
-    /**
-     * A generic crash reporter component configured to use both Sentry and Socorro.
-     */
+/** Component group for all functionality related to analytics e.g. crash reporting and telemetry. */
+class Analytics(private val context: Context) {
+    /** A generic crash reporter component configured to use both Sentry and Socorro. */
     val crashReporter: CrashReporter by lazy {
-        val socorroService = MozillaSocorroService(
-            context,
-            appName = "ReferenceBrowser",
-            version = MOZ_APP_VERSION,
-            buildId = MOZ_APP_BUILDID,
-            vendor = MOZ_APP_VENDOR,
-            releaseChannel = MOZ_UPDATE_CHANNEL,
-        )
+        val socorroService =
+            MozillaSocorroService(
+                context,
+                appName = "ReferenceBrowser",
+                version = MOZ_APP_VERSION,
+                buildId = MOZ_APP_BUILDID,
+                vendor = MOZ_APP_VENDOR,
+                releaseChannel = MOZ_UPDATE_CHANNEL,
+            )
 
         val services: MutableList<CrashReporterService> = mutableListOf(socorroService)
 
         if (isSentryEnabled()) {
-            val sentryService = SentryService(
-                context,
-                BuildConfig.SENTRY_TOKEN,
-                mapOf("geckoview" to "$MOZ_APP_VERSION-$MOZ_APP_BUILDID"),
-                sendEventForNativeCrashes = true,
-            )
+            val sentryService =
+                SentryService(
+                    context,
+                    BuildConfig.SENTRY_TOKEN,
+                    mapOf("geckoview" to "$MOZ_APP_VERSION-$MOZ_APP_BUILDID"),
+                    sendEventForNativeCrashes = true,
+                )
             services.add(sentryService)
         }
 
-        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_IMMUTABLE
-        } else {
-            0
-        }
+        val flags =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_IMMUTABLE
+            } else {
+                0
+            }
 
         CrashReporter(
             context = context,
             services = services,
             telemetryServices = emptyList(),
             shouldPrompt = CrashReporter.Prompt.ALWAYS,
-            promptConfiguration = CrashReporter.PromptConfiguration(
-                appName = context.getString(R.string.app_name),
-                organizationName = "Mozilla",
-            ),
-            nonFatalCrashIntent = PendingIntent
-                .getBroadcast(context, 0, Intent(BrowserApplication.NON_FATAL_CRASH_BROADCAST), flags),
+            promptConfiguration =
+                CrashReporter.PromptConfiguration(
+                    appName = context.getString(R.string.app_name),
+                    organizationName = "Mozilla",
+                ),
+            nonFatalCrashIntent =
+                PendingIntent.getBroadcast(context, 0, Intent(BrowserApplication.NON_FATAL_CRASH_BROADCAST), flags),
             enabled = true,
         )
     }

--- a/app/src/main/java/org/mozilla/reference/browser/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/BackgroundServices.kt
@@ -6,6 +6,7 @@ package org.mozilla.reference.browser.components
 
 import android.content.Context
 import android.os.Build
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -31,14 +32,13 @@ import mozilla.components.service.sync.logins.SyncableLoginsStorage
 import org.mozilla.reference.browser.NotificationManager
 import org.mozilla.reference.browser.ext.components
 import org.mozilla.reference.browser.tabs.synced.SyncedTabsIntegration
-import java.util.concurrent.TimeUnit
 
 const val DEFAULT_ACTIVE_DAYS = 14L
 val maxActiveTime = TimeUnit.DAYS.toMillis(DEFAULT_ACTIVE_DAYS)
 
 /**
- * Component group for background services. These are components that need to be accessed from
- * within a background worker.
+ * Component group for background services. These are components that need to be accessed from within a background
+ * worker.
  */
 class BackgroundServices(
     context: Context,
@@ -61,40 +61,42 @@ class BackgroundServices(
     }
 
     private val serverConfig = ServerConfig(FxaServer.Release, CLIENT_ID, REDIRECT_URL)
-    private val deviceConfig = DeviceConfig(
-        name = "Reference Browser on " + Build.MANUFACTURER + " " + Build.MODEL,
-        type = DeviceType.MOBILE,
-        capabilities = setOf(DeviceCapability.SEND_TAB),
-    )
-    private val syncConfig = SyncConfig(
-        supportedEngines = SUPPORTED_SYNC_ENGINES,
-        periodicSyncConfig = PeriodicSyncConfig(),
-    ) // four hours
+    private val deviceConfig =
+        DeviceConfig(
+            name = "Reference Browser on " + Build.MANUFACTURER + " " + Build.MODEL,
+            type = DeviceType.MOBILE,
+            capabilities = setOf(DeviceCapability.SEND_TAB),
+        )
+    private val syncConfig =
+        SyncConfig(
+            supportedEngines = SUPPORTED_SYNC_ENGINES,
+            periodicSyncConfig = PeriodicSyncConfig(),
+        ) // four hours
 
     val accountManager by lazy {
         FxaAccountManager(
-            context,
-            serverConfig,
-            deviceConfig,
-            syncConfig,
-            // We don't need to specify this explicitly, but `syncConfig` may be disabled due to an 'experiments'
-            // flag. In that case, sync scope necessary for syncing won't be acquired during authentication
-            // unless we explicitly specify it below.
-            // This is a good example of an information leak at the API level.
-            // See https://github.com/mozilla-mobile/android-components/issues/3732
-            setOf("https://identity.mozilla.com/apps/oldsync"),
-        ).also { accountManager ->
+                context,
+                serverConfig,
+                deviceConfig,
+                syncConfig,
+                // We don't need to specify this explicitly, but `syncConfig` may be disabled due to an 'experiments'
+                // flag. In that case, sync scope necessary for syncing won't be acquired during authentication
+                // unless we explicitly specify it below.
+                // This is a good example of an information leak at the API level.
+                // See https://github.com/mozilla-mobile/android-components/issues/3732
+                setOf("https://identity.mozilla.com/apps/oldsync"),
+            )
+            .also { accountManager ->
+                SendTabFeature(accountManager) { device, tabs ->
+                    NotificationManager.showReceivedTabs(context, device, tabs)
+                }
 
-            SendTabFeature(accountManager) { device, tabs ->
-                NotificationManager.showReceivedTabs(context, device, tabs)
+                push.feature?.let { push -> FxaPushSupportFeature(context, accountManager, push) }
+
+                SyncedTabsIntegration(context, accountManager).launch()
+
+                CoroutineScope(Dispatchers.Main).launch { accountManager.start() }
             }
-
-            push.feature?.let { push -> FxaPushSupportFeature(context, accountManager, push) }
-
-            SyncedTabsIntegration(context, accountManager).launch()
-
-            CoroutineScope(Dispatchers.Main).launch { accountManager.start() }
-        }
     }
 
     val syncedTabsStorage by lazy {
@@ -119,7 +121,7 @@ class BackgroundServices(
                     // If the queue is empty when the worker runs, that's OK; the worker
                     // won't do anything, and won't run again until the next call to `onAdded`.
                     override fun onRemoved() = Unit
-                },
+                }
             )
         }
     }

--- a/app/src/main/java/org/mozilla/reference/browser/components/Core.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Core.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.os.Environment
 import androidx.preference.PreferenceManager
+import java.util.concurrent.TimeUnit
 import mozilla.components.browser.engine.gecko.permission.GeckoSitePermissionsStorage
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.session.storage.SessionStorage
@@ -57,147 +58,120 @@ import org.mozilla.reference.browser.ext.components
 import org.mozilla.reference.browser.ext.getPreferenceKey
 import org.mozilla.reference.browser.media.MediaSessionService
 import org.mozilla.reference.browser.settings.Settings
-import java.util.concurrent.TimeUnit
 
 private const val DAY_IN_MINUTES = 24 * 60L
 
-/**
- * Component group for all core browser functionality.
- */
+/** Component group for all core browser functionality. */
 class Core(
     private val context: Context,
     crashReporter: CrashReporter,
 ) {
-    /**
-     * The browser engine component initialized based on the build
-     * configuration (see build variants).
-     */
+    /** The browser engine component initialized based on the build configuration (see build variants). */
     val engine: Engine by lazy {
         val prefs = PreferenceManager.getDefaultSharedPreferences(context)
 
-        val defaultSettings = DefaultSettings(
-            requestInterceptor = AppRequestInterceptor(context),
-            remoteDebuggingEnabled = prefs.getBoolean(context.getPreferenceKey(pref_key_remote_debugging), false),
-            testingModeEnabled = prefs.getBoolean(context.getPreferenceKey(R.string.pref_key_testing_mode), false),
-            trackingProtectionPolicy = createTrackingProtectionPolicy(prefs),
-            historyTrackingDelegate = HistoryDelegate(lazyHistoryStorage),
-            globalPrivacyControlEnabled = prefs.getBoolean(
-                context.getPreferenceKey(R.string.pref_key_global_privacy_control),
-                false,
-            ),
-        )
+        val defaultSettings =
+            DefaultSettings(
+                requestInterceptor = AppRequestInterceptor(context),
+                remoteDebuggingEnabled = prefs.getBoolean(context.getPreferenceKey(pref_key_remote_debugging), false),
+                testingModeEnabled = prefs.getBoolean(context.getPreferenceKey(R.string.pref_key_testing_mode), false),
+                trackingProtectionPolicy = createTrackingProtectionPolicy(prefs),
+                historyTrackingDelegate = HistoryDelegate(lazyHistoryStorage),
+                globalPrivacyControlEnabled =
+                    prefs.getBoolean(
+                        context.getPreferenceKey(R.string.pref_key_global_privacy_control),
+                        false,
+                    ),
+            )
         EngineProvider.createEngine(context, defaultSettings)
     }
 
-    /**
-     * The [Client] implementation (`concept-fetch`) used for HTTP requests.
-     */
+    /** The [Client] implementation (`concept-fetch`) used for HTTP requests. */
     val client: Client by lazy {
         EngineProvider.createClient(context)
     }
 
-    /**
-     * The [BrowserStore] holds the global [BrowserState].
-     */
+    /** The [BrowserStore] holds the global [BrowserState]. */
     val store by lazy {
         BrowserStore(
-            middleware = listOf(
-                DownloadMiddleware(
-                    applicationContext = context,
-                    downloadServiceClass = DownloadService::class.java,
-                    deleteFileFromStorage = { false },
-                    downloadFileUtils = DefaultDownloadFileUtils(
-                        context = context,
-                        downloadLocation = {
-                            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path
-                        },
-                    ),
-                ),
-                ThumbnailsMiddleware(thumbnailStorage),
-                ReaderViewMiddleware(),
-                RegionMiddleware(
-                    context,
-                    LocationService.default(),
-                ),
-                SearchMiddleware(context),
-                RecordingDevicesMiddleware(context, context.components.notificationsDelegate),
-            ) + EngineMiddleware.create(engine),
-        ).apply {
-            icons.install(engine, this)
-
-            WebNotificationFeature(
-                context,
-                engine,
-                icons,
-                R.drawable.ic_notification,
-                geckoSitePermissionsStorage,
-                BrowserActivity::class.java,
-                notificationsDelegate = context.components.notificationsDelegate,
+                middleware =
+                    listOf(
+                        DownloadMiddleware(
+                            applicationContext = context,
+                            downloadServiceClass = DownloadService::class.java,
+                            deleteFileFromStorage = { false },
+                            downloadFileUtils =
+                                DefaultDownloadFileUtils(
+                                    context = context,
+                                    downloadLocation = {
+                                        Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+                                            .path
+                                    },
+                                ),
+                        ),
+                        ThumbnailsMiddleware(thumbnailStorage),
+                        ReaderViewMiddleware(),
+                        RegionMiddleware(
+                            context,
+                            LocationService.default(),
+                        ),
+                        SearchMiddleware(context),
+                        RecordingDevicesMiddleware(context, context.components.notificationsDelegate),
+                    ) + EngineMiddleware.create(engine)
             )
+            .apply {
+                icons.install(engine, this)
 
-            MediaSessionFeature(context, MediaSessionService::class.java, this).start()
-        }
+                WebNotificationFeature(
+                    context,
+                    engine,
+                    icons,
+                    R.drawable.ic_notification,
+                    geckoSitePermissionsStorage,
+                    BrowserActivity::class.java,
+                    notificationsDelegate = context.components.notificationsDelegate,
+                )
+
+                MediaSessionFeature(context, MediaSessionService::class.java, this).start()
+            }
     }
 
-    /**
-     * The [CustomTabsServiceStore] holds global custom tabs related data.
-     */
+    /** The [CustomTabsServiceStore] holds global custom tabs related data. */
     val customTabsStore by lazy { CustomTabsServiceStore() }
 
-    /**
-     * The storage component for persisting browser tab sessions.
-     */
+    /** The storage component for persisting browser tab sessions. */
     val sessionStorage: SessionStorage by lazy {
         SessionStorage(context, engine)
     }
 
-    /**
-     * The storage component to persist browsing history (with the exception of
-     * private sessions).
-     */
+    /** The storage component to persist browsing history (with the exception of private sessions). */
     val lazyHistoryStorage = lazy { PlacesHistoryStorage(context) }
 
-    /**
-     * A convenience accessor to the [PlacesHistoryStorage].
-     */
+    /** A convenience accessor to the [PlacesHistoryStorage]. */
     val historyStorage by lazy { lazyHistoryStorage.value }
 
-    /**
-     * The storage component to persist logins data (username/password) for websites.
-     */
+    /** The storage component to persist logins data (username/password) for websites. */
     val lazyLoginsStorage = lazy { SyncableLoginsStorage(context, lazySecurePrefs) }
 
-    /**
-     * A convenience accessor to the [SyncableLoginsStorage].
-     */
+    /** A convenience accessor to the [SyncableLoginsStorage]. */
     val loginsStorage by lazy { lazyLoginsStorage.value }
 
-    /**
-     * The storage component to sync and persist tabs in a Firefox Sync account.
-     */
+    /** The storage component to sync and persist tabs in a Firefox Sync account. */
     val lazyRemoteTabsStorage = lazy { RemoteTabsStorage(context, crashReporter) }
 
-    /**
-     * A storage component for persisting thumbnail images of tabs.
-     */
+    /** A storage component for persisting thumbnail images of tabs. */
     val thumbnailStorage by lazy { ThumbnailStorage(context) }
 
-    /**
-     * Component for managing shortcuts (both regular and PWA).
-     */
+    /** Component for managing shortcuts (both regular and PWA). */
     val shortcutManager by lazy { WebAppShortcutManager(context, client, ManifestStorage(context)) }
 
-    /**
-     * A storage component for site permissions.
-     */
+    /** A storage component for site permissions. */
     val geckoSitePermissionsStorage by lazy {
         val geckoRuntime = EngineProvider.getOrCreateRuntime(context)
         GeckoSitePermissionsStorage(geckoRuntime, OnDiskSitePermissionsStorage(context))
     }
 
-    /**
-     * Icons component for loading, caching and processing website icons.
-     */
+    /** Icons component for loading, caching and processing website icons. */
     val icons by lazy { BrowserIcons(context, client) }
 
     // Addons
@@ -251,12 +225,11 @@ class Core(
     /**
      * Constructs a [TrackingProtectionPolicy] based on current preferences.
      *
-     * @param prefs the shared preferences to use when reading tracking
-     * protection settings.
-     * @param normalMode whether or not tracking protection should be enabled
-     * in normal browsing mode, defaults to the current preference value.
-     * @param privateMode whether or not tracking protection should be enabled
-     * in private browsing mode, default to the current preference value.
+     * @param prefs the shared preferences to use when reading tracking protection settings.
+     * @param normalMode whether or not tracking protection should be enabled in normal browsing mode, defaults to the
+     *   current preference value.
+     * @param privateMode whether or not tracking protection should be enabled in private browsing mode, default to the
+     *   current preference value.
      * @return the constructed tracking protection policy based on preferences.
      */
     fun createTrackingProtectionPolicy(

--- a/app/src/main/java/org/mozilla/reference/browser/components/Push.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Push.kt
@@ -13,8 +13,8 @@ import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.reference.browser.push.FirebasePush
 
 /**
- * Component group for push services. These components use services that strongly depend on
- * push messaging (e.g. WebPush, SendTab).
+ * Component group for push services. These components use services that strongly depend on push messaging (e.g.
+ * WebPush, SendTab).
  */
 @SuppressLint("DiscouragedApi")
 class Push(
@@ -35,8 +35,8 @@ class Push(
     /**
      * The push configuration data class used to initialize the AutoPushFeature.
      *
-     * If we have the `project_id` resource, then we know that the Firebase configuration and API
-     * keys are available for the FCM service to be used.
+     * If we have the `project_id` resource, then we know that the Firebase configuration and API keys are available for
+     * the FCM service to be used.
      */
     private val pushConfig by lazy {
         val logger = Logger("AutoPush")

--- a/app/src/main/java/org/mozilla/reference/browser/components/Services.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Services.kt
@@ -15,9 +15,7 @@ import mozilla.components.service.fxa.manager.FxaAccountManager
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.getPreferenceKey
 
-/**
- * Component group which encapsulates foreground-friendly services.
- */
+/** Component group which encapsulates foreground-friendly services. */
 class Services(
     private val context: Context,
     private val accountManager: FxaAccountManager,

--- a/app/src/main/java/org/mozilla/reference/browser/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/UseCases.kt
@@ -20,8 +20,7 @@ import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.utils.DefaultDownloadFileUtils
 
 /**
- * Component group for all use cases. Use cases are provided by feature
- * modules and can be triggered by UI interactions.
+ * Component group for all use cases. Use cases are provided by feature modules and can be triggered by UI interactions.
  */
 class UseCases(
     private val context: Context,
@@ -29,55 +28,40 @@ class UseCases(
     private val store: BrowserStore,
     private val shortcutManager: WebAppShortcutManager,
 ) {
-    /**
-     * Use cases that provide engine interactions for a given browser session.
-     */
+    /** Use cases that provide engine interactions for a given browser session. */
     val sessionUseCases by lazy { SessionUseCases(store) }
 
-    /**
-     * Use cases that provide tab management.
-     */
+    /** Use cases that provide tab management. */
     val tabsUseCases: TabsUseCases by lazy { TabsUseCases(store) }
 
-    /**
-     * Use cases that provide search engine integration.
-     */
+    /** Use cases that provide search engine integration. */
     val searchUseCases by lazy {
         SearchUseCases(store, tabsUseCases, sessionUseCases)
     }
 
-    /**
-     * Use cases that provide settings management.
-     */
+    /** Use cases that provide settings management. */
     val settingsUseCases by lazy { SettingsUseCases(engine, store) }
 
-    /**
-     * Use cases that provide shortcut and progressive web app management.
-     */
+    /** Use cases that provide shortcut and progressive web app management. */
     val webAppUseCases by lazy { WebAppUseCases(context, store, shortcutManager) }
 
-    /**
-     * Uses cases that provides context menu
-     */
+    /** Uses cases that provides context menu */
     val contextMenuUseCases: ContextMenuUseCases by lazy { ContextMenuUseCases(store) }
 
-    /**
-     * Use cases related to the downloads feature.
-     */
+    /** Use cases related to the downloads feature. */
     val downloadsUseCases: DownloadsUseCases by lazy {
         DownloadsUseCases(
             store = store,
-            downloadFileUtils = DefaultDownloadFileUtils(
-                context = context,
-                downloadLocation = {
-                    Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path
-                },
-            ),
+            downloadFileUtils =
+                DefaultDownloadFileUtils(
+                    context = context,
+                    downloadLocation = {
+                        Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path
+                    },
+                ),
         )
     }
 
-    /**
-     * Use cases related to Custom Tabs.
-     */
+    /** Use cases related to Custom Tabs. */
     val customTabsUseCases: CustomTabsUseCases by lazy { CustomTabsUseCases(store, sessionUseCases.loadUrl) }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/components/Utilities.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Utilities.kt
@@ -16,9 +16,7 @@ import mozilla.components.feature.tabs.CustomTabsUseCases
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 
-/**
- * Component group for miscellaneous components.
- */
+/** Component group for miscellaneous components. */
 class Utilities(
     private val context: Context,
     private val store: BrowserStore,
@@ -27,9 +25,7 @@ class Utilities(
     private val tabsUseCases: TabsUseCases,
     private val customTabsUseCases: CustomTabsUseCases,
 ) {
-    /**
-     * Provides intent processing functionality for Progressive Web App and Custom Tab intents.
-     */
+    /** Provides intent processing functionality for Progressive Web App and Custom Tab intents. */
     val externalIntentProcessors by lazy {
         listOf(
             CustomTabIntentProcessor(
@@ -46,12 +42,11 @@ class Utilities(
     }
 
     /**
-     * Provides intent processing functionality for ACTION_VIEW and ACTION_SEND intents,
-     * along with external intent processors.
+     * Provides intent processing functionality for ACTION_VIEW and ACTION_SEND intents, along with external intent
+     * processors.
      */
     val intentProcessors by lazy {
-        externalIntentProcessors +
-            TabIntentProcessor(tabsUseCases, searchUseCases.newTabSearch)
+        externalIntentProcessors + TabIntentProcessor(tabsUseCases, searchUseCases.newTabSearch)
     }
 
     val publicSuffixList by lazy {

--- a/app/src/main/java/org/mozilla/reference/browser/compose/ComposableComponents.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/compose/ComposableComponents.kt
@@ -10,11 +10,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.session.SessionUseCases
 import org.mozilla.reference.browser.ext.components
 
-/**
- * Composable helper for providing the [BrowserStore] instance of this application.
- */
-@Composable
-fun browserStore(): BrowserStore = LocalContext.current.components.core.store
+/** Composable helper for providing the [BrowserStore] instance of this application. */
+@Composable fun browserStore(): BrowserStore = LocalContext.current.components.core.store
 
-@Composable
-fun sessionUseCases(): SessionUseCases = LocalContext.current.components.useCases.sessionUseCases
+@Composable fun sessionUseCases(): SessionUseCases = LocalContext.current.components.useCases.sessionUseCases

--- a/app/src/main/java/org/mozilla/reference/browser/ext/Context.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/ext/Context.kt
@@ -18,26 +18,20 @@ import org.mozilla.reference.browser.BrowserApplication
 import org.mozilla.reference.browser.Components
 import org.mozilla.reference.browser.R
 
-/**
- * Get the BrowserApplication object from a context.
- */
+/** Get the BrowserApplication object from a context. */
 val Context.application: BrowserApplication
     get() = applicationContext as BrowserApplication
 
-/**
- * Get the requireComponents of this application.
- */
+/** Get the requireComponents of this application. */
 val Context.components: Components
     get() = application.components
 
-fun Context.getPreferenceKey(
-    @StringRes resourceId: Int,
-): String = resources.getString(resourceId)
+fun Context.getPreferenceKey(@StringRes resourceId: Int): String = resources.getString(resourceId)
 
 /**
- *  Shares content via [ACTION_SEND] intent.
+ * Shares content via [ACTION_SEND] intent.
  *
- * @param text the data to be shared  [EXTRA_TEXT]
+ * @param text the data to be shared [EXTRA_TEXT]
  * @param subject of the intent [EXTRA_TEXT]
  * @return true it is able to share false otherwise.
  */
@@ -46,16 +40,18 @@ fun Context.share(
     subject: String = "",
 ): Boolean =
     try {
-        val intent = Intent(ACTION_SEND).apply {
-            type = "text/plain"
-            putExtra(EXTRA_SUBJECT, subject)
-            putExtra(EXTRA_TEXT, text)
-            flags = FLAG_ACTIVITY_NEW_TASK
-        }
+        val intent =
+            Intent(ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(EXTRA_SUBJECT, subject)
+                putExtra(EXTRA_TEXT, text)
+                flags = FLAG_ACTIVITY_NEW_TASK
+            }
 
-        val shareIntent = Intent.createChooser(intent, getString(R.string.menu_share_with)).apply {
-            flags = FLAG_ACTIVITY_NEW_TASK
-        }
+        val shareIntent =
+            Intent.createChooser(intent, getString(R.string.menu_share_with)).apply {
+                flags = FLAG_ACTIVITY_NEW_TASK
+            }
 
         startActivity(shareIntent)
         true

--- a/app/src/main/java/org/mozilla/reference/browser/ext/Fragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/ext/Fragment.kt
@@ -6,8 +6,6 @@ package org.mozilla.reference.browser.ext
 
 import org.mozilla.reference.browser.Components
 
-/**
- * Get the requireComponents of this application.
- */
+/** Get the requireComponents of this application. */
 val androidx.fragment.app.Fragment.requireComponents: Components
     get() = requireContext().components

--- a/app/src/main/java/org/mozilla/reference/browser/ext/Long.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/ext/Long.kt
@@ -6,24 +6,24 @@ package org.mozilla.reference.browser.ext
 
 import android.content.Context
 import android.text.format.DateUtils
-import org.mozilla.reference.browser.R
 import java.util.Calendar
 import java.util.Date
 import java.util.GregorianCalendar
+import org.mozilla.reference.browser.R
 
 /**
- * Returns a human-readable string describing how long ago a given timestamp occurred,
- * relative to this `Long` value (typically representing the current system time in millis).
- *
+ * Returns a human-readable string describing how long ago a given timestamp occurred, relative to this `Long` value
+ * (typically representing the current system time in millis).
  */
 fun Long.timeSince(
     context: Context,
     time: Long,
 ): String {
-    val earliestValidSyncDate: Date = GregorianCalendar.getInstance().run {
-        set(2000, Calendar.JANUARY, 1, 0, 0, 0)
-        getTime()
-    }
+    val earliestValidSyncDate: Date =
+        GregorianCalendar.getInstance().run {
+            set(2000, Calendar.JANUARY, 1, 0, 0, 0)
+            getTime()
+        }
 
     if (Date(time).before(earliestValidSyncDate)) {
         return context.getString(R.string.preferences_sync_never_synced_summary)

--- a/app/src/main/java/org/mozilla/reference/browser/ext/String.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/ext/String.kt
@@ -4,9 +4,7 @@
 
 package org.mozilla.reference.browser.ext
 
-/**
- * Replaces the keys with the values with the map provided.
- */
+/** Replaces the keys with the values with the map provided. */
 fun String.replace(pairs: Map<String, String>): String {
     var result = this
     pairs.forEach { (l, r) -> result = result.replace(l, r) }

--- a/app/src/main/java/org/mozilla/reference/browser/media/MediaSessionService.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/media/MediaSessionService.kt
@@ -10,9 +10,7 @@ import mozilla.components.feature.media.service.AbstractMediaSessionService
 import mozilla.components.support.base.android.NotificationsDelegate
 import org.mozilla.reference.browser.ext.components
 
-/**
- * [AbstractMediaSessionService] implementation for injecting [BrowserStore] singleton.
- */
+/** [AbstractMediaSessionService] implementation for injecting [BrowserStore] singleton. */
 class MediaSessionService : AbstractMediaSessionService() {
     override val store: BrowserStore by lazy { components.core.store }
     override val crashReporter: CrashReporting by lazy { components.analytics.crashReporter }

--- a/app/src/main/java/org/mozilla/reference/browser/pip/PictureInPictureIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/pip/PictureInPictureIntegration.kt
@@ -27,12 +27,13 @@ class PictureInPictureIntegration(
     private var whiteListed = false
 
     override fun start() {
-        scope = store.flowScoped(dispatcher = Dispatchers.Main) { flow ->
-            flow
-                .mapNotNull { state -> state.findTabOrCustomTabOrSelectedTab(customTabId) }
-                .distinctUntilChangedBy { it.content.url }
-                .collect { whiteListed = isWhitelisted(it.content.url) }
-        }
+        scope =
+            store.flowScoped(dispatcher = Dispatchers.Main) { flow ->
+                flow
+                    .mapNotNull { state -> state.findTabOrCustomTabOrSelectedTab(customTabId) }
+                    .distinctUntilChangedBy { it.content.url }
+                    .collect { whiteListed = isWhitelisted(it.content.url) }
+            }
     }
 
     override fun stop() {
@@ -41,10 +42,10 @@ class PictureInPictureIntegration(
 
     fun onHomePressed() =
         if (whiteListed) {
-        pictureFeature.enterPipModeCompat()
-    } else {
-        pictureFeature.onHomePressed()
-    }
+            pictureFeature.enterPipModeCompat()
+        } else {
+            pictureFeature.onHomePressed()
+        }
 
     private fun isWhitelisted(url: String): Boolean {
         val exists = whiteList.firstOrNull { url.contains(it) }

--- a/app/src/main/java/org/mozilla/reference/browser/push/FirebasePush.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/push/FirebasePush.kt
@@ -7,5 +7,4 @@ package org.mozilla.reference.browser.push
 import android.annotation.SuppressLint
 import mozilla.components.lib.push.firebase.AbstractFirebasePushService
 
-@SuppressLint("MissingFirebaseInstanceTokenRefresh")
-class FirebasePush : AbstractFirebasePushService()
+@SuppressLint("MissingFirebaseInstanceTokenRefresh") class FirebasePush : AbstractFirebasePushService()

--- a/app/src/main/java/org/mozilla/reference/browser/push/PushFxaIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/push/PushFxaIntegration.kt
@@ -23,35 +23,31 @@ import org.mozilla.reference.browser.components.Push
 /**
  * A lazy initializer for FxaAccountManager if it isn't already initialized.
  *
- * Implementation notes: For push notifications, we need to initialize the service on
- * Application#onCreate as soon as possible in order to receive messages. These are then decrypted
- * and the observers of the push feature are notified.
+ * Implementation notes: For push notifications, we need to initialize the service on Application#onCreate as soon as
+ * possible in order to receive messages. These are then decrypted and the observers of the push feature are notified.
  *
- * One of our observers is [FxaAccountManager] that needs to know about messages like Send Tab,
- * new account logins, etc. This however comes at the cost of having the account manager
- * initialized and observing the push feature when it initializes (which once again happens on
- * application create) - the total cost of startup time now is additive for the both of them.
+ * One of our observers is [FxaAccountManager] that needs to know about messages like Send Tab, new account logins, etc.
+ * This however comes at the cost of having the account manager initialized and observing the push feature when it
+ * initializes (which once again happens on application create) - the total cost of startup time now is additive for the
+ * both of them.
  *
- * What this integration class aims to do, is to observe the push feature immediately in order to act
- * as a (temporary) delegate, and when we see a push message from FxA, only then we should
- * initialize and deliver the message.
+ * What this integration class aims to do, is to observe the push feature immediately in order to act as a (temporary)
+ * delegate, and when we see a push message from FxA, only then we should initialize and deliver the message.
  *
- * Once FxaAccountManager is initialized, we no longer need this integration as there already are
- * existing features to support these feature requirements, so we safely unregister ourselves.
- * See: [FxaPushSupportFeature] and [SendTabFeature].
+ * Once FxaAccountManager is initialized, we no longer need this integration as there already are existing features to
+ * support these feature requirements, so we safely unregister ourselves. See: [FxaPushSupportFeature] and
+ * [SendTabFeature].
  *
- * A solution that we considered was to pass in [BackgroundServices] to the [Push] class
- * and lazily invoke the account manager - that lead to a cyclic dependency of initialization since
- * [BackgroundServices] also depends on [Push] directly for observing messages via the account-based
- * features.
+ * A solution that we considered was to pass in [BackgroundServices] to the [Push] class and lazily invoke the account
+ * manager - that lead to a cyclic dependency of initialization since [BackgroundServices] also depends on [Push]
+ * directly for observing messages via the account-based features.
  *
- * Another solution was to create a message buffer to queue up the messages until the account could
- * consume them - this added the complexity of maintaining a buffer, the possibility of flooding the
- * buffer, and delaying the delivery of high importance messages like Send Tab which are required to
- * be processed immediately.
+ * Another solution was to create a message buffer to queue up the messages until the account could consume them - this
+ * added the complexity of maintaining a buffer, the possibility of flooding the buffer, and delaying the delivery of
+ * high importance messages like Send Tab which are required to be processed immediately.
  *
- * Our final solution ended up being more concise that the above options that met all our required
- * assurances, and most importantly, maintainable.
+ * Our final solution ended up being more concise that the above options that met all our required assurances, and most
+ * importantly, maintainable.
  */
 class PushFxaIntegration(
     private val pushFeature: AutoPushFeature,
@@ -73,10 +69,7 @@ class PushFxaIntegration(
     }
 }
 
-/**
- * Observes push messages from [AutoPushFeature], then initializes [FxaAccountManager] if it isn't
- * already.
- */
+/** Observes push messages from [AutoPushFeature], then initializes [FxaAccountManager] if it isn't already. */
 internal class OneTimePushMessageObserver(
     private val lazyAccountManager: Lazy<FxaAccountManager>,
     private val pushFeature: AutoPushFeature,
@@ -110,8 +103,8 @@ internal class OneTimePushMessageObserver(
 }
 
 /**
- * Waits for the [FxaAccountManager] to authenticate itself in order to deliver the [message], then
- * unregisters itself once complete.
+ * Waits for the [FxaAccountManager] to authenticate itself in order to deliver the [message], then unregisters itself
+ * once complete.
  */
 internal class OneTimeMessageDeliveryObserver(
     private val lazyAccount: Lazy<FxaAccountManager>,

--- a/app/src/main/java/org/mozilla/reference/browser/push/WebPushEngineIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/push/WebPushEngineIntegration.kt
@@ -50,9 +50,7 @@ class WebPushEngineIntegration(
     }
 }
 
-internal class WebPushEngineDelegate(
-    private val pushFeature: AutoPushFeature,
-) : WebPushDelegate {
+internal class WebPushEngineDelegate(private val pushFeature: AutoPushFeature) : WebPushDelegate {
     private val logger = Logger("WebPushEngineDelegate")
 
     override fun onGetSubscription(
@@ -105,17 +103,17 @@ internal class WebPushEngineDelegate(
 
 internal fun AutoPushSubscription.toEnginePushSubscription() =
     WebPushSubscription(
-    scope = this.scope,
-    publicKey = this.publicKey.toDecodedByteArray(),
-    endpoint = this.endpoint,
-    authSecret = this.authKey.toDecodedByteArray(),
-    // We don't send the `serverKey` because the code path from that will query
-    // the push database for this key, which leads to an exception thrown.
-    // Our workaround for now is to not put the server key in to begin with (which
-    // will probably break a lot of sites).
-    // See: https://github.com/mozilla/application-services/issues/2698
-    appServerKey = null,
-)
+        scope = this.scope,
+        publicKey = this.publicKey.toDecodedByteArray(),
+        endpoint = this.endpoint,
+        authSecret = this.authKey.toDecodedByteArray(),
+        // We don't send the `serverKey` because the code path from that will query
+        // the push database for this key, which leads to an exception thrown.
+        // Our workaround for now is to not put the server key in to begin with (which
+        // will probably break a lot of sites).
+        // See: https://github.com/mozilla/application-services/issues/2698
+        appServerKey = null,
+    )
 
 private fun String.toDecodedByteArray() =
     Base64.decode(this.toByteArray(), Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)

--- a/app/src/main/java/org/mozilla/reference/browser/search/AwesomeBarWrapper.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/search/AwesomeBarWrapper.kt
@@ -19,18 +19,16 @@ import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.reference.browser.ext.components
 
 /**
- * This wrapper wraps the `AwesomeBar()` composable and exposes it as a `View` and `concept-awesomebar`
- * implementation to be integrated as a `View` until more parts of the app have been refactored to
- * use Jetpack Compose.
+ * This wrapper wraps the `AwesomeBar()` composable and exposes it as a `View` and `concept-awesomebar` implementation
+ * to be integrated as a `View` until more parts of the app have been refactored to use Jetpack Compose.
  */
 class AwesomeBarWrapper
-    @JvmOverloads
-    constructor(
+@JvmOverloads
+constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,
-) : AbstractComposeView(context, attrs, defStyleAttr),
-    AwesomeBar {
+) : AbstractComposeView(context, attrs, defStyleAttr), AwesomeBar {
     private val providers = mutableStateOf(emptyList<AwesomeBar.SuggestionProvider>())
     private val text = mutableStateOf("")
     private val hiddenSuggestions = mutableStateOf(emptySet<GroupedSuggestion>())
@@ -50,12 +48,13 @@ class AwesomeBarWrapper
             providers = providers.value,
             hiddenSuggestions = hiddenSuggestions.value,
             orientation = AwesomeBarOrientation.BOTTOM,
-            colors = AwesomeBarDefaults.colors(
-                background = Color(0xff222222),
-                title = Color(0xffffffff),
-                description = Color(0xffdddddd),
-                autocompleteIcon = Color(0xffdddddd),
-            ),
+            colors =
+                AwesomeBarDefaults.colors(
+                    background = Color(0xff222222),
+                    title = Color(0xffffffff),
+                    description = Color(0xffdddddd),
+                    autocompleteIcon = Color(0xffdddddd),
+                ),
             onSuggestionClicked = { suggestion ->
                 suggestion.onSuggestionClicked?.invoke()
                 onStopListener?.invoke()

--- a/app/src/main/java/org/mozilla/reference/browser/settings/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/AboutFragment.kt
@@ -40,30 +40,37 @@ class AboutFragment : Fragment() {
         val appName = requireContext().resources.getString(R.string.app_name)
         (activity as AppCompatActivity).title = getString(R.string.preferences_about_page)
 
-        val aboutText = try {
-            val packageInfo = requireContext().packageManager.getPackageInfo(requireContext().packageName, 0)
-            val geckoVersion = PackageInfoCompat.getLongVersionCode(packageInfo).toString() + " GV: " +
-                MOZ_APP_VERSION + "-" + MOZ_APP_BUILDID
-            String.format(
-                "%s (Build #%s)\n",
-                packageInfo.versionName,
-                geckoVersion,
-            )
-        } catch (e: PackageManager.NameNotFoundException) {
-            ""
-        }
+        val aboutText =
+            try {
+                val packageInfo = requireContext().packageManager.getPackageInfo(requireContext().packageName, 0)
+                val geckoVersion =
+                    PackageInfoCompat.getLongVersionCode(packageInfo).toString() +
+                        " GV: " +
+                        MOZ_APP_VERSION +
+                        "-" +
+                        MOZ_APP_BUILDID
+                String.format(
+                    "%s (Build #%s)\n",
+                    packageInfo.versionName,
+                    geckoVersion,
+                )
+            } catch (e: PackageManager.NameNotFoundException) {
+                ""
+            }
 
-        val versionInfo = String.format(
-            "%s \uD83D\uDCE6: %s, %s\n\uD83D\uDEA2: %s",
-            aboutText,
-            Build.VERSION,
-            Build.GIT_HASH,
-            Build.APPLICATION_SERVICES_VERSION,
-        )
-        val content = HtmlCompat.fromHtml(
-            resources.getString(R.string.about_content, appName),
-            FROM_HTML_SEPARATOR_LINE_BREAK_LIST_ITEM,
-        )
+        val versionInfo =
+            String.format(
+                "%s \uD83D\uDCE6: %s, %s\n\uD83D\uDEA2: %s",
+                aboutText,
+                Build.VERSION,
+                Build.GIT_HASH,
+                Build.APPLICATION_SERVICES_VERSION,
+            )
+        val content =
+            HtmlCompat.fromHtml(
+                resources.getString(R.string.about_content, appName),
+                FROM_HTML_SEPARATOR_LINE_BREAK_LIST_ITEM,
+            )
 
         val aboutView = view.findViewById<TextView>(R.id.about_content)
         aboutView.text = content

--- a/app/src/main/java/org/mozilla/reference/browser/settings/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/AccountSettingsFragment.kt
@@ -37,37 +37,38 @@ import org.mozilla.reference.browser.ext.requireComponents
 import org.mozilla.reference.browser.sync.BrowserFxAEntryPoint
 
 class AccountSettingsFragment : PreferenceFragmentCompat() {
-    private val syncStatusObserver = object : SyncStatusObserver {
-        override fun onStarted() {
-            CoroutineScope(Dispatchers.Main).launch {
-                val pref = findPreference<Preference>(requireContext().getPreferenceKey(pref_key_sync_now))
+    private val syncStatusObserver =
+        object : SyncStatusObserver {
+            override fun onStarted() {
+                CoroutineScope(Dispatchers.Main).launch {
+                    val pref = findPreference<Preference>(requireContext().getPreferenceKey(pref_key_sync_now))
 
-                pref?.title = getString(R.string.syncing)
-                pref?.isEnabled = false
+                    pref?.title = getString(R.string.syncing)
+                    pref?.isEnabled = false
+                }
+            }
+
+            // Sync stopped successfully.
+            override fun onIdle() {
+                CoroutineScope(Dispatchers.Main).launch {
+                    val pref = findPreference<Preference>(requireContext().getPreferenceKey(pref_key_sync_now))
+                    pref?.title = getString(R.string.sync_now)
+                    pref?.isEnabled = true
+                    updateLastSyncedTimePref(context!!, pref, failed = false)
+                    updateSyncEngineStates()
+                }
+            }
+
+            // Sync stopped after encountering a problem.
+            override fun onError(error: Exception?) {
+                CoroutineScope(Dispatchers.Main).launch {
+                    val pref = findPreference<Preference>(requireContext().getPreferenceKey(pref_key_sync_now))
+                    pref?.title = getString(R.string.sync_now)
+                    pref?.isEnabled = true
+                    updateLastSyncedTimePref(context!!, pref, failed = true)
+                }
             }
         }
-
-        // Sync stopped successfully.
-        override fun onIdle() {
-            CoroutineScope(Dispatchers.Main).launch {
-                val pref = findPreference<Preference>(requireContext().getPreferenceKey(pref_key_sync_now))
-                pref?.title = getString(R.string.sync_now)
-                pref?.isEnabled = true
-                updateLastSyncedTimePref(context!!, pref, failed = false)
-                updateSyncEngineStates()
-            }
-        }
-
-        // Sync stopped after encountering a problem.
-        override fun onError(error: Exception?) {
-            CoroutineScope(Dispatchers.Main).launch {
-                val pref = findPreference<Preference>(requireContext().getPreferenceKey(pref_key_sync_now))
-                pref?.title = getString(R.string.sync_now)
-                pref?.isEnabled = true
-                updateLastSyncedTimePref(context!!, pref, failed = true)
-            }
-        }
-    }
 
     override fun onCreatePreferences(
         savedInstanceState: Bundle?,
@@ -121,81 +122,74 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
     ) {
         val lastSyncTime = getLastSynced(context)
 
-        pref?.summary = if (!failed && lastSyncTime == 0L) {
-            // Never tried to sync.
-            getString(R.string.preferences_sync_never_synced_summary)
-        } else if (failed && lastSyncTime == 0L) {
-            // Failed to sync, never succeeded before.
-            getString(R.string.preferences_sync_failed_never_synced_summary)
-        } else if (!failed && lastSyncTime != 0L) {
-            // Successfully synced.
-            getString(
-                R.string.preferences_sync_last_synced_summary,
-                DateUtils.getRelativeTimeSpanString(lastSyncTime),
-            )
-        } else {
-            // Failed to sync, succeeded before.
-            getString(
-                R.string.preferences_sync_failed_summary,
-                DateUtils.getRelativeTimeSpanString(lastSyncTime),
-            )
-        }
+        pref?.summary =
+            if (!failed && lastSyncTime == 0L) {
+                // Never tried to sync.
+                getString(R.string.preferences_sync_never_synced_summary)
+            } else if (failed && lastSyncTime == 0L) {
+                // Failed to sync, never succeeded before.
+                getString(R.string.preferences_sync_failed_never_synced_summary)
+            } else if (!failed && lastSyncTime != 0L) {
+                // Successfully synced.
+                getString(
+                    R.string.preferences_sync_last_synced_summary,
+                    DateUtils.getRelativeTimeSpanString(lastSyncTime),
+                )
+            } else {
+                // Failed to sync, succeeded before.
+                getString(
+                    R.string.preferences_sync_failed_summary,
+                    DateUtils.getRelativeTimeSpanString(lastSyncTime),
+                )
+            }
     }
 
-    private fun getClickListenerForSignOut(): OnPreferenceClickListener =
-        OnPreferenceClickListener {
-            CoroutineScope(Dispatchers.Main).launch {
-                requireComponents.backgroundServices.accountManager.logout()
-                activity?.onBackPressedDispatcher?.onBackPressed()
-            }
-            true
+    private fun getClickListenerForSignOut(): OnPreferenceClickListener = OnPreferenceClickListener {
+        CoroutineScope(Dispatchers.Main).launch {
+            requireComponents.backgroundServices.accountManager.logout()
+            activity?.onBackPressedDispatcher?.onBackPressed()
         }
+        true
+    }
 
-    private fun getClickListenerForSyncNow(): OnPreferenceClickListener =
-        OnPreferenceClickListener {
-            CoroutineScope(Dispatchers.Main).launch {
-                // Trigger a sync & update devices.
-                requireComponents.backgroundServices.accountManager.syncNow(SyncReason.User)
-                // Poll for device events.
-                requireComponents.backgroundServices.accountManager
-                    .authenticatedAccount()
-                    ?.deviceConstellation()
-                    ?.run {
-                        refreshDevices()
-                        pollForCommands()
-                    }
+    private fun getClickListenerForSyncNow(): OnPreferenceClickListener = OnPreferenceClickListener {
+        CoroutineScope(Dispatchers.Main).launch {
+            // Trigger a sync & update devices.
+            requireComponents.backgroundServices.accountManager.syncNow(SyncReason.User)
+            // Poll for device events.
+            requireComponents.backgroundServices.accountManager.authenticatedAccount()?.deviceConstellation()?.run {
+                refreshDevices()
+                pollForCommands()
             }
-            true
         }
+        true
+    }
 
-    private fun getClickListenerForManageAccount(): OnPreferenceClickListener =
-        OnPreferenceClickListener {
-            viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
-                context?.let {
-                    val account =
-                        requireComponents.backgroundServices.accountManager.authenticatedAccount()
-                    val url = account?.getManageAccountURL(BrowserFxAEntryPoint.AccountSettings)
-                    if (url != null) {
-                        val intent = createCustomTabIntent(it, url)
-                        startActivity(intent)
-                    }
+    private fun getClickListenerForManageAccount(): OnPreferenceClickListener = OnPreferenceClickListener {
+        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+            context?.let {
+                val account = requireComponents.backgroundServices.accountManager.authenticatedAccount()
+                val url = account?.getManageAccountURL(BrowserFxAEntryPoint.AccountSettings)
+                if (url != null) {
+                    val intent = createCustomTabIntent(it, url)
+                    startActivity(intent)
                 }
             }
-            true
         }
+        true
+    }
 
     private fun createCustomTabIntent(
         context: Context,
         url: String,
     ): Intent =
-        CustomTabsIntent
-        .Builder()
-        .setInstantAppsEnabled(false)
-        .build()
-        .intent
-        .setData(url.toUri())
-        .setClassName(context, IntentReceiverActivity::class.java.name)
-        .setPackage(context.packageName)
+        CustomTabsIntent.Builder()
+            .setInstantAppsEnabled(false)
+            .build()
+            .intent
+            .setData(url.toUri())
+            .setClassName(context, IntentReceiverActivity::class.java.name)
+            .setPackage(context.packageName)
 
     private fun updateSyncEngineState(
         engine: SyncEngine,
@@ -219,9 +213,9 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
 
     private fun SyncEngine.prefId(): Int =
         when (this) {
-        SyncEngine.History -> pref_key_sync_history
-        SyncEngine.Passwords -> pref_key_sync_passwords
-        SyncEngine.Tabs -> pref_key_sync_tabs
-        else -> throw IllegalStateException("Accessing unsupported sync engines")
-    }
+            SyncEngine.History -> pref_key_sync_history
+            SyncEngine.Passwords -> pref_key_sync_passwords
+            SyncEngine.Tabs -> pref_key_sync_tabs
+            else -> throw IllegalStateException("Accessing unsupported sync engines")
+        }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/settings/PairSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/PairSettingsFragment.kt
@@ -22,9 +22,7 @@ import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.requireComponents
 import org.mozilla.reference.browser.sync.BrowserFxAEntryPoint
 
-class PairSettingsFragment :
-    Fragment(),
-    UserInteractionHandler {
+class PairSettingsFragment : Fragment(), UserInteractionHandler {
     private val qrFeature = ViewBoundFeatureWrapper<QrFeature>()
     private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
 
@@ -50,22 +48,23 @@ class PairSettingsFragment :
     ) {
         super.onViewCreated(view, savedInstanceState)
         qrFeature.set(
-            feature = QrFeature(
-                requireContext(),
-                fragmentManager = parentFragmentManager,
-                onNeedToRequestPermissions = { permissions ->
-                    requestPermissionLauncher.launch(permissions[0])
-                },
-                onScanResult = { pairingUrl ->
-                    requireComponents.services.accountsAuthFeature.beginPairingAuthentication(
-                        requireContext(),
-                        pairingUrl,
-                        BrowserFxAEntryPoint.HomeMenu,
-                        setOf(SCOPE_SYNC, SCOPE_PROFILE, SCOPE_SESSION),
-                    )
-                    activity?.finish()
-                },
-            ),
+            feature =
+                QrFeature(
+                    requireContext(),
+                    fragmentManager = parentFragmentManager,
+                    onNeedToRequestPermissions = { permissions ->
+                        requestPermissionLauncher.launch(permissions[0])
+                    },
+                    onScanResult = { pairingUrl ->
+                        requireComponents.services.accountsAuthFeature.beginPairingAuthentication(
+                            requireContext(),
+                            pairingUrl,
+                            BrowserFxAEntryPoint.HomeMenu,
+                            setOf(SCOPE_SYNC, SCOPE_PROFILE, SCOPE_SESSION),
+                        )
+                        activity?.finish()
+                    },
+                ),
             owner = this,
             view = view,
         )

--- a/app/src/main/java/org/mozilla/reference/browser/settings/PrivacySettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/PrivacySettingsFragment.kt
@@ -41,25 +41,21 @@ class PrivacySettingsFragment : PreferenceFragmentCompat() {
 
         globalPrivacyControl?.onPreferenceChangeListener = getChangeListenerForGPC { enabled ->
             requireComponents.core.engine.settings.globalPrivacyControlEnabled = enabled
-            requireComponents.useCases.sessionUseCases.reload
-                .invoke()
+            requireComponents.useCases.sessionUseCases.reload.invoke()
         }
     }
 
-    private fun getChangeListenerForTelemetry(): OnPreferenceChangeListener =
-        OnPreferenceChangeListener { _, _ ->
-            true
-        }
+    private fun getChangeListenerForTelemetry(): OnPreferenceChangeListener = OnPreferenceChangeListener { _, _ ->
+        true
+    }
 
     private fun getChangeListenerForTrackingProtection(
-        createTrackingProtectionPolicy: (Boolean) -> TrackingProtectionPolicy,
-    ): OnPreferenceChangeListener =
-        OnPreferenceChangeListener { _, value ->
-            val policy = createTrackingProtectionPolicy(value as Boolean)
-            requireComponents.useCases.settingsUseCases.updateTrackingProtection
-                .invoke(policy)
-            true
-        }
+        createTrackingProtectionPolicy: (Boolean) -> TrackingProtectionPolicy
+    ): OnPreferenceChangeListener = OnPreferenceChangeListener { _, value ->
+        val policy = createTrackingProtectionPolicy(value as Boolean)
+        requireComponents.useCases.settingsUseCases.updateTrackingProtection.invoke(policy)
+        true
+    }
 
     private fun getChangeListenerForGPC(action: (Boolean) -> Unit): OnPreferenceChangeListener =
         OnPreferenceChangeListener { _, enabled ->

--- a/app/src/main/java/org/mozilla/reference/browser/settings/Settings.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/Settings.kt
@@ -11,22 +11,25 @@ import org.mozilla.reference.browser.R
 
 object Settings {
     fun isTelemetryEnabled(context: Context): Boolean =
-        PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
-            context.getString(R.string.pref_key_telemetry),
-            true,
-        )
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .getBoolean(
+                context.getString(R.string.pref_key_telemetry),
+                true,
+            )
 
     fun getOverrideAmoUser(context: Context): String =
-        PreferenceManager.getDefaultSharedPreferences(context).getString(
-            context.getString(R.string.pref_key_override_amo_user),
-            "",
-        ) ?: ""
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .getString(
+                context.getString(R.string.pref_key_override_amo_user),
+                "",
+            ) ?: ""
 
     fun getOverrideAmoCollection(context: Context): String =
-        PreferenceManager.getDefaultSharedPreferences(context).getString(
-            context.getString(R.string.pref_key_override_amo_collection),
-            "",
-        ) ?: ""
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .getString(
+                context.getString(R.string.pref_key_override_amo_collection),
+                "",
+            ) ?: ""
 
     fun setOverrideAmoUser(
         context: Context,

--- a/app/src/main/java/org/mozilla/reference/browser/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/SettingsActivity.kt
@@ -15,9 +15,7 @@ import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.ktx.android.view.setupPersistentInsets
 import org.mozilla.reference.browser.R
 
-class SettingsActivity :
-    AppCompatActivity(),
-    SettingsFragment.ActionBarUpdater {
+class SettingsActivity : AppCompatActivity(), SettingsFragment.ActionBarUpdater {
     override fun onCreate(savedInstanceState: Bundle?) {
         setContentView(R.layout.activity_main)
         enableEdgeToEdge(SystemBarStyle.dark(Color.TRANSPARENT))
@@ -27,16 +25,17 @@ class SettingsActivity :
         onBackPressedDispatcher.addCallback(
             this,
             object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                val handled = supportFragmentManager.fragments.any {
-                    it is UserInteractionHandler && it.onBackPressed()
+                override fun handleOnBackPressed() {
+                    val handled =
+                        supportFragmentManager.fragments.any {
+                            it is UserInteractionHandler && it.onBackPressed()
+                        }
+                    if (!handled) {
+                        remove()
+                        onBackPressedDispatcher.onBackPressed()
+                    }
                 }
-                if (!handled) {
-                    remove()
-                    onBackPressedDispatcher.onBackPressed()
-                }
-            }
-        },
+            },
         )
 
         if (savedInstanceState == null) {
@@ -49,15 +48,15 @@ class SettingsActivity :
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean =
         when (item.itemId) {
-        android.R.id.home -> {
-            onBackPressedDispatcher.onBackPressed()
-            true
-        }
+            android.R.id.home -> {
+                onBackPressedDispatcher.onBackPressed()
+                true
+            }
 
-        else -> {
-            super.onOptionsItemSelected(item)
+            else -> {
+                super.onOptionsItemSelected(item)
+            }
         }
-    }
 
     override fun updateTitle(titleResId: Int) {
         setTitle(titleResId)

--- a/app/src/main/java/org/mozilla/reference/browser/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/settings/SettingsFragment.kt
@@ -19,6 +19,7 @@ import androidx.preference.Preference.OnPreferenceChangeListener
 import androidx.preference.Preference.OnPreferenceClickListener
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
+import kotlin.system.exitProcess
 import mozilla.components.service.fxa.manager.SCOPE_PROFILE
 import mozilla.components.service.fxa.manager.SCOPE_SYNC
 import mozilla.components.support.ktx.android.view.showKeyboard
@@ -35,7 +36,6 @@ import org.mozilla.reference.browser.autofill.AutofillPreference
 import org.mozilla.reference.browser.ext.getPreferenceKey
 import org.mozilla.reference.browser.ext.requireComponents
 import org.mozilla.reference.browser.sync.BrowserFxAEntryPoint
-import kotlin.system.exitProcess
 
 private typealias RBSettings = org.mozilla.reference.browser.settings.Settings
 
@@ -109,64 +109,57 @@ class SettingsFragment : PreferenceFragmentCompat() {
         preferenceCustomAddons?.onPreferenceClickListener = getClickListenerForCustomAddons()
     }
 
-    private fun getClickListenerForMakeDefaultBrowser(): OnPreferenceClickListener =
-        OnPreferenceClickListener {
-            val intent = Intent(
-                Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS,
-            )
-            startActivity(intent)
-            true
-        }
+    private fun getClickListenerForMakeDefaultBrowser(): OnPreferenceClickListener = OnPreferenceClickListener {
+        val intent = Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS)
+        startActivity(intent)
+        true
+    }
 
-    private fun getClickListenerForSignIn(): OnPreferenceClickListener =
-        OnPreferenceClickListener {
-            requireComponents.services.accountsAuthFeature.beginAuthentication(
-                requireContext(),
-                BrowserFxAEntryPoint.HomeMenu,
-                setOf(SCOPE_PROFILE, SCOPE_SYNC),
-            )
-            activity?.finish()
-            true
-        }
+    private fun getClickListenerForSignIn(): OnPreferenceClickListener = OnPreferenceClickListener {
+        requireComponents.services.accountsAuthFeature.beginAuthentication(
+            requireContext(),
+            BrowserFxAEntryPoint.HomeMenu,
+            setOf(SCOPE_PROFILE, SCOPE_SYNC),
+        )
+        activity?.finish()
+        true
+    }
 
-    private fun getClickListenerForPairingSignIn(): OnPreferenceClickListener =
-        OnPreferenceClickListener {
-            parentFragmentManager
-                .beginTransaction()
-                .replace(R.id.container, PairSettingsFragment())
-                .addToBackStack(null)
-                .commit()
-            getActionBarUpdater().apply {
-                updateTitle(R.string.pair_preferences)
-            }
-            true
+    private fun getClickListenerForPairingSignIn(): OnPreferenceClickListener = OnPreferenceClickListener {
+        parentFragmentManager
+            .beginTransaction()
+            .replace(R.id.container, PairSettingsFragment())
+            .addToBackStack(null)
+            .commit()
+        getActionBarUpdater().apply {
+            updateTitle(R.string.pair_preferences)
         }
+        true
+    }
 
-    private fun getClickListenerForFirefoxAccount(): OnPreferenceClickListener =
-        OnPreferenceClickListener {
-            parentFragmentManager
-                .beginTransaction()
-                .replace(R.id.container, AccountSettingsFragment())
-                .addToBackStack(null)
-                .commit()
-            getActionBarUpdater().apply {
-                updateTitle(R.string.account_settings)
-            }
-            true
+    private fun getClickListenerForFirefoxAccount(): OnPreferenceClickListener = OnPreferenceClickListener {
+        parentFragmentManager
+            .beginTransaction()
+            .replace(R.id.container, AccountSettingsFragment())
+            .addToBackStack(null)
+            .commit()
+        getActionBarUpdater().apply {
+            updateTitle(R.string.account_settings)
         }
+        true
+    }
 
-    private fun getClickListenerForPrivacy(): OnPreferenceClickListener =
-        OnPreferenceClickListener {
-            parentFragmentManager
-                .beginTransaction()
-                .replace(R.id.container, PrivacySettingsFragment())
-                .addToBackStack(null)
-                .commit()
-            getActionBarUpdater().apply {
-                updateTitle(R.string.privacy_settings)
-            }
-            true
+    private fun getClickListenerForPrivacy(): OnPreferenceClickListener = OnPreferenceClickListener {
+        parentFragmentManager
+            .beginTransaction()
+            .replace(R.id.container, PrivacySettingsFragment())
+            .addToBackStack(null)
+            .commit()
+        getActionBarUpdater().apply {
+            updateTitle(R.string.privacy_settings)
         }
+        true
+    }
 
     private fun getChangeListenerForRemoteDebugging(): OnPreferenceChangeListener =
         OnPreferenceChangeListener { _, newValue ->
@@ -174,28 +167,21 @@ class SettingsFragment : PreferenceFragmentCompat() {
             true
         }
 
-    private fun getAboutPageListener(): OnPreferenceClickListener =
-        OnPreferenceClickListener {
-            parentFragmentManager
-                .beginTransaction()
-                .replace(R.id.container, AboutFragment())
-                .addToBackStack(null)
-                .commit()
-            true
-        }
+    private fun getAboutPageListener(): OnPreferenceClickListener = OnPreferenceClickListener {
+        parentFragmentManager.beginTransaction().replace(R.id.container, AboutFragment()).addToBackStack(null).commit()
+        true
+    }
 
     private fun getActionBarUpdater() = activity as ActionBarUpdater
 
-    private fun getClickListenerForCustomAddons(): OnPreferenceClickListener =
-        OnPreferenceClickListener {
-            val context = requireContext()
-            val dialogView = View.inflate(context, R.layout.amo_collection_override_dialog, null)
-            val userView = dialogView.findViewById<EditText>(R.id.custom_amo_user)
-            val collectionView = dialogView.findViewById<EditText>(R.id.custom_amo_collection)
+    private fun getClickListenerForCustomAddons(): OnPreferenceClickListener = OnPreferenceClickListener {
+        val context = requireContext()
+        val dialogView = View.inflate(context, R.layout.amo_collection_override_dialog, null)
+        val userView = dialogView.findViewById<EditText>(R.id.custom_amo_user)
+        val collectionView = dialogView.findViewById<EditText>(R.id.custom_amo_collection)
 
-            AlertDialog
-                .Builder(context)
-                .apply {
+        AlertDialog.Builder(context)
+            .apply {
                 setTitle(context.getString(R.string.preferences_customize_amo_collection))
                 setView(dialogView)
                 setNegativeButton(R.string.customize_addon_collection_cancel) { dialog: DialogInterface, _ ->
@@ -206,19 +192,20 @@ class SettingsFragment : PreferenceFragmentCompat() {
                     RBSettings.setOverrideAmoUser(context, userView.text.toString())
                     RBSettings.setOverrideAmoCollection(context, collectionView.text.toString())
 
-                    Toast
-                        .makeText(
-                        context,
-                        getString(R.string.toast_customize_addon_collection_done),
-                        Toast.LENGTH_LONG,
-                    ).show()
+                    Toast.makeText(
+                            context,
+                            getString(R.string.toast_customize_addon_collection_done),
+                            Toast.LENGTH_LONG,
+                        )
+                        .show()
 
-                    Handler(Looper.getMainLooper()).postDelayed(
-                        {
-                            exitProcess(0)
-                        },
-                        AMO_COLLECTION_OVERRIDE_EXIT_DELAY,
-                    )
+                    Handler(Looper.getMainLooper())
+                        .postDelayed(
+                            {
+                                exitProcess(0)
+                            },
+                            AMO_COLLECTION_OVERRIDE_EXIT_DELAY,
+                        )
                 }
 
                 collectionView.setText(RBSettings.getOverrideAmoCollection(context))
@@ -226,9 +213,10 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 userView.requestFocus()
                 userView.showKeyboard()
                 create()
-            }.show()
-            true
-        }
+            }
+            .show()
+        true
+    }
 
     companion object {
         private const val AMO_COLLECTION_OVERRIDE_EXIT_DELAY = 3000L

--- a/app/src/main/java/org/mozilla/reference/browser/sync/BrowserFxAEntryPoint.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/sync/BrowserFxAEntryPoint.kt
@@ -6,19 +6,11 @@ package org.mozilla.reference.browser.sync
 
 import mozilla.components.concept.sync.FxAEntryPoint
 
-/**
- * Reference Browser implementation of [FxAEntryPoint].
- */
-enum class BrowserFxAEntryPoint(
-    override val entryName: String,
-) : FxAEntryPoint {
-    /**
-     * Authenticating from the home menu (the hamburger menu)
-     */
+/** Reference Browser implementation of [FxAEntryPoint]. */
+enum class BrowserFxAEntryPoint(override val entryName: String) : FxAEntryPoint {
+    /** Authenticating from the home menu (the hamburger menu) */
     HomeMenu("home-menu"),
 
-    /**
-     * Authenticating from the account settings
-     */
+    /** Authenticating from the account settings */
     AccountSettings("account-settings"),
 }

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/LastTabFeature.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/LastTabFeature.kt
@@ -13,28 +13,24 @@ import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 
-/**
- * A feature that removes the tab and selects the parent, if one exists.
- */
+/** A feature that removes the tab and selects the parent, if one exists. */
 class LastTabFeature(
     private val store: BrowserStore,
     private val tabId: String? = null,
     private val removeTabUseCase: TabsUseCases.RemoveTabUseCase,
     private val activity: Activity,
-) : LifecycleAwareFeature,
-    UserInteractionHandler {
-        override fun start() = Unit
+) : LifecycleAwareFeature, UserInteractionHandler {
+    override fun start() = Unit
 
     override fun stop() = Unit
 
     /**
-     * Removes the session if it was opened by an ACTION_VIEW intent
-     * or if it has a parent session and no more history.
+     * Removes the session if it was opened by an ACTION_VIEW intent or if it has a parent session and no more history.
      */
     override fun onBackPressed(): Boolean {
         val tab = store.state.findTabOrCustomTabOrSelectedTab(tabId) ?: return false
-        val isExternalOrCustomTab = tab.source is SessionState.Source.External ||
-            tab.source is SessionState.Source.Internal.CustomTab
+        val isExternalOrCustomTab =
+            tab.source is SessionState.Source.External || tab.source is SessionState.Source.Internal.CustomTab
 
         return if (isExternalOrCustomTab && !tab.restored) {
             activity.finish()

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/PrivatePage.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/PrivatePage.kt
@@ -9,18 +9,17 @@ import androidx.annotation.RawRes
 import org.mozilla.reference.browser.R
 
 object PrivatePage {
-    /**
-     * Load and generate a private browsing page for the given url and html/css resources
-     */
+    /** Load and generate a private browsing page for the given url and html/css resources */
     fun createPrivateBrowsingPage(
         context: Context,
         url: String,
         @RawRes htmlRes: Int = R.raw.private_mode,
         @RawRes cssRes: Int = R.raw.private_style,
     ): String {
-        val css = context.resources.openRawResource(cssRes).bufferedReader().use {
-            it.readText()
-        }
+        val css =
+            context.resources.openRawResource(cssRes).bufferedReader().use {
+                it.readText()
+            }
 
         return context.resources
             .openRawResource(htmlRes)

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/TabsPanel.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/TabsPanel.kt
@@ -20,27 +20,28 @@ import mozilla.components.ui.colors.R as colorsR
 import mozilla.components.ui.icons.R as iconsR
 
 class TabsPanel
-    @JvmOverloads
-    constructor(
+@JvmOverloads
+constructor(
     context: Context,
     attrs: AttributeSet? = null,
-) : TabLayout(context, attrs),
-    TabLayout.OnTabSelectedListener {
+) : TabLayout(context, attrs), TabLayout.OnTabSelectedListener {
     private var normalTab: Tab
     private var privateTab: Tab
     private var tabsFeature: TabsFeature? = null
     private var updateTabsToolbar: ((isPrivate: Boolean) -> Unit)? = null
 
     init {
-        normalTab = newTab().apply {
-            contentDescription = "Tabs"
-            icon = resources.getThemedDrawable(iconsR.drawable.mozac_ic_tab_24)
-        }
+        normalTab =
+            newTab().apply {
+                contentDescription = "Tabs"
+                icon = resources.getThemedDrawable(iconsR.drawable.mozac_ic_tab_24)
+            }
 
-        privateTab = newTab().apply {
-            contentDescription = "Private tabs"
-            icon = resources.getThemedDrawable(iconsR.drawable.mozac_ic_private_mode_24)
-        }
+        privateTab =
+            newTab().apply {
+                contentDescription = "Private tabs"
+                icon = resources.getThemedDrawable(iconsR.drawable.mozac_ic_private_mode_24)
+            }
 
         addOnTabSelectedListener(this)
 
@@ -80,13 +81,10 @@ class TabsPanel
         tab?.icon?.colorFilter = null
     }
 
-    private fun Resources.getThemedDrawable(
-        @DrawableRes resId: Int,
-    ) = ResourcesCompat.getDrawable(resources, resId, context.theme)
+    private fun Resources.getThemedDrawable(@DrawableRes resId: Int) =
+        ResourcesCompat.getDrawable(resources, resId, context.theme)
 
-    private fun Drawable.colorTint(
-        @ColorRes color: Int,
-    ) = apply {
+    private fun Drawable.colorTint(@ColorRes color: Int) = apply {
         mutate()
         colorFilter = createBlendModeColorFilterCompat(ContextCompat.getColor(context, color), SRC_IN)
     }

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/TabsToolbar.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/TabsToolbar.kt
@@ -7,13 +7,13 @@ package org.mozilla.reference.browser.tabs
 import android.content.Context
 import android.util.AttributeSet
 import mozilla.components.feature.tabs.tabstray.TabsFeature
+import mozilla.components.ui.icons.R as iconsR
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.ext.components
-import mozilla.components.ui.icons.R as iconsR
 
 class TabsToolbar
-    @JvmOverloads
-    constructor(
+@JvmOverloads
+constructor(
     context: Context,
     attrs: AttributeSet? = null,
 ) : androidx.appcompat.widget.Toolbar(context, attrs) {
@@ -63,11 +63,12 @@ class TabsToolbar
         isPrivateTray = isPrivate
 
         // Update the menu option text
-        menu.findItem(R.id.closeTab).title = if (isPrivate) {
-            context.getString(R.string.menu_action_close_tabs_private)
-        } else {
-            context.getString(R.string.menu_action_close_tabs)
-        }
+        menu.findItem(R.id.closeTab).title =
+            if (isPrivate) {
+                context.getString(R.string.menu_action_close_tabs_private)
+            } else {
+                context.getString(R.string.menu_action_close_tabs)
+            }
     }
 
     private val components = context.components

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/TabsTouchHelper.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/TabsTouchHelper.kt
@@ -5,15 +5,16 @@
 package org.mozilla.reference.browser.tabs
 
 import androidx.recyclerview.widget.ItemTouchHelper
+import kotlin.math.abs
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.tabstray.TabTouchCallback
-import kotlin.math.abs
 
-class TabsTouchHelper(
-    observable: (TabSessionState) -> Unit,
-) : ItemTouchHelper(object : TabTouchCallback(observable) {
-        override fun alphaForItemSwipe(
-            dX: Float,
-            distanceToAlphaMin: Int,
-        ): Float = 1f - 2f * abs(dX) / distanceToAlphaMin
-    })
+class TabsTouchHelper(observable: (TabSessionState) -> Unit) :
+    ItemTouchHelper(
+        object : TabTouchCallback(observable) {
+            override fun alphaForItemSwipe(
+                dX: Float,
+                distanceToAlphaMin: Int,
+            ): Float = 1f - 2f * abs(dX) / distanceToAlphaMin
+        }
+    )

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/TabsTrayFragment.kt
@@ -27,12 +27,8 @@ import org.mozilla.reference.browser.browser.BrowserFragment
 import org.mozilla.reference.browser.ext.components
 import org.mozilla.reference.browser.ext.requireComponents
 
-/**
- * A fragment for displaying the tabs tray.
- */
-class TabsTrayFragment :
-    Fragment(),
-    UserInteractionHandler {
+/** A fragment for displaying the tabs tray. */
+class TabsTrayFragment : Fragment(), UserInteractionHandler {
     private var tabsFeature: TabsFeature? = null
 
     override fun onCreateView(
@@ -49,11 +45,14 @@ class TabsTrayFragment :
 
         val trayAdapter = createAndSetupTabsTray(requireContext())
 
-        tabsFeature = TabsFeature(
-            trayAdapter,
-            requireComponents.core.store,
-            ::closeTabsTray,
-        ) { !it.content.private }
+        tabsFeature =
+            TabsFeature(
+                trayAdapter,
+                requireComponents.core.store,
+                ::closeTabsTray,
+            ) {
+                !it.content.private
+            }
 
         val tabsPanel: TabsPanel = view.findViewById(R.id.tabsPanel)
         val tabsToolbar: TabsToolbar = view.findViewById(R.id.tabsToolbar)
@@ -96,41 +95,42 @@ class TabsTrayFragment :
         val thumbnailLoader = ThumbnailLoader(context.components.core.thumbnailStorage)
         val trayStyling = TabsTrayStyling(itemBackgroundColor = Color.TRANSPARENT, itemTextColor = Color.WHITE)
         val viewHolderProvider: ViewHolderProvider = { viewGroup ->
-            val view = LayoutInflater
-                .from(context)
-                .inflate(R.layout.browser_tabstray_item, viewGroup, false)
+            val view = LayoutInflater.from(context).inflate(R.layout.browser_tabstray_item, viewGroup, false)
 
             DefaultTabViewHolder(view, thumbnailLoader)
         }
-        val tabsAdapter = TabsAdapter(
-            thumbnailLoader = thumbnailLoader,
-            viewHolderProvider = viewHolderProvider,
-            styling = trayStyling,
-            delegate = object : TabsTray.Delegate {
-                override fun onTabSelected(
-                    tab: TabSessionState,
-                    source: String?,
-                ) {
-                    requireComponents.useCases.tabsUseCases.selectTab(tab.id)
-                    closeTabsTray()
-                }
+        val tabsAdapter =
+            TabsAdapter(
+                thumbnailLoader = thumbnailLoader,
+                viewHolderProvider = viewHolderProvider,
+                styling = trayStyling,
+                delegate =
+                    object : TabsTray.Delegate {
+                        override fun onTabSelected(
+                            tab: TabSessionState,
+                            source: String?,
+                        ) {
+                            requireComponents.useCases.tabsUseCases.selectTab(tab.id)
+                            closeTabsTray()
+                        }
 
-                override fun onTabClosed(
-                    tab: TabSessionState,
-                    source: String?,
-                ) {
-                    requireComponents.useCases.tabsUseCases.removeTab(tab.id)
-                }
-            },
-        )
+                        override fun onTabClosed(
+                            tab: TabSessionState,
+                            source: String?,
+                        ) {
+                            requireComponents.useCases.tabsUseCases.removeTab(tab.id)
+                        }
+                    },
+            )
 
         val tabsTray = requireView().findViewById<RecyclerView>(R.id.tabsTray)
         tabsTray.layoutManager = layoutManager
         tabsTray.adapter = tabsAdapter
 
         TabsTouchHelper {
-            requireComponents.useCases.tabsUseCases.removeTab(it.id)
-        }.attachToRecyclerView(tabsTray)
+                requireComponents.useCases.tabsUseCases.removeTab(it.id)
+            }
+            .attachToRecyclerView(tabsTray)
 
         return tabsAdapter
     }

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/synced/SyncedTabsAdapter.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/synced/SyncedTabsAdapter.kt
@@ -8,16 +8,13 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
-import org.mozilla.reference.browser.tabs.synced.SyncedTabsViewHolder.DeviceViewHolder
-import org.mozilla.reference.browser.tabs.synced.SyncedTabsViewHolder.TabViewHolder
 import mozilla.components.browser.storage.sync.Tab as SyncTab
 import mozilla.components.concept.sync.Device as SyncDevice
+import org.mozilla.reference.browser.tabs.synced.SyncedTabsViewHolder.DeviceViewHolder
+import org.mozilla.reference.browser.tabs.synced.SyncedTabsViewHolder.TabViewHolder
 
-class SyncedTabsAdapter(
-    private val listener: (SyncTab) -> Unit,
-) : ListAdapter<SyncedTabsAdapter.AdapterItem, SyncedTabsViewHolder>(
-    DiffCallback,
-) {
+class SyncedTabsAdapter(private val listener: (SyncTab) -> Unit) :
+    ListAdapter<SyncedTabsAdapter.AdapterItem, SyncedTabsViewHolder>(DiffCallback) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
@@ -35,10 +32,11 @@ class SyncedTabsAdapter(
         holder: SyncedTabsViewHolder,
         position: Int,
     ) {
-        val item = when (holder) {
-            is DeviceViewHolder -> getItem(position) as AdapterItem.Device
-            is TabViewHolder -> getItem(position) as AdapterItem.Tab
-        }
+        val item =
+            when (holder) {
+                is DeviceViewHolder -> getItem(position) as AdapterItem.Device
+                is TabViewHolder -> getItem(position) as AdapterItem.Tab
+            }
         holder.bind(item, listener)
     }
 
@@ -61,12 +59,8 @@ class SyncedTabsAdapter(
     }
 
     sealed class AdapterItem {
-        data class Device(
-            val device: SyncDevice,
-        ) : AdapterItem()
+        data class Device(val device: SyncDevice) : AdapterItem()
 
-        data class Tab(
-            val tab: SyncTab,
-        ) : AdapterItem()
+        data class Tab(val tab: SyncTab) : AdapterItem()
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/synced/SyncedTabsFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/synced/SyncedTabsFragment.kt
@@ -35,15 +35,16 @@ class SyncedTabsFragment : Fragment() {
         val backgroundServices = requireContext().components.backgroundServices
 
         syncedTabsFeature.set(
-            feature = SyncedTabsFeature(
-                context = requireContext(),
-                storage = backgroundServices.syncedTabsStorage,
-                commands = backgroundServices.syncedTabsCommands,
-                accountManager = backgroundServices.accountManager,
-                view = view.findViewById<SyncedTabsLayout>(R.id.synced_tabs_layout),
-                lifecycleOwner = this,
-                onTabClicked = ::handleTabClicked,
-            ),
+            feature =
+                SyncedTabsFeature(
+                    context = requireContext(),
+                    storage = backgroundServices.syncedTabsStorage,
+                    commands = backgroundServices.syncedTabsCommands,
+                    accountManager = backgroundServices.accountManager,
+                    view = view.findViewById<SyncedTabsLayout>(R.id.synced_tabs_layout),
+                    lifecycleOwner = this,
+                    onTabClicked = ::handleTabClicked,
+                ),
             owner = this,
             view = view,
         )

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/synced/SyncedTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/synced/SyncedTabsIntegration.kt
@@ -27,19 +27,15 @@ class SyncedTabsIntegration(
     }
 }
 
-internal class SyncedTabsAccountObserver(
-    private val context: Context,
-) : AccountObserver {
+internal class SyncedTabsAccountObserver(private val context: Context) : AccountObserver {
     override fun onAuthenticated(
         account: OAuthAccount,
         authType: AuthType,
     ) {
-        context.components.backgroundServices.syncedTabsStorage
-            .start()
+        context.components.backgroundServices.syncedTabsStorage.start()
     }
 
     override fun onLoggedOut() {
-        context.components.backgroundServices.syncedTabsStorage
-            .stop()
+        context.components.backgroundServices.syncedTabsStorage.stop()
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/synced/SyncedTabsLayout.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/synced/SyncedTabsLayout.kt
@@ -22,21 +22,22 @@ import mozilla.components.feature.syncedtabs.view.SyncedTabsView.ErrorType.SYNC_
 import org.mozilla.reference.browser.R
 
 class SyncedTabsLayout
-    @JvmOverloads
-    constructor(
+@JvmOverloads
+constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,
-) : FrameLayout(context, attrs, defStyleAttr),
-    SyncedTabsView {
-        override var listener: SyncedTabsView.Listener? = null
+) : FrameLayout(context, attrs, defStyleAttr), SyncedTabsView {
+    override var listener: SyncedTabsView.Listener? = null
 
     private val adapter = SyncedTabsAdapter { listener?.onTabClicked(it) }
 
     private val syncedTabsList: RecyclerView
         get() = findViewById(R.id.synced_tabs_list)
+
     private val syncedTabsPullToRefresh: SwipeRefreshLayout
         get() = findViewById(R.id.synced_tabs_pull_to_refresh)
+
     private val syncedTabsStatus: TextView
         get() = findViewById(R.id.synced_tabs_status)
 
@@ -50,12 +51,14 @@ class SyncedTabsLayout
     }
 
     override fun onError(error: SyncedTabsView.ErrorType) {
-        val stringResId = when (error) {
-            MULTIPLE_DEVICES_UNAVAILABLE, NO_TABS_AVAILABLE -> R.string.synced_tabs_connect_another_device
-            SYNC_ENGINE_UNAVAILABLE -> R.string.synced_tabs_enable_tab_syncing
-            SYNC_UNAVAILABLE -> R.string.synced_tabs_connect_to_sync_account
-            SYNC_NEEDS_REAUTHENTICATION -> R.string.synced_tabs_reauth
-        }
+        val stringResId =
+            when (error) {
+                MULTIPLE_DEVICES_UNAVAILABLE,
+                NO_TABS_AVAILABLE -> R.string.synced_tabs_connect_another_device
+                SYNC_ENGINE_UNAVAILABLE -> R.string.synced_tabs_enable_tab_syncing
+                SYNC_UNAVAILABLE -> R.string.synced_tabs_connect_to_sync_account
+                SYNC_NEEDS_REAUTHENTICATION -> R.string.synced_tabs_reauth
+            }
 
         syncedTabsStatus.text = context.getText(stringResId)
 
@@ -67,14 +70,16 @@ class SyncedTabsLayout
         syncedTabsList.visibility = View.VISIBLE
         syncedTabsStatus.visibility = View.GONE
 
-        val allDeviceTabs = syncedTabs
-            .filter {
-            it.tabs.isEmpty()
-        }.flatMap { (device, tabs) ->
-            val deviceTabs = tabs.map { SyncedTabsAdapter.AdapterItem.Tab(it) }
+        val allDeviceTabs =
+            syncedTabs
+                .filter {
+                    it.tabs.isEmpty()
+                }
+                .flatMap { (device, tabs) ->
+                    val deviceTabs = tabs.map { SyncedTabsAdapter.AdapterItem.Tab(it) }
 
-            listOf(SyncedTabsAdapter.AdapterItem.Device(device)) + deviceTabs
-        }
+                    listOf(SyncedTabsAdapter.AdapterItem.Device(device)) + deviceTabs
+                }
 
         adapter.submitList(allDeviceTabs)
     }

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/synced/SyncedTabsViewHolder.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/synced/SyncedTabsViewHolder.kt
@@ -11,17 +11,13 @@ import mozilla.components.browser.storage.sync.Tab
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.tabs.synced.SyncedTabsAdapter.AdapterItem
 
-sealed class SyncedTabsViewHolder(
-    itemView: View,
-) : RecyclerView.ViewHolder(itemView) {
+sealed class SyncedTabsViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
     abstract fun <T : AdapterItem> bind(
         item: T,
         interactor: (Tab) -> Unit,
     )
 
-    class TabViewHolder(
-        itemView: View,
-    ) : SyncedTabsViewHolder(itemView) {
+    class TabViewHolder(itemView: View) : SyncedTabsViewHolder(itemView) {
         // See TODO below
         // private val image = itemView.findViewById<ImageView>(R.id.synced_tabs_item_image)
         private val title = itemView.findViewById<TextView>(R.id.synced_tabs_item_title)
@@ -52,9 +48,7 @@ sealed class SyncedTabsViewHolder(
         }
     }
 
-    class DeviceViewHolder(
-        itemView: View,
-    ) : SyncedTabsViewHolder(itemView) {
+    class DeviceViewHolder(itemView: View) : SyncedTabsViewHolder(itemView) {
         private val title = itemView.findViewById<TextView>(R.id.synced_tabs_group_name)
 
         override fun <T : AdapterItem> bind(

--- a/build.gradle
+++ b/build.gradle
@@ -198,18 +198,6 @@ spotless {
     }
 }
 
-configurations {
-    ktlint
-}
-
-dependencies {
-    ktlint(libs.ktlint) {
-        attributes {
-            attribute(Bundling.BUNDLING_ATTRIBUTE, getObjects().named(Bundling, Bundling.EXTERNAL))
-        }
-    }
-}
-
 tasks.register('ktfmtCheck') {
     group = "verification"
     description = "Check Kotlin code style with ktfmt."
@@ -220,20 +208,6 @@ tasks.register('ktfmtFormat') {
     group = "formatting"
     description = "Format Kotlin code with ktfmt."
     dependsOn 'spotlessKotlinApply'
-}
-
-tasks.register('ktlint', JavaExec) {
-    description = "Check Kotlin code style."
-    classpath = configurations.ktlint
-    mainClass.set("com.pinterest.ktlint.Main")
-    args "app/src/**/*.kt", "!**/build/**/*.kt"
-}
-
-tasks.register('ktlintFormat', JavaExec) {
-    description = "Fix Kotlin code style deviations."
-    classpath = configurations.ktlint
-    mainClass.set("com.pinterest.ktlint.Main")
-    args "-F", "app/src/**/*.kt", "!**/build/**/*.kt"
 }
 
 tasks.register('listRepositories') {

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ plugins {
     alias libs.plugins.compose.compiler apply false
     alias libs.plugins.dependency.analysis
     alias libs.plugins.detekt
+    alias libs.plugins.spotless
 }
 
 allprojects {
@@ -147,10 +148,6 @@ subprojects {
 }
 
 
-tasks.register('clean', Delete) {
-    delete rootProject.buildDir
-}
-
 dependencyAnalysis {
     structure {
         // Ignore Android KTX dependencies. See https://developer.android.com/kotlin/ktx#modules
@@ -188,6 +185,19 @@ tasks.withType(Detekt).configureEach {
     }
 }
 
+spotless {
+    lineEndings = com.diffplug.spotless.LineEnding.UNIX
+    kotlin {
+        target fileTree(projectDir) {
+            include 'app/src/**/*.kt', 'buildSrc/src/**/*.kt'
+            exclude '**/build/**'
+        }
+        ktfmt(libs.versions.ktfmt.get()).kotlinlangStyle().configure {
+            it.setMaxWidth(120)
+        }
+    }
+}
+
 configurations {
     ktlint
 }
@@ -198,6 +208,18 @@ dependencies {
             attribute(Bundling.BUNDLING_ATTRIBUTE, getObjects().named(Bundling, Bundling.EXTERNAL))
         }
     }
+}
+
+tasks.register('ktfmtCheck') {
+    group = "verification"
+    description = "Check Kotlin code style with ktfmt."
+    dependsOn 'spotlessKotlinCheck'
+}
+
+tasks.register('ktfmtFormat') {
+    group = "formatting"
+    description = "Format Kotlin code with ktfmt."
+    dependsOn 'spotlessKotlinApply'
 }
 
 tasks.register('ktlint', JavaExec) {

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import org.gradle.api.Project
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import org.gradle.api.Project
 
 object Config {
     // Synchronized build configuration for all modules

--- a/config/detekt-baseline.xml
+++ b/config/detekt-baseline.xml
@@ -60,7 +60,7 @@
     <ID>UndocumentedPublicFunction:ComposableComponents.kt$@Composable fun sessionUseCases(): SessionUseCases</ID>
     <ID>UndocumentedPublicFunction:Config.kt$Config$@JvmStatic fun generateDebugVersionName(): String</ID>
     <ID>UndocumentedPublicFunction:Config.kt$Config$@JvmStatic fun releaseVersionName(project: Project): String</ID>
-    <ID>UndocumentedPublicFunction:Context.kt$fun Context.getPreferenceKey( @StringRes resourceId: Int, ): String</ID>
+    <ID>UndocumentedPublicFunction:Context.kt$fun Context.getPreferenceKey(@StringRes resourceId: Int): String</ID>
     <ID>UndocumentedPublicFunction:CrashIntegration.kt$CrashIntegration$@OptIn(DelicateCoroutinesApi::class) fun sendCrashReport(crash: Crash)</ID>
     <ID>UndocumentedPublicFunction:EngineProvider.kt$EngineProvider$@Synchronized fun getOrCreateRuntime(context: Context): GeckoRuntime</ID>
     <ID>UndocumentedPublicFunction:EngineProvider.kt$EngineProvider$fun createClient(context: Context): Client</ID>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,9 @@ androidx-test-uiautomator = "2.4.0"
 dependency-analysis = "3.18.0"
 detekt = "1.23.8"
 jspecify = "1.0.0"
+ktfmt = "0.64"
 ktlint = "1.8.0"
+spotless = "8.10.0"
 
 # Third Party Testing
 hamcrest = "1.3"
@@ -195,3 +197,4 @@ android-application = { id = "com.android.application", version.ref = "android-g
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,6 @@ dependency-analysis = "3.18.0"
 detekt = "1.23.8"
 jspecify = "1.0.0"
 ktfmt = "0.64"
-ktlint = "1.8.0"
 spotless = "8.10.0"
 
 # Third Party Testing
@@ -107,7 +106,6 @@ androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiaut
 
 # Third Party Linting & Static Code Analysis
 jspecify = { group = "org.jspecify", name = "jspecify", version.ref = "jspecify" }
-ktlint = { group = "com.pinterest.ktlint", name = "ktlint-cli", version.ref = "ktlint" }
 
 # Third Party Testing
 hamcrest-core = { group = "org.hamcrest", name = "hamcrest-core", version.ref = "hamcrest" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,6 +24,18 @@ pluginManagement {
         } else {
             mavenCentral()
         }
+
+        // Spotless publishes its plugin marker only to the plugin portal.
+        def pluginRepo = providers.gradleProperty("pluginRepo")
+        if (pluginRepo.present) {
+            maven {
+                name "GradlePlugins"
+                url pluginRepo.get()
+                allowInsecureProtocol true // Local Nexus in CI uses HTTP
+            }
+        } else {
+            gradlePluginPortal()
+        }
     }
 }
 

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -61,13 +61,13 @@ tasks:
             gradlew: [detekt]
         treeherder:
             symbol: detekt
-    ktlint:
-        description: 'Running ktlint over all modules'
+    ktfmt:
+        description: 'Running ktfmt over all modules'
         run:
             using: gradlew
-            gradlew: [ktlint]
+            gradlew: [ktfmtCheck]
         treeherder:
-            symbol: ktlint
+            symbol: ktfmt
     lint:
         description: 'Running lint over all modules'
         run:

--- a/taskcluster/kinds/toolchain/android.yml
+++ b/taskcluster/kinds/toolchain/android.yml
@@ -41,6 +41,7 @@ linux64-android-gradle-dependencies:
             - 'buildSrc/**'
             - 'gradle.properties'
             - 'gradle/**'
+            - taskcluster/scripts/toolchain/android-gradle-dependencies.sh
             - taskcluster/scripts/toolchain/android-gradle-dependencies/**
         toolchain-artifact: public/build/android-gradle-dependencies.tar.zst
         toolchain-alias: android-gradle-dependencies

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
@@ -30,7 +30,7 @@ GRADLE_FLAGS=(
 
 # Enumerates and downloads the dependencies of every resolvable configuration
 # without running the requested tasks.
-./gradlew "${GRADLE_FLAGS[@]}" --write-verification-metadata sha256 --dry-run detekt ktlint ktfmtCheck lint buildHealth build
+./gradlew "${GRADLE_FLAGS[@]}" --write-verification-metadata sha256 --dry-run detekt ktfmtCheck lint buildHealth build
 
 # AGP resolves the aapt2 binary while its tasks run, so the pass above misses it.
 ./gradlew "${GRADLE_FLAGS[@]}" :app:processDebugResources

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
@@ -30,10 +30,15 @@ GRADLE_FLAGS=(
 
 # Enumerates and downloads the dependencies of every resolvable configuration
 # without running the requested tasks.
-./gradlew "${GRADLE_FLAGS[@]}" --write-verification-metadata sha256 --dry-run detekt ktlint lint buildHealth build
+./gradlew "${GRADLE_FLAGS[@]}" --write-verification-metadata sha256 --dry-run detekt ktlint ktfmtCheck lint buildHealth build
 
 # AGP resolves the aapt2 binary while its tasks run, so the pass above misses it.
 ./gradlew "${GRADLE_FLAGS[@]}" :app:processDebugResources
+
+# Spotless resolves ktfmt the same way, so run the formatter for real. spotlessKotlin
+# rather than ktfmtCheck: it resolves the same classpath but reports no violations, so a
+# misformatted tree cannot fail the toolchain every other task depends on.
+./gradlew "${GRADLE_FLAGS[@]}" spotlessKotlin
 
 # Don't leave a 4GB heap sitting there while `after.sh` packages everything up.
 ./gradlew --stop


### PR DESCRIPTION
Ports [bug 2050591](https://bugzilla.mozilla.org/show_bug.cgi?id=2050591), which moved mozilla-central's Android Kotlin code from ktlint to ktfmt, over to reference-browser so this repo and android-components share one style.

Same settings as mozilla-central: ktfmt 0.64, `kotlinlangStyle()`, max width 120, UNIX line endings. 120 because detekt's `MaxLineLength` and `.editorconfig` already use it, so no detekt config change was needed.

### Commits

**Add ktfmt via Spotless** — config only. ktlint stays, nothing is reformatted, CI is unaffected.

**Format Kotlin sources with ktfmt** — the reformat, ktlint removal and the CI lint task swap, atomically. ktlint and ktfmt cannot both be green at once, since ktfmt's wrapping and trailing commas violate ktlint rules this repo leaves enabled, so these have to land together for every commit to stay green.

**Ignore the dependency enumeration's dry-run inventory** — unrelated one-line ride-along; drop it if you'd rather it went separately.

### Notes for review

ktfmt is driven through Spotless rather than its CLI because the 0.64 CLI has no `--max-width` flag; only Spotless can set 120 columns.

Three things worth a second look:

- **The toolchain script gains a real `spotlessKotlin` run.** Spotless resolves ktfmt while its task executes, which the `--write-verification-metadata --dry-run` enumeration pass cannot see, so the packaged offline cache would ship without it. The script already has exactly this problem for the aapt2 binary and solves it by running a real task; this follows that precedent. `spotlessKotlin` rather than `ktfmtCheck` deliberately: it resolves the same classpath but reports no violations, so a misformatted tree cannot fail the toolchain artifact that every other task depends on. Verified locally that it exits 0 on misformatted input and does not modify sources.
- **`settings.gradle` gains a plugin repository.** Spotless publishes its plugin marker only to the plugin portal, not Maven Central, so root plugin resolution needs the `pluginRepo`/`gradlePluginPortal()` fallback that `buildSrc/settings.gradle.kts` already had. CI already passes `-PpluginRepo` and `after.sh` already packages that proxy's storage, so plugins keep resolving through the local Nexus.
- **The hand-rolled `clean` task is gone.** Spotless applies Gradle's `base` plugin, which registers an equivalent `clean`; keeping both fails the configuration phase.

Also adds `android-gradle-dependencies.sh` to the toolchain task's `resources`. Only the sibling directory was listed, so editing the script did not rebuild the dependency cache it produces.

### The reformat is mechanical

`git diff -w` is misleading here, since reflowing joins lines. Comparing each file with imports, comment-only lines and whitespace stripped and trailing commas normalised gives **zero** code-level differences across all 104 files, and net imports added/removed is zero — they were only re-sorted.

One detekt baseline entry needed re-keying: baseline IDs embed source text, and ktfmt collapsed `getPreferenceKey`'s signature onto one line. Nothing else in the baseline moved.

### Accepted losses

Matching bug 2050591, ktfmt is a formatter only and nothing was ported to detekt: `no-wildcard-imports` is now unchecked, and `function-naming` is left to detekt/Android lint's `FunctionName`. This repo had zero `ktlint-disable` comments and zero `@Suppress("ktlint...")` annotations, so there were no suppressions to strip.

`.kts` and `.gradle` build scripts stay unformatted. Spotless's `kotlin {}` covers the `.kt` globs only; that matches the old ktlint glob, and bug 2050591 deferred `kotlinGradle {}` too.

### Verification

`ktfmtCheck`, `detekt`, `lintDebug`, `assembleDebug`, `assembleDebugAndroidTest` and `buildHealth` all pass locally, with tasks forced to re-run rather than reporting UP-TO-DATE. Both of the toolchain script's Gradle invocations were replayed locally too. `testDebugUnitTest` is a no-op — `app/src/test` does not exist.

### Follow-up

`.git-blame-ignore-revs` needs to be added in a separate PR once this merges, since mergify rebase-merges and the reformat commit's final SHA isn't knowable beforehand.

### Pull Request checklist
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features