### PR TITLE
Update Okio and OkHttp to the latest upstream releases

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,8 +51,8 @@ spotless = "8.10.0"
 hamcrest = "1.3"
 jacoco = "0.8.15"
 junit = "4.13.2"
-okhttp = "5.4.0"
-okio = "3.17.0"
+okhttp = "5.5.0"
+okio = "3.18.1"
 
 [libraries]
 # Kotlin


### PR DESCRIPTION
Release notes:
* https://github.com/lysine-dev/okio/blob/main/CHANGELOG.md#version-3181
* https://github.com/lysine-dev/okhttp/blob/main/CHANGELOG.md#version-550