### PR TITLE
Update Kotlin to version 2.4.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ android-components = "157.0.20260907210752"
 android-gradle-plugin = "9.3.1"
 
 # Kotlin
-kotlin = "2.4.10"
+kotlin = "2.4.20"
 kotlinx-coroutines = "1.11.0"
 
 # Google


### PR DESCRIPTION
Release notes: https://github.com/JetBrains/kotlin/releases/tag/v2.4.20