### PR TITLE
fix: Anchor context-menu snackbars above the browser toolbar

### DIFF
--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/ContextMenusTest.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/ContextMenusTest.kt
@@ -69,7 +69,13 @@ class ContextMenusTest {
             .enterUrlAndEnterToBrowser(pageLinks.url) {
                 longClickMatchingText("Link 1")
                 clickContextOpenLinkInNewTab()
+                verifySnackbarIsAnchoredAboveToolbar()
+                focusToolbarWithSnackbarShown()
+                verifySnackbarIsAnchoredAboveToolbar()
+                dismissKeyboardWithSnackbarShown()
+                verifySnackbarIsAnchoredAboveToolbar()
                 clickSnackbarSwitchButton()
+                verifyUrl(genericURL.url.toString())
             }
         navigationToolbar {}
             .openTabTrayMenu {

--- a/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/reference/browser/ui/robots/BrowserRobot.kt
@@ -4,6 +4,8 @@
 
 package org.mozilla.reference.browser.ui.robots
 
+import android.graphics.Rect
+import android.view.View
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
@@ -20,9 +22,12 @@ import org.mozilla.reference.browser.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.reference.browser.helpers.TestAssetHelper.waitingTime
 import org.mozilla.reference.browser.helpers.TestHelper.packageName
 import org.mozilla.reference.browser.helpers.TestHelper.waitForObjects
+import kotlin.math.abs
 
 /** Implementation of Robot Pattern for browser action. */
 class BrowserRobot {
+    private var snackbarToolbarGap: Int? = null
+
     /* Asserts that the text within DOM element with ID="testContent" has the given text, i.e.
      * document.querySelector('#testContent').innerText == expectedText
      */
@@ -208,6 +213,54 @@ class BrowserRobot {
             it.click()
         }
 
+    fun verifySnackbarIsAnchoredAboveToolbar() {
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/snackbar_text")).waitForExists(waitingTime)
+        onView(withId(com.google.android.material.R.id.snackbar_text)).check { snackbarText, exception ->
+            if (exception != null) {
+                throw exception
+            }
+
+            val snackbarContent = snackbarText.parent as View
+            val snackbar = snackbarContent.parent as View
+            val toolbar = snackbar.rootView.findViewById<View>(org.mozilla.reference.browser.R.id.toolbar)
+            val snackbarBounds = Rect().also(snackbar::getGlobalVisibleRect)
+            val toolbarBounds = Rect().also(toolbar::getGlobalVisibleRect)
+            val visibleScreenBounds = Rect().also(snackbar.rootView::getWindowVisibleDisplayFrame)
+            val gap = toolbarBounds.top - snackbarBounds.bottom
+            val maximumGap = (snackbar.resources.displayMetrics.density * MAXIMUM_SNACKBAR_GAP_DP).toInt()
+            val positionTolerance = (snackbar.resources.displayMetrics.density * POSITION_TOLERANCE_DP).toInt()
+
+            assertTrue("Snackbar overlaps toolbar: snackbar=$snackbarBounds toolbar=$toolbarBounds", gap >= 0)
+            assertTrue("Snackbar is too far above toolbar: gap=$gap", gap <= maximumGap)
+            assertTrue(
+                "Toolbar is not aligned with the visible screen: toolbar=$toolbarBounds screen=$visibleScreenBounds",
+                abs(toolbarBounds.bottom - visibleScreenBounds.bottom) <= positionTolerance,
+            )
+
+            snackbarToolbarGap?.let { initialGap ->
+                assertTrue(
+                    "Snackbar gap changed from $initialGap to $gap",
+                    abs(initialGap - gap) <= positionTolerance,
+                )
+            } ?: run {
+                snackbarToolbarGap = gap
+            }
+        }
+    }
+
+    fun focusToolbarWithSnackbarShown() {
+        mDevice
+            .findObject(UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_url_view"))
+            .click()
+        mDevice.findObject(UiSelector().textContains("Search or enter address")).waitForExists(waitingTime)
+        mDevice.waitForIdle()
+    }
+
+    fun dismissKeyboardWithSnackbarShown() {
+        mDevice.pressBack()
+        mDevice.waitForIdle()
+    }
+
     class Transition {
         fun checkExternalApps(interact: ExternalAppsRobot.() -> Unit): ExternalAppsRobot.Transition {
             mDevice.waitForWindowUpdate(packageName, waitingTime)
@@ -236,6 +289,9 @@ class BrowserRobot {
         }
     }
 }
+
+private const val MAXIMUM_SNACKBAR_GAP_DP = 32
+private const val POSITION_TOLERANCE_DP = 1
 
 fun browser(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
     BrowserRobot().interact()

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
@@ -230,6 +230,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                     requireComponents.useCases.contextMenuUseCases,
                     engineView,
                     view,
+                    toolbar,
                     sessionId,
                 ),
             owner = this,

--- a/app/src/main/java/org/mozilla/reference/browser/browser/ContextMenuIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/ContextMenuIntegration.kt
@@ -31,11 +31,14 @@ class ContextMenuIntegration(
     contextMenuUseCases: ContextMenuUseCases,
     engineView: EngineView,
     parentView: View,
+    toolbar: View,
     sessionId: String? = null,
 ) : LifecycleAwareFeature {
     private val candidates = run {
         if (sessionId != null) {
-            val snackbarDelegate = DefaultSnackbarDelegate()
+            val snackbarDelegate = DefaultSnackbarDelegate { snackbar ->
+                snackbar.anchorView = toolbar
+            }
             listOf(
                 createCopyLinkCandidate(context, parentView, snackbarDelegate),
                 createShareLinkCandidate(context),


### PR DESCRIPTION
Pass the existing browser toolbar from `BaseBrowserFragment` into `ContextMenuIntegration` alongside the current parent view. Configure the production snackbar delegate used by link context-menu candidates to anchor each snackbar to that toolbar before display, while retaining the coordinator root as the snackbar's parent and preserving all candidate behavior. The Material snackbar anchor should then track the toolbar as `ImeInsetsSynchronizer` changes its position, keeping one consistent separation above the toolbar without independently applying the keyboard height.

Context-menu actions such as opening a link in a new tab display a snackbar from the browser fragment's coordinator root. Because the browser toolbar is a separate bottom-aligned view whose margins move during IME transitions, the snackbar can overlap the toolbar before the keyboard opens and retain roughly a keyboard-height gap after it opens. The issue provides a reproducible link-context-menu and keyboard sequence and identifies the IME behavior introduced around PR #3680. No prior or competing pull request is present in the supplied issue timeline.

Open a link in a new tab with the keyboard hidden and verify the snackbar is immediately above the bottom toolbar rather than overlapping it on the Z axis.
While that snackbar remains visible, focus the browser toolbar to show the IME and verify the snackbar remains directly above the moved toolbar with only the intended Material spacing, not an additional keyboard-height gap.
Dismiss the keyboard and verify the snackbar/toolbar relationship returns to the bottom of the visible browser area without stale margins or overlap.
Exercise the snackbar's existing `SWITCH` action and confirm it still selects the newly opened tab, proving that anchoring does not alter context-menu behavior.

### Pull Request checklist

- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

Fixes #3746
