### PR TITLE
Fix hiddenVideoControlsContextMenuTest UI test

### DIFF
--- a/app/src/androidTest/assets/pages/noControlsVideoMediaPage.html
+++ b/app/src/androidTest/assets/pages/noControlsVideoMediaPage.html
@@ -1,9 +1,10 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <title>No_Controls_Video_Test_Page</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
-<body>
-<p id="testContent">Page content: video player</p>
+<body style="margin:0;display:flex;align-items:center;justify-content:center;height:100vh">
 <video title="test_link_video" width="320" height="240">
     <source src="../resources/mov_bbb.mp4" type="video/mp4">
     Your browser does not support HTML video.

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/MediaPlaybackTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/MediaPlaybackTest.kt
@@ -80,7 +80,7 @@ class MediaPlaybackTest {
 
         navigationToolbar {}
             .enterUrlAndEnterToBrowser(noControlsVideoTestPage.url) {
-                longClickMatchingText("test_link_video")
+                longClickVideoWithNoControls()
                 verifyNoControlsVideoContextMenuItems()
             }
     }

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
@@ -72,6 +72,14 @@ class BrowserRobot {
         link.click(LONG_CLICK_DURATION)
     }
 
+    fun longClickVideoWithNoControls() {
+        mDevice.waitForWindowUpdate(packageName, waitingTime)
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView")).waitForExists(waitingTime)
+        mDevice.waitForIdle()
+        val engineView = mDevice.findObject(By.res("$packageName:id/engineView"))
+        engineView.click(engineView.visibleCenter, LONG_CLICK_DURATION)
+    }
+
     fun longClickAndCopyText(
         expectedText: String,
         selectAll: Boolean = false,


### PR DESCRIPTION
Summary:
The test tried to long-click the no-controls video by matching its title text, but a control-less video isn’t exposed in the accessibility tree at all, so UiAutomator never found it.

I've placed the video in the center of the page, then changed the test to long-press that exact center spot instead of searching for the video by name. 
Since the video is what’s drawn there, the press reliably lands on it and opens its menu.

The UI test successfully passed 25x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
